### PR TITLE
Fix typo in extents array constructor

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -204,7 +204,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr explicit
   extents(std::array<IndexType, rank_dynamic()> const& dyn) noexcept
-    : __base_t(__base_t{typename __base_t::stored_type{
+    : __base_t(__base_t{typename __base_t::__stored_type{
         detail::__construct_psa_from_dynamic_values_tag_t<>{}, dyn}})
   { }
 


### PR DESCRIPTION
Fixes the constructor that takes dynamic extents as a std::array.