### PR TITLE
Add converting constructor to basic_accessor

### DIFF
--- a/include/experimental/__p0009_bits/accessor_basic.hpp
+++ b/include/experimental/__p0009_bits/accessor_basic.hpp
@@ -52,11 +52,22 @@ namespace experimental {
 
 template <class ElementType>
 struct accessor_basic {
-  
+
   using offset_policy = accessor_basic;
   using element_type = ElementType;
   using reference = ElementType&;
   using pointer = ElementType*;
+
+  constexpr accessor_basic() noexcept = default;
+
+  MDSPAN_TEMPLATE_REQUIRES(
+    class OtherElementType,
+    /* requires */ (
+      _MDSPAN_TRAIT(is_convertible, typename accessor_basic<OtherElementType>::pointer, pointer)
+    )
+  )
+  MDSPAN_INLINE_FUNCTION
+  constexpr accessor_basic(accessor_basic<OtherElementType>) {}
 
   MDSPAN_INLINE_FUNCTION
   constexpr pointer

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,4 +38,5 @@ mdspan_add_test(test_contiguous_layouts)
 mdspan_add_test(test_layout_ctors)
 mdspan_add_test(test_layout_stride)
 mdspan_add_test(test_element_access)
+mdspan_add_test(test_conversion)
 

--- a/tests/test_conversion.cpp
+++ b/tests/test_conversion.cpp
@@ -1,0 +1,58 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 3.0
+//       Copyright (2020) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY NTESS "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL NTESS OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+
+#include <experimental/mdspan>
+
+#include <gtest/gtest.h>
+
+namespace stdex = std::experimental;
+
+TEST(TestConversion, const_element) {
+    std::array<double, 6> a{};
+    stdex::mdspan<double, 2, 3> s(a.data());
+    s(0, 1) = 3.14;
+    stdex::mdspan<double const, 2, 3> c_s(s);
+    ASSERT_EQ(c_s(0, 1), 3.14);
+}


### PR DESCRIPTION
Alternate solution to #44 
I cherry-picked the test added in #47 and added a converting constructor to `accessor_basic` per our discussion.