### PR TITLE
Fix errors reported by gcc-8.1.0.

### DIFF
--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -198,19 +198,27 @@ public:
 
   // TODO @proposal-bug @proposal-extension layout stride needs this constructor
   // clang-format off
+#if defined(__INTEL_COMPILER)
+  // Work-around for an ICE. layout_stride won't properly SFINAE with ICC, but oh well
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr explicit),
     layout_stride_impl, (std::experimental::extents<Exts...> const& e), noexcept,
     /* requires */ (
       // remember that this also covers the zero strides case because an && fold on an empty pack is true
-#if defined(__INTEL_COMPILER)
-      // Work-around for an ICE. layout_stride won't properly SFINAE with ICC, but oh well
       true
-#else
-      _MDSPAN_FOLD_AND(Strides != dynamic_extent /* && ... */)
-#endif
     )
-  ) : __base_t(__base_t{__member_pair_t(e, __strides_storage_t())})
+  )
+#else
+  MDSPAN_FUNCTION_REQUIRES(
+    (MDSPAN_INLINE_FUNCTION constexpr explicit),
+    layout_stride_impl, (std::experimental::extents<Exts...> const& e), noexcept,
+    /* requires */ (
+      // remember that this also covers the zero strides case because an && fold on an empty pack is true
+      _MDSPAN_FOLD_AND(Strides != dynamic_extent /* && ... */)
+    )
+  )
+#endif
+  : __base_t(__base_t{__member_pair_t(e, __strides_storage_t())})
   { }
   // clang-format on
 

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -211,7 +211,7 @@
 //==============================================================================
 // <editor-fold desc="inline variables"> {{{1
 
-#if _MDSPAN_USE_INLINE_VARIABLES
+#ifdef _MDSPAN_USE_INLINE_VARIABLES
 #  define _MDSPAN_INLINE_VARIABLE inline
 #else
 #  define _MDSPAN_INLINE_VARIABLE
@@ -610,4 +610,3 @@ struct __bools;
 
 // </editor-fold> end Pre-C++14 constexpr }}}1
 //==============================================================================
-

--- a/include/experimental/__p0009_bits/subspan.hpp
+++ b/include/experimental/__p0009_bits/subspan.hpp
@@ -125,7 +125,7 @@ struct preserve_layout_right_analysis : integral_constant<bool, result> {
     // nothing else changes (though if they're true, it doesn't matter)
     encountered_first_all,
     encountered_first_pair
-  >;  
+  >;
 };
 
 template <
@@ -137,7 +137,7 @@ template <
 struct preserve_layout_left_analysis : integral_constant<bool, result> {
   using layout_type_if_preserved = layout_left;
   using encounter_pair = preserve_layout_left_analysis<
-    // Only the left-most slice can be a pair.  If we've encountered anything else, 
+    // Only the left-most slice can be a pair.  If we've encountered anything else,
     // we can't preserve any contiguous layout
     (encountered_first_scalar || encountered_first_all || encountered_first_pair) ? false : result,
     // These change in the expected ways
@@ -228,6 +228,7 @@ struct __assign_op_slice_handler<
   __extents_storage_t __exts;
   __strides_storage_t __strides;
 
+#ifdef __INTEL_COMPILER
 #if __INTEL_COMPILER <= 1800
   MDSPAN_INLINE_FUNCTION constexpr __assign_op_slice_handler(__assign_op_slice_handler&& __other) noexcept
     : __offsets(::std::move(__other.__offsets)), __exts(::std::move(__other.__exts)), __strides(::std::move(__other.__strides))
@@ -239,6 +240,7 @@ struct __assign_op_slice_handler<
   ) noexcept
     : __offsets(::std::move(__o)), __exts(::std::move(__e)), __strides(::std::move(__s))
   { }
+#endif
 #endif
 
 // Don't define this unless we need it; they have a cost to compile


### PR DESCRIPTION
* Fixes #20
* Fixes #16 

* This PR changed a couple of `#if MACRO` to `#ifdef MACRO` to silence gcc warnings about processing undefined macros.
* In `layout_stride.hpp`, I rewrote come logic to eliminate the embedded CPP macro reported in #20.

cc: @brryan