### PR TITLE
Implement missing `strides` function of `layout_stride::mapping`

### DIFF
--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -176,6 +176,12 @@ struct layout_stride {
       return __strides_storage().extent(R);
     }
 
+    template <size_t... Idxs>
+    MDSPAN_INLINE_FUNCTION
+    constexpr array< size_t, Extents::rank() > __strides(std::index_sequence<Idxs...>) const noexcept {
+      return {__strides_storage().template __extent<Idxs>()...};
+    }
+
     MDSPAN_INLINE_FUNCTION
     static constexpr mapping
     __make_mapping(
@@ -321,6 +327,11 @@ struct layout_stride {
     MDSPAN_INLINE_FUNCTION
     constexpr size_t stride(size_t r) const noexcept {
       return __strides_storage().extent(r);
+    }
+
+    MDSPAN_INLINE_FUNCTION
+    constexpr array< size_t, Extents::rank() > strides() const noexcept {
+      return __strides(std::make_index_sequence<Extents::rank()>());
     }
 
     MDSPAN_INLINE_FUNCTION

--- a/tests/test_layout_stride.cpp
+++ b/tests/test_layout_stride.cpp
@@ -104,6 +104,7 @@ TEST(TestLayoutStrideListInitialization, test_list_initialization) {
   ASSERT_EQ(m.extents().extent(1), 32);
   ASSERT_EQ(m.stride(0), 1);
   ASSERT_EQ(m.stride(1), 128);
+  ASSERT_EQ(m.strides(), (std::array<std::size_t, 2>{1, 128}));
   ASSERT_FALSE(m.is_contiguous());
 }
 
@@ -117,6 +118,7 @@ TEST(TestLayoutStrideCTAD, test_ctad) {
   ASSERT_EQ(m0.extents().extent(1), 32);
   ASSERT_EQ(m0.stride(0), 1);
   ASSERT_EQ(m0.stride(1), 128);
+  ASSERT_EQ(m0.strides(), (std::array<std::size_t, 2>{1, 128}));
   ASSERT_FALSE(m0.is_contiguous());
 
   stdex::layout_stride::mapping m1{stdex::extents{16, 32}, std::array{1, 128}};
@@ -126,6 +128,7 @@ TEST(TestLayoutStrideCTAD, test_ctad) {
   ASSERT_EQ(m1.extents().extent(1), 32);
   ASSERT_EQ(m1.stride(0), 1);
   ASSERT_EQ(m1.stride(1), 128);
+  ASSERT_EQ(m1.strides(), (std::array<std::size_t, 2>{1, 128}));
   ASSERT_FALSE(m1.is_contiguous());
 
 // TODO These won't work with our current implementation, because the array will


### PR DESCRIPTION
I propose an implementation for the missing `strides` member function with some tests.