### PR TITLE
Adopt new extents explicit rules

### DIFF
--- a/compilation_tests/ctest_constexpr_layouts.cpp
+++ b/compilation_tests/ctest_constexpr_layouts.cpp
@@ -55,7 +55,7 @@ layout_stride_simple(int i) {
   using map_t = stdex::layout_stride::template mapping<
     stdex::extents<3>
   >;
-  return map_t(stdex::extents<3>{}, {1})(i);
+  return map_t(stdex::extents<3>{}, std::array<size_t,1>{1})(i);
 }
 
 MDSPAN_STATIC_TEST(

--- a/compilation_tests/ctest_extents_ctors.cpp
+++ b/compilation_tests/ctest_extents_ctors.cpp
@@ -129,14 +129,14 @@ MDSPAN_STATIC_TEST(
 
 
 MDSPAN_STATIC_TEST(
-  std::is_convertible<
+  std::is_constructible<
     stdex::extents<2, stdex::dynamic_extent>,
     stdex::extents<2, 3>
   >::value
 );
 
 MDSPAN_STATIC_TEST(
-  !std::is_convertible<
+  !std::is_constructible<
     stdex::extents<3, stdex::dynamic_extent>,
     stdex::extents<2, 3>
   >::value

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -232,8 +232,10 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #  endif
 #endif
 
-#ifndef _MDSPAN_USE_CONDITIONAL_EXPLICIT
+#ifndef MDSPAN_CONDITIONAL_EXPLICIT
 #  if (defined(MDSPAN_HAS_CXX_20))
-#    define _MDSPAN_USE_CONDITIONAL_EXPLICIT 1
+#    define MDSPAN_CONDITIONAL_EXPLICIT(COND) explicit(COND)
+#  else
+#    define MDSPAN_CONDITIONAL_EXPLICIT(COND)
 #  endif
 #endif

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -231,3 +231,9 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #    endif
 #  endif
 #endif
+
+#ifndef _MDSPAN_USE_CONDITIONAL_EXPLICIT
+#  if (defined(MDSPAN_HAS_CXX_20))
+#    define _MDSPAN_USE_CONDITIONAL_EXPLICIT 1
+#  endif
+#endif

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -196,6 +196,9 @@ public:
     )
   )
   MDSPAN_INLINE_FUNCTION
+#if defined(_MDSPAN_USE_CONDITIONAL_EXPLICIT)
+  explicit((((Extents != dynamic_extent) && (OtherExtents == dynamic_extent)) || ...))
+#endif
   constexpr extents(const extents<OtherExtents...>& __other)
     noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
@@ -219,7 +222,7 @@ public:
     )
   )
   MDSPAN_INLINE_FUNCTION
-  constexpr extents(Integral... dyn) noexcept
+  explicit constexpr extents(Integral... dyn) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     : __storage_{
 #else

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -196,9 +196,7 @@ public:
     )
   )
   MDSPAN_INLINE_FUNCTION
-#if defined(_MDSPAN_USE_CONDITIONAL_EXPLICIT)
-  explicit((((Extents != dynamic_extent) && (OtherExtents == dynamic_extent)) || ...))
-#endif
+  MDSPAN_CONDITIONAL_EXPLICIT((((Extents != dynamic_extent) && (OtherExtents == dynamic_extent)) || ...))
   constexpr extents(const extents<OtherExtents...>& __other)
     noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)

--- a/include/experimental/__p0009_bits/fixed_layout_impl.hpp
+++ b/include/experimental/__p0009_bits/fixed_layout_impl.hpp
@@ -126,6 +126,22 @@ public:
       })
 #endif
   { }
+  template<std::size_t ... OtherExts>
+  MDSPAN_INLINE_FUNCTION
+  constexpr /* implicit */ __extents_storage_impl(experimental::extents<OtherExts...> const& __exts) noexcept
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+    : __extents_{
+#else
+    : __base_t(__base_t{
+#endif
+    // Need to convert extents here potentially explicit
+        extents_type(__exts)
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+      }
+#else
+      })
+#endif
+  { }
 
   // The layouts need to be implicitly convertible from extents (as currently specified),
   // which means we need to make this not explicit here

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -110,9 +110,12 @@ struct layout_left {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_convertible, OtherExtents, Extents)
+        _MDSPAN_TRAIT(is_constructible, OtherExtents, Extents)
       )
     )
