### PR TITLE
Addresses Compilation on MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vs
+CMakeSettings.json
+out

--- a/include/experimental/__p0009_bits/basic_mdspan.hpp
+++ b/include/experimental/__p0009_bits/basic_mdspan.hpp
@@ -82,11 +82,11 @@ private:
   using __accessor_base_t = detail::__no_unique_address_emulation<AccessorPolicy, 1>;
 
   // Workaround for non-deducibility of the index sequence template parameter if it's given at the top level
-  template <class=make_index_sequence<sizeof...(Exts)>>
-  struct __impl;
+  template <class>
+  struct __impl_impl;
 
   template <size_t... Idxs>
-  struct __impl<index_sequence<Idxs...>>
+  struct __impl_impl<index_sequence<Idxs...>>
   {
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
     ptrdiff_t __size(basic_mdspan const& __self) noexcept {
@@ -98,6 +98,9 @@ private:
       return __self.__accessor_ref().access(__self.__pointer_ref(), __self.__mapping_ref()(indices[Idxs]...));
     }
   };
+
+  // Can't use defaulted parameter in the __impl_impl template because of a bug in MSVC warning C4348.
+  using __impl = make_index_sequence<sizeof...(Exts)>;
 
 public:
   
@@ -261,7 +264,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(const array<IndexType, N>& indices) const noexcept
   {
-    return __impl<>::template __callop<reference>(*this, indices);
+    return __impl::template __callop<reference>(*this, indices);
   }
 
   // TODO @proposal-bug The proposal is missing constexpr here
@@ -278,7 +281,7 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr extents_type extents() const noexcept { return __mapping_ref().extents(); };
   MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return __mapping_ref().extents().extent(r); };
   MDSPAN_INLINE_FUNCTION constexpr index_type size() const noexcept {
-    return __impl<>::__size(*this);
+    return __impl::__size(*this);
   };
 
   // TODO @proposal-bug for non-unique, non-contiguous mappings this is unimplementable

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -55,11 +55,19 @@
 #  include <utility>
 #endif
 
+#ifdef _MSVC_LANG
+#define _MDSPAN_CPLUSPLUS _MSVC_LANG
+#else
+#define _MDSPAN_CPLUSPLUS __cplusplus
+#endif
+
+static_assert(_MDSPAN_CPLUSPLUS >= 201102L, "MDSpan requires C++11 or later.");
+
 #define MDSPAN_CXX_STD_14 201402L
 #define MDSPAN_CXX_STD_17 201703L
 
-#define MDSPAN_HAS_CXX_14 (__cplusplus >= MDSPAN_CXX_STD_14)
-#define MDSPAN_HAS_CXX_17 (__cplusplus >= MDSPAN_CXX_STD_17)
+#define MDSPAN_HAS_CXX_14 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14)
+#define MDSPAN_HAS_CXX_17 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_17)
 
 #ifdef __apple_build_version__
 #  define _MDSPAN_COMPILER_APPLECLANG

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -69,8 +69,38 @@ static_assert(_MDSPAN_CPLUSPLUS >= 201102L, "MDSpan requires C++11 or later.");
 #define MDSPAN_HAS_CXX_14 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14)
 #define MDSPAN_HAS_CXX_17 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_17)
 
-#ifdef __apple_build_version__
-#  define _MDSPAN_COMPILER_APPLECLANG
+#ifndef _MDSPAN_COMPILER_CLANG
+#  if defined(__clang__)
+#    define _MDSPAN_COMPILER_CLANG __clang__
+#  endif
+#endif
+
+#if !defined(_MDSPAN_COMPILER_MSVC) && !defined(_MDSPAN_COMPILER_MSVC_CLANG)
+#  if defined(_MSC_VER)
+#    if !defined(_MDSPAN_COMPILER_CLANG)
+#      define _MDSPAN_COMPILER_MSVC _MSC_VER
+#    else
+#      define _MDSPAN_COMPILER_MSVC_CLANG _MSC_VER
+#    endif
+#  endif
+#endif
+
+#ifndef _MDSPAN_COMPILER_INTEL
+#  ifdef __INTEL_COMPILER
+#    define _MDSPAN_COMPILER_INTEL __INTEL_COMPILER
+#  endif
+#endif
+
+#ifndef _MDSPAN_COMPILER_APPLECLANG
+#  ifdef __apple_build_version__
+#    define _MDSPAN_COMPILER_APPLECLANG __apple_build_version__
+#  endif
+#endif
+
+#ifndef _MDSPAN_HAS_CUDA
+#  if defined(__CUDACC__)
+#    define _MDSPAN_HAS_CUDA __CUDACC__
+#  endif
 #endif
 
 #ifndef __has_cpp_attribute
