### PR TITLE
Remove exported target's interface C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,6 @@ target_include_directories(mdspan INTERFACE
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
-target_compile_features(mdspan INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 
 ################################################################################
 


### PR DESCRIPTION
Mdspan supports multiple C++ standards.
Setting this in the target's interface compile features
overconstrains the exported target by forcing it to use
the standard it was originally configured to use.