+#ifdef _MDSPAN_USE_CONDITIONAL_EXPLICIT
+    explicit (!is_convertible<OtherExtents, Extents>::value)
+#endif
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) // NOLINT(google-explicit-constructor)
       : base_t(other.extents())
@@ -122,7 +125,7 @@ struct layout_left {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_convertible, OtherExtents, Extents)
+        _MDSPAN_TRAIT(is_assignable, OtherExtents, Extents)
       )
     )
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -113,9 +113,7 @@ struct layout_left {
         _MDSPAN_TRAIT(is_constructible, OtherExtents, Extents)
       )
     )
-#ifdef _MDSPAN_USE_CONDITIONAL_EXPLICIT
-    explicit (!is_convertible<OtherExtents, Extents>::value)
-#endif
+    MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, Extents>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) // NOLINT(google-explicit-constructor)
       : base_t(other.extents())

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -110,9 +110,12 @@ struct layout_right {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_convertible, OtherExtents, Extents)
+        _MDSPAN_TRAIT(is_constructible, OtherExtents, Extents)
       )
     )
+#ifdef _MDSPAN_USE_CONDITIONAL_EXPLICIT
+    explicit (!is_convertible<OtherExtents, Extents>::value)
+#endif
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) // NOLINT(google-explicit-constructor)
       : base_t(other.extents())
@@ -122,7 +125,7 @@ struct layout_right {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
         /* requires */ (
-        _MDSPAN_TRAIT(is_convertible, OtherExtents, Extents)
+        _MDSPAN_TRAIT(is_assignable, OtherExtents, Extents)
       )
     )
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -113,9 +113,7 @@ struct layout_right {
         _MDSPAN_TRAIT(is_constructible, OtherExtents, Extents)
       )
     )