@@ -135,7 +165,7 @@ static_assert(_MDSPAN_CPLUSPLUS >= 201102L, "MDSpan requires C++11 or later.");
 #endif
 
 #ifndef _MDSPAN_USE_INTEGER_SEQUENCE
-#  ifdef _MSC_VER
+#  if defined(_MDSPAN_COMPILER_MSVC)
 #    if (defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence >= 201304)
 #      define _MDSPAN_USE_INTEGER_SEQUENCE 1
 #    endif
@@ -148,7 +178,7 @@ static_assert(_MDSPAN_CPLUSPLUS >= 201102L, "MDSpan requires C++11 or later.");
         || (defined(__GLIBCXX__) && __GLIBCXX__ > 20150422 && __GNUC__ < 5 && !defined(__INTEL_CXX11_MODE__))
      // several compilers lie about integer_sequence working properly unless the C++14 standard is used
 #    define _MDSPAN_USE_INTEGER_SEQUENCE 1
-#  elif defined(_MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
+#  elif defined(_MDSPAN_COMPILER_APPLE_CLANG) && MDSPAN_HAS_CXX_14
      // appleclang seems to be missing the __cpp_lib_... macros, but doesn't seem to lie about C++14 making
      // integer_sequence work
 #    define _MDSPAN_USE_INTEGER_SEQUENCE 1
@@ -156,7 +186,7 @@ static_assert(_MDSPAN_CPLUSPLUS >= 201102L, "MDSpan requires C++11 or later.");
 #endif
 
 #ifndef _MDSPAN_USE_RETURN_TYPE_DEDUCTION
-#  ifdef _MSC_VER
+#  ifdef _MDSPAN_COMPILER_MSVC
 #    if (defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence >= 201304) && MDSPAN_HAS_CXX_14
 #      define _MDSPAN_USE_RETURN_TYPE_DEDUCTION 1
 #    endif
@@ -180,8 +210,10 @@ static_assert(_MDSPAN_CPLUSPLUS >= 201102L, "MDSpan requires C++11 or later.");
 #endif
 
 #ifndef _MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND
-#  if __GNUC__ < 9
-#    define _MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND 1
+#  ifdef __GNUC__
+#    if __GNUC__ < 9
+#      define _MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND 1
+#    endif
 #  endif
 #endif
 

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -282,7 +282,7 @@ public:  // (but not really)
   MDSPAN_INLINE_FUNCTION
   static constexpr
   index_type __static_extent() noexcept {
-    return __base_t::__stored_type::template __get_static_n<N, Default>();
+    return __storage_t::template __get_static_n<N, Default>();
   }
 
 };

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -202,7 +202,7 @@ public:
 
   // TODO @proposal-bug @proposal-extension layout stride needs this constructor
   // clang-format off
-#if defined(__INTEL_COMPILER)
+#if defined(_MDSPAN_COMPILER_INTEL)
   // Work-around for an ICE. layout_stride won't properly SFINAE with ICC, but oh well
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr explicit),

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -97,11 +97,11 @@ private:
   //----------------------------------------------------------------------------
 
   // Workaround for non-deducibility of the index sequence template parameter if it's given at the top level
-  template <class=make_index_sequence<sizeof...(Exts)>>
-  struct __impl;
-
+  template <class>
+  struct __impl_impl;
+  
   template <size_t... Idxs>
-  struct __impl<index_sequence<Idxs...>>
+  struct __impl_impl<index_sequence<Idxs...>>
   {
     template <class OtherExtents, ptrdiff_t... OtherStrides>
     MDSPAN_INLINE_FUNCTION
@@ -126,6 +126,10 @@ private:
       return __impl::_call_op_impl(self, (self.extents().template __extent<Idxs>() - 1)...) + 1;
     }
   };
