### PR TITLE
Fixup missing return statement in predicate in `layout_stride::is_contiguous()`

### DIFF
--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -242,7 +242,7 @@ public:
     std::iota(rem.begin(), rem.end(), size_t(0));
     auto next_idx_iter = std::find_if(
       rem.begin(), rem.end(),
-      [&](size_t i) { this->stride(i) == 1;  }
+      [&](size_t i) { return this->stride(i) == 1;  }
     );
     if(next_idx_iter != rem.end()) {
       size_t prev_stride_times_prev_extent =

--- a/tests/test_contiguous_layouts.cpp
+++ b/tests/test_contiguous_layouts.cpp
@@ -176,6 +176,7 @@ TEST(TestLayoutLeftListInitialization, test_layout_left_list_initialization) {
   ASSERT_EQ(m.stride(1), 16);
   ASSERT_EQ(m.extent(0), 16);
   ASSERT_EQ(m.extent(1), 32);
+  ASSERT_TRUE(m.is_contiguous());
 }
 
 // GCC 10 ICEs if I stick this in the body of the below test.
@@ -207,6 +208,7 @@ TEST(TestLayoutRightListInitialization, test_layout_right_list_initialization) {
   ASSERT_EQ(m.stride(1), 1);
   ASSERT_EQ(m.extent(0), 16);
   ASSERT_EQ(m.extent(1), 32);
+  ASSERT_TRUE(m.is_contiguous());
 }
 
 // GCC 10 ICEs if I stick this in the body of the below test.

--- a/tests/test_layout_stride.cpp
+++ b/tests/test_layout_stride.cpp
@@ -119,6 +119,7 @@ TEST(TestLayoutStrideListInitialization, test_list_initialization) {
   ASSERT_EQ(m.stride(1), 128);
   ASSERT_EQ(m.extent(0), 16);
   ASSERT_EQ(m.extent(1), 32);
+  ASSERT_FALSE(m.is_contiguous());
 }
 
 // GCC 10 ICEs if I stick this in the body of the below test.


### PR DESCRIPTION
Fix #55