-#ifdef _MDSPAN_USE_CONDITIONAL_EXPLICIT
-    explicit (!is_convertible<OtherExtents, Extents>::value)
-#endif
+    MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, Extents>::value)) // needs to () due to ,
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) // NOLINT(google-explicit-constructor)
       : base_t(other.extents())

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -212,9 +212,6 @@ struct layout_stride {
     mapping& operator=(mapping&&) noexcept = default;
     MDSPAN_INLINE_FUNCTION_DEFAULTED ~mapping() noexcept = default;
 
-    // TODO @proposal-bug In the proposal, the constructor doesn't take a
-    // `dextents`, and doesn't accept any `array` with elements convertible to
-    // `size_t`.
     template<class IntegralType>
     MDSPAN_INLINE_FUNCTION
     constexpr

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -77,6 +77,7 @@ struct layout_stride {
     // This could be a `requires`, but I think it's better and clearer as a `static_assert`.
     static_assert(detail::__is_extents_v<Extents>, "std::experimental::layout_stride::mapping must be instantiated with a specialization of std::experimental::extents.");
 
+    using size_type = typename Extents::size_type;
     using extents_type = Extents;
 
     // TODO @proposal-bug This isn't a requirement of layouts in the proposal,
@@ -214,11 +215,12 @@ struct layout_stride {
     // TODO @proposal-bug In the proposal, the constructor doesn't take a
     // `dextents`, and doesn't accept any `array` with elements convertible to
     // `size_t`.
+    template<class IntegralType>
     MDSPAN_INLINE_FUNCTION
     constexpr
     mapping(
       Extents const& e,
-      ::std::experimental::dextents<Extents::rank()> const& strides
+      ::std::array<IntegralType, Extents::rank()> const& strides
     ) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -236,6 +236,7 @@ struct layout_stride {
     { }
 
     template<class OtherExtents>
+    MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, Extents>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION
     constexpr
     mapping(

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -143,14 +143,14 @@ public:
   )
   MDSPAN_INLINE_FUNCTION
   // TODO @proposal-bug Why is this explicit?
-  explicit constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
+  constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
     noexcept
     : __members(p, __map_acc_pair_t(mapping_type(extents_type(dynamic_extents)), accessor_type()))
   { }
 
   MDSPAN_INLINE_FUNCTION
   // TODO @proposal-bug This is missing from the proposal.
-  explicit constexpr mdspan(pointer p, const extents_type& exts)
+  constexpr mdspan(pointer p, const extents_type& exts)
     noexcept
     : __members(p, __map_acc_pair_t(mapping_type(exts), accessor_type()))
   { }

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -114,7 +114,6 @@ public:
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mdspan(const mdspan&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mdspan(mdspan&&) noexcept = default;
 
-  // TODO noexcept specification
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
@@ -131,7 +130,6 @@ public:
     : __members(p, __map_acc_pair_t(mapping_type(extents_type(dynamic_extents...)), accessor_type()))
   { }
 
-  // TODO noexcept specification
   MDSPAN_TEMPLATE_REQUIRES(
     class SizeType, size_t N,
     /* requires */ (
@@ -142,20 +140,17 @@ public:
     )
   )
   MDSPAN_INLINE_FUNCTION
-  // TODO @proposal-bug Why is this explicit?
   constexpr mdspan(pointer p, const array<SizeType, N>& dynamic_extents)
     noexcept
     : __members(p, __map_acc_pair_t(mapping_type(extents_type(dynamic_extents)), accessor_type()))
   { }
 
   MDSPAN_INLINE_FUNCTION
-  // TODO @proposal-bug This is missing from the proposal.
   constexpr mdspan(pointer p, const extents_type& exts)
     noexcept
     : __members(p, __map_acc_pair_t(mapping_type(exts), accessor_type()))
   { }
 
-  // TODO noexcept specification
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdspan, (pointer p, const mapping_type& m), noexcept,
@@ -163,13 +158,11 @@ public:
   ) : __members(p, __map_acc_pair_t(m, accessor_type()))
   { }
 
-  // TODO noexcept specification
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(pointer p, const mapping_type& m, const accessor_type& a) noexcept
     : __members(p, __map_acc_pair_t(m, a))
   { }
 
-  // TODO noexcept specification
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor,
     /* requires */ (

--- a/tests/test_layout_ctors.cpp
+++ b/tests/test_layout_ctors.cpp
@@ -199,8 +199,8 @@ TYPED_TEST(TestLayoutRightCompatCtors, compatible_assign_2) {
   ASSERT_EQ(this->map1.extents(), this->map2.extents());
 }
 
-TEST(TestLayoutLeftListInitialization, test_layout_left_list_initialization) {
-  stdex::layout_left::mapping<stdex::extents<dyn, dyn>> m{{16, 32}};
+TEST(TestLayoutLeftListInitialization, test_layout_left_extent_initialization) {
+  stdex::layout_left::mapping<stdex::extents<dyn, dyn>> m{stdex::dextents<2>{16, 32}};
   ASSERT_EQ(m.extents().rank(), 2);
   ASSERT_EQ(m.extents().rank_dynamic(), 2);
   ASSERT_EQ(m.extents().extent(0), 16);
@@ -223,8 +223,8 @@ TEST(TestLayoutLeftCTAD, test_layout_left_ctad) {
 }
 #endif
 
-TEST(TestLayoutRightListInitialization, test_layout_right_list_initialization) {
-  stdex::layout_right::mapping<stdex::extents<dyn, dyn>> m{{16, 32}};
+TEST(TestLayoutRightListInitialization, test_layout_right_extent_initialization) {
+  stdex::layout_right::mapping<stdex::extents<dyn, dyn>> m{stdex::dextents<2>{16, 32}};
   ASSERT_EQ(m.extents().rank(), 2);
   ASSERT_EQ(m.extents().rank_dynamic(), 2);
   ASSERT_EQ(m.extents().extent(0), 16);

--- a/tests/test_layout_stride.cpp
+++ b/tests/test_layout_stride.cpp
@@ -97,7 +97,7 @@ TYPED_TEST(TestLayoutStrideAllZero, test_mapping) {
 }
 
 TEST(TestLayoutStrideListInitialization, test_list_initialization) {
-  stdex::layout_stride::mapping<stdex::extents<dyn, dyn>> m{{16, 32}, {1, 128}};
+  stdex::layout_stride::mapping<stdex::extents<dyn, dyn>> m{stdex::dextents<2>{16, 32}, std::array<int,2>{1, 128}};
   ASSERT_EQ(m.extents().rank(), 2);
   ASSERT_EQ(m.extents().rank_dynamic(), 2);
   ASSERT_EQ(m.extents().extent(0), 16);
@@ -110,6 +110,8 @@ TEST(TestLayoutStrideListInitialization, test_list_initialization) {
 // This fails on GCC 9.2 and others
 #if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 TEST(TestLayoutStrideCTAD, test_ctad) {
+  // This is not possible wiht the array constructor we actually provide
+  /*
   stdex::layout_stride::mapping m0{stdex::extents{16, 32}, stdex::extents{1, 128}};
   ASSERT_EQ(m0.extents().rank(), 2);
   ASSERT_EQ(m0.extents().rank_dynamic(), 2);
@@ -118,6 +120,7 @@ TEST(TestLayoutStrideCTAD, test_ctad) {
   ASSERT_EQ(m0.stride(0), 1);
   ASSERT_EQ(m0.stride(1), 128);
   ASSERT_FALSE(m0.is_contiguous());
+  */
 
   stdex::layout_stride::mapping m1{stdex::extents{16, 32}, std::array{1, 128}};
   ASSERT_EQ(m1.extents().rank(), 2);

--- a/tests/test_mdspan_ctors.cpp
+++ b/tests/test_mdspan_ctors.cpp
@@ -102,7 +102,7 @@ TEST(TestMdspanListInitializationLayoutRight, test_mdspan_list_initialization_la
 
 TEST(TestMdspanListInitializationLayoutStride, test_mdspan_list_initialization_layout_stride) {
   std::array<int, 1> d{42};
-  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_stride> m{d.data(), {stdex::extents{16, 32}, std::array{1, 128}}};
+  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_stride> m{d.data(), {stdex::dextents<2>{16, 32}, std::array<std::size_t, 2>{1, 128}}};
   ASSERT_EQ(m.data(), d.data());
   ASSERT_EQ(m.rank(), 2);
   ASSERT_EQ(m.rank_dynamic(), 2);

--- a/tests/test_mdspan_ctors.cpp
+++ b/tests/test_mdspan_ctors.cpp
@@ -76,7 +76,7 @@ TEST(TestMdspanCtorExtentsStdArrayConvertibleToSizeT, test_mdspan_ctor_extents_s
 
 TEST(TestMdspanListInitializationLayoutLeft, test_mdspan_list_initialization_layout_left) {
   std::array<int, 1> d{42};
-  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_left> m{d.data(), {{16, 32}}};
+  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_left> m{d.data(), 16, 32};
   ASSERT_EQ(m.data(), d.data());
   ASSERT_EQ(m.rank(), 2);
   ASSERT_EQ(m.rank_dynamic(), 2);
@@ -89,7 +89,7 @@ TEST(TestMdspanListInitializationLayoutLeft, test_mdspan_list_initialization_lay
 
 TEST(TestMdspanListInitializationLayoutRight, test_mdspan_list_initialization_layout_right) {
   std::array<int, 1> d{42};
-  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_right> m{d.data(), {{16, 32}}};
+  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_right> m{d.data(), 16, 32};
   ASSERT_EQ(m.data(), d.data());
   ASSERT_EQ(m.rank(), 2);
   ASSERT_EQ(m.rank_dynamic(), 2);
@@ -102,7 +102,7 @@ TEST(TestMdspanListInitializationLayoutRight, test_mdspan_list_initialization_la
 
 TEST(TestMdspanListInitializationLayoutStride, test_mdspan_list_initialization_layout_stride) {
   std::array<int, 1> d{42};
-  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_stride> m{d.data(), {{16, 32}, {1, 128}}};
+  stdex::mdspan<int, stdex::extents<dyn, dyn>, stdex::layout_stride> m{d.data(), {stdex::extents{16, 32}, std::array{1, 128}}};
   ASSERT_EQ(m.data(), d.data());
   ASSERT_EQ(m.rank(), 2);
   ASSERT_EQ(m.rank_dynamic(), 2);
@@ -215,6 +215,7 @@ TEST(TestMdspanCTADLayoutStride, test_mdspan_ctad_layout_stride) {
   ASSERT_EQ(m0.stride(1), 128);
   ASSERT_FALSE(m0.is_contiguous());
 
+  /* 
   stdex::mdspan m1{d.data(), stdex::layout_stride::mapping{stdex::extents{16, 32}, stdex::extents{1, 128}}};
   ASSERT_EQ(m1.data(), d.data());
   ASSERT_EQ(m1.rank(), 2);
@@ -224,6 +225,7 @@ TEST(TestMdspanCTADLayoutStride, test_mdspan_ctad_layout_stride) {
   ASSERT_EQ(m1.stride(0), 1);
   ASSERT_EQ(m1.stride(1), 128);
   ASSERT_FALSE(m1.is_contiguous());
+  */
 
 // TODO: Perhaps one day I'll get this to work.
 /*


### PR DESCRIPTION
This changes the extents constructors to be explicit for construction from integers and when converting runtime to compile time extents