+
+  // Can't use defaulted parameter in the __impl_impl template because of a bug in MSVC warning C4348.
+  using __impl = __impl_impl<make_index_sequence<sizeof...(Exts)>>;
+
 
   //----------------------------------------------------------------------------
 
@@ -285,7 +289,7 @@ public:
   )
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr ptrdiff_t operator()(Indices... idxs) const noexcept {
-    return __impl<>::_call_op_impl(*this, idxs...);
+    return __impl::_call_op_impl(*this, idxs...);
   }
 
   MDSPAN_INLINE_FUNCTION
@@ -296,7 +300,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr ptrdiff_t required_span_size() const noexcept {
     // assumes no negative strides; not sure if I'm allowed to assume that or not
-    return __impl<>::_req_span_size_impl(*this);
+    return __impl::_req_span_size_impl(*this);
   }
 
   // TODO @proposal-bug these (and other analogous operators) should be non-member functions
@@ -305,13 +309,13 @@ public:
   template<class OtherExtents, ptrdiff_t... OtherStaticStrides>
   MDSPAN_INLINE_FUNCTION
   constexpr bool operator==(layout_stride_impl<OtherExtents, OtherStaticStrides...> const& other) const noexcept {
-    return __impl<>::_eq_impl(*this, other);
+    return __impl::_eq_impl(*this, other);
   }
 
   template<class OtherExtents, ptrdiff_t... OtherStaticStrides>
   MDSPAN_INLINE_FUNCTION
   constexpr bool operator!=(layout_stride_impl<OtherExtents, OtherStaticStrides...> const& other) const noexcept {
-    return __impl<>::_not_eq_impl(*this, other);
+    return __impl::_not_eq_impl(*this, other);
   }
 
 };

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -48,31 +48,35 @@
 
 #include <type_traits> // std::is_void
 
+#ifndef _MDSPAN_HOST_DEVICE
+#  if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP)
+#    define _MDSPAN_HOST_DEVICE __host__ __device__
+#  else
+#    define _MDSPAN_HOST_DEVICE
+#  endif
+#endif
+
 #ifndef MDSPAN_FORCE_INLINE_FUNCTION
-#  ifdef _MSC_VER // Microsoft compilers
-#    define MDSPAN_FORCE_INLINE_FUNCTION __forceinline
-#  elif defined(__CUDA_ARCH__)
-#    define MDSPAN_FORCE_INLINE_FUNCTION __attribute__((always_inline)) __host__ __device__
+#  ifdef _MDSPAN_COMPILER_MSVC // Microsoft compilers
+#    define MDSPAN_FORCE_INLINE_FUNCTION __forceinline _MDSPAN_HOST_DEVICE
 #  else
-#    define MDSPAN_FORCE_INLINE_FUNCTION __attribute__((always_inline))
+#    define MDSPAN_FORCE_INLINE_FUNCTION __attribute__((always_inline)) _MDSPAN_HOST_DEVICE
 #  endif
 #endif
+
 #ifndef MDSPAN_INLINE_FUNCTION
-#  if defined(__CUDA_ARCH__)
-#    define MDSPAN_INLINE_FUNCTION inline __host__ __device__
-#  else
-#    define MDSPAN_INLINE_FUNCTION inline
-#  endif
+#  define MDSPAN_INLINE_FUNCTION inline _MDSPAN_HOST_DEVICE
 #endif
+
+// In CUDA defaulted functions do not need host device markup
 #ifndef MDSPAN_INLINE_FUNCTION_DEFAULTED
-#  define MDSPAN_INLINE_FUNCTION_DEFAULTED inline
+#  define MDSPAN_INLINE_FUNCTION_DEFAULTED
 #endif
 
 //==============================================================================
 // <editor-fold desc="Preprocessor helpers"> {{{1
 
-
-#ifdef _MSC_VER // Microsoft compilers
+#if defined(_MDSPAN_COMPILER_MSVC) // Microsoft compilers
 
 #define MDSPAN_PP_COUNT(...) \
   _MDSPAN_PP_INTERNAL_EXPAND_ARGS_PRIVATE( \
@@ -161,7 +165,7 @@
 #endif
 
 
-#ifdef _MSC_VER
+#if defined(_MDSPAN_COMPILER_MSVC)
 #  define MDSPAN_TEMPLATE_REQUIRES(...) \
       MDSPAN_PP_CAT( \
         MDSPAN_PP_CAT(MDSPAN_TEMPLATE_REQUIRES_, MDSPAN_PP_COUNT(__VA_ARGS__))\

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -75,7 +75,19 @@ struct __no_unique_address_emulation<
                 // If the type isn't trivially destructible, its destructor
                 // won't be called at the right time, so don't use this
                 // specialization
-                _MDSPAN_TRAIT(is_trivially_destructible, _T)>> : private _T {
+                _MDSPAN_TRAIT(is_trivially_destructible, _T)>> : 
+#ifdef _MSC_VER
+    // MSVC doesn't allow you to access public static member functions of a type
+    // when you *happen* to privately inherit from that type.
+    protected
+#else
+    // But we still want this to be private if possible so that we don't accidentally 
+    // access members of _T directly rather than calling __ref() first, which wouldn't
+    // work if _T happens to be stateful and thus we're using the unspecialized definition
+    // of __no_unique_address_emulation above.
+    private
+#endif
+    _T {
   using __stored_type = _T;
   MDSPAN_FORCE_INLINE_FUNCTION constexpr _T const &__ref() const noexcept {
     return *static_cast<_T const *>(this);

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -76,7 +76,7 @@ struct __no_unique_address_emulation<
                 // won't be called at the right time, so don't use this
                 // specialization
                 _MDSPAN_TRAIT(is_trivially_destructible, _T)>> : 
-#ifdef _MSC_VER
+#ifdef _MDSPAN_COMPILER_MSVC
     // MSVC doesn't allow you to access public static member functions of a type
     // when you *happen* to privately inherit from that type.
     protected

--- a/include/experimental/__p0009_bits/standard_layout_static_array.hpp
+++ b/include/experimental/__p0009_bits/standard_layout_static_array.hpp
@@ -83,7 +83,6 @@ template <class _Tag, class _T, class _ValsSeq, _T __sentinal = dynamic_extent,
 struct __standard_layout_psa;
 
 //==============================================================================
-
 // Static case
 template <class _Tag, class _T, _T __value, _T... __values_or_sentinals,
           _T __sentinal, size_t _Idx, size_t... _Idxs>

--- a/include/experimental/__p0009_bits/standard_layout_static_array.hpp
+++ b/include/experimental/__p0009_bits/standard_layout_static_array.hpp
@@ -108,7 +108,7 @@ struct __standard_layout_psa<
   }
 
   static constexpr auto __size = sizeof...(_Idxs) + 1;
-#ifdef _MSC_VER
+#ifdef _MDSPAN_COMPILER_MSVC
   // MSVC doesn't like the fact that __next_t happens to be a base
   // class that's private, even though __size_synamic is public in
   // it's definition.
@@ -145,7 +145,7 @@ struct __standard_layout_psa<
 
   MDSPAN_INLINE_FUNCTION
   constexpr __standard_layout_psa(
-      __construct_partially_static_array_from_sizes_tag_t, _T const &__val,
+      __construct_partially_static_array_from_sizes_tag_t, _T const & /*__val*/,
       __repeated_with_idxs<_Idxs, _T> const &... __vals) noexcept
       : __base_t(__base_t{__next_t(
             __construct_partially_static_array_from_sizes_tag, __vals...)}) {}

--- a/include/experimental/__p0009_bits/trait_backports.hpp
+++ b/include/experimental/__p0009_bits/trait_backports.hpp
@@ -53,7 +53,7 @@
 //==============================================================================
 // <editor-fold desc="Variable template trait backports (e.g., is_void_v)"> {{{1
 
-#if _MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
+#ifdef _MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
 
 #if _MDSPAN_USE_VARIABLE_TEMPLATES
 namespace std {


### PR DESCRIPTION
in particular issue #23 and a problem with accessing public static members of private base classes. We still need to fix warnings, but the examples now compile under MSVC 16.5.0

Also adding gitignore file