### PR TITLE
Allow extents construction from all extents

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -228,8 +228,8 @@ public:
     : __base_t(__base_t{typename __base_t::__stored_type{
 #endif
       std::conditional_t<sizeof...(Integral)==rank_dynamic(),
-        detail::__construct_partially_static_array_from_dynamic_sizes_tag_t,
-        detail::__construct_partially_static_array_from_all_sizes_tag_t>(),
+        detail::__construct_psa_from_dynamic_exts_values_tag_t,
+        detail::__construct_psa_from_all_exts_values_tag_t>(),
         static_cast<size_t>(exts)...
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       }
@@ -255,8 +255,8 @@ public:
     : __base_t(__base_t{typename __base_t::__stored_type{
 #endif
       std::conditional_t<N==rank_dynamic(),
-        detail::__construct_psa_from_dynamic_values_tag_t<0>,
-        detail::__construct_psa_from_all_values_tag_t>(),
+        detail::__construct_psa_from_dynamic_exts_array_tag_t<0>,
+        detail::__construct_psa_from_all_exts_array_tag_t>(),
         std::array<SizeType,N>{exts}
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       }

--- a/include/experimental/__p0009_bits/standard_layout_static_array.hpp
+++ b/include/experimental/__p0009_bits/standard_layout_static_array.hpp
@@ -63,15 +63,15 @@ namespace detail {
 //==============================================================================
 
 _MDSPAN_INLINE_VARIABLE constexpr struct
-    __construct_partially_static_array_from_dynamic_sizes_tag_t {
-} __construct_partially_static_array_from_dynamic_sizes_tag = {};
+    __construct_psa_from_dynamic_exts_values_tag_t {
+} __construct_psa_from_dynamic_exts_values_tag = {};
 
 _MDSPAN_INLINE_VARIABLE constexpr struct
-    __construct_partially_static_array_from_all_sizes_tag_t {
-} __construct_partially_static_array_from_all_sizes_tag = {};
+    __construct_psa_from_all_exts_values_tag_t {
+} __construct_psa_from_all_exts_values_tag = {};
 
-struct __construct_psa_from_all_values_tag_t {};
-template <size_t _N = 0> struct __construct_psa_from_dynamic_values_tag_t {};
+struct __construct_psa_from_all_exts_array_tag_t {};
+template <size_t _N = 0> struct __construct_psa_from_dynamic_exts_array_tag_t {};
 
 //==============================================================================
 
@@ -172,14 +172,14 @@ struct __standard_layout_psa<
 
   MDSPAN_INLINE_FUNCTION
   constexpr __standard_layout_psa(
-      __construct_partially_static_array_from_all_sizes_tag_t, _T const & /*__val*/,
+      __construct_psa_from_all_exts_values_tag_t, _T const & /*__val*/,
       __repeated_with_idxs<_Idxs, _T> const &... __vals) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __next_{
 #else
       : __base_t(__base_t{__next_t(
 #endif
-          __construct_partially_static_array_from_all_sizes_tag, __vals...
+          __construct_psa_from_all_exts_values_tag, __vals...
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -189,14 +189,14 @@ struct __standard_layout_psa<
 
   template <class... _Ts>
   MDSPAN_INLINE_FUNCTION constexpr __standard_layout_psa(
-      __construct_partially_static_array_from_dynamic_sizes_tag_t,
+      __construct_psa_from_dynamic_exts_values_tag_t,
       _Ts const &... __vals) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __next_{
 #else
       : __base_t(__base_t{__next_t(
 #endif
-          __construct_partially_static_array_from_dynamic_sizes_tag, __vals...
+          __construct_psa_from_dynamic_exts_values_tag, __vals...
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -222,7 +222,7 @@ struct __standard_layout_psa<
 
   template <class _U, size_t _NStatic>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
-      __construct_psa_from_all_values_tag_t const & __tag,
+      __construct_psa_from_all_exts_array_tag_t const & __tag,
       array<_U, _NStatic> const &__vals) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __next_{
@@ -239,7 +239,7 @@ struct __standard_layout_psa<
 
   template <class _U, size_t _IDynamic, size_t _NDynamic>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
-      __construct_psa_from_dynamic_values_tag_t<_IDynamic> __tag,
+      __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic> __tag,
       array<_U, _NDynamic> const &__vals) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __next_{
@@ -367,18 +367,18 @@ struct __standard_layout_psa<
 
   MDSPAN_INLINE_FUNCTION
   constexpr __standard_layout_psa(
-      __construct_partially_static_array_from_all_sizes_tag_t, _T const &__val,
+      __construct_psa_from_all_exts_values_tag_t, _T const &__val,
       __repeated_with_idxs<_Idxs, _T> const &... __vals) noexcept
       : __value_pair(__val,
-                     __next_t(__construct_partially_static_array_from_all_sizes_tag,
+                     __next_t(__construct_psa_from_all_exts_values_tag,
                               __vals...)) {}
 
   template <class... _Ts>
   MDSPAN_INLINE_FUNCTION constexpr __standard_layout_psa(
-      __construct_partially_static_array_from_dynamic_sizes_tag_t, _T const &__val,
+      __construct_psa_from_dynamic_exts_values_tag_t, _T const &__val,
       _Ts const &... __vals) noexcept
       : __value_pair(__val,
-                     __next_t(__construct_partially_static_array_from_dynamic_sizes_tag,
+                     __next_t(__construct_psa_from_dynamic_exts_values_tag,
                               __vals...)) {}
 
   template <class _U, size_t _N>
@@ -388,7 +388,7 @@ struct __standard_layout_psa<
 
   template <class _U, size_t _NStatic>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
-      __construct_psa_from_all_values_tag_t __tag,
+      __construct_psa_from_all_exts_array_tag_t __tag,
       array<_U, _NStatic> const &__vals) noexcept
       : __value_pair(
             ::std::get<_Idx>(__vals),
@@ -397,11 +397,11 @@ struct __standard_layout_psa<
 
   template <class _U, size_t _IDynamic, size_t _NDynamic>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
-      __construct_psa_from_dynamic_values_tag_t<_IDynamic> __tag,
+      __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic> __tag,
       array<_U, _NDynamic> const &__vals) noexcept
       : __value_pair(
             ::std::get<_IDynamic>(__vals),
-            __next_t(__construct_psa_from_dynamic_values_tag_t<_IDynamic + 1>{},
+            __next_t(__construct_psa_from_dynamic_exts_array_tag_t<_IDynamic + 1>{},
                      __vals)) {}
 
   template <class _UTag, class _U, class _UValsSeq, _U __u_sentinal,
@@ -490,11 +490,11 @@ struct __standard_layout_psa<_Tag, _T, integer_sequence<_T>, __sentinal,
 
   MDSPAN_INLINE_FUNCTION
   constexpr __standard_layout_psa(
-      __construct_partially_static_array_from_all_sizes_tag_t) noexcept {}
+      __construct_psa_from_all_exts_values_tag_t) noexcept {}
 
   template <class... _Ts>
   MDSPAN_INLINE_FUNCTION constexpr __standard_layout_psa(
-      __construct_partially_static_array_from_dynamic_sizes_tag_t) noexcept {}
+      __construct_psa_from_dynamic_exts_values_tag_t) noexcept {}
 
   template <class _U, size_t _N>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
@@ -502,12 +502,12 @@ struct __standard_layout_psa<_Tag, _T, integer_sequence<_T>, __sentinal,
 
   template <class _U, size_t _NStatic>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
-      __construct_psa_from_all_values_tag_t __tag,
+      __construct_psa_from_all_exts_array_tag_t __tag,
       array<_U, _NStatic> const &) noexcept {}
 
   template <class _U, size_t _IDynamic, size_t _NDynamic>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
-      __construct_psa_from_dynamic_values_tag_t<_IDynamic> __tag,
+      __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic> __tag,
       array<_U, _NDynamic> const &) noexcept {}
 
   template <class _UTag, class _U, class _UValsSeq, _U __u_sentinal,

--- a/include/experimental/__p0009_bits/static_array.hpp
+++ b/include/experimental/__p0009_bits/static_array.hpp
@@ -145,24 +145,20 @@ public:
 
   MDSPAN_INLINE_FUNCTION
   constexpr __partially_static_array_impl(
-      __construct_partially_static_array_from_sizes_tag_t,
+      __construct_partially_static_array_from_all_sizes_tag_t,
       __repeated_with_idxs<_Idxs, _T> const &... __vals) noexcept
       : __base_n<_Idxs>(__base_n<_Idxs>{{__vals}})... {}
 
-  // Dynamic idxs only given version, which is probably going to not need to
-  // supported by the time mdspan is merged into the standard, but is currently the
-  // way this is specified.  Use a repeated tag for the old semantics
   MDSPAN_INLINE_FUNCTION
   constexpr __partially_static_array_impl(
-      __construct_partially_static_array_from_sizes_tag_t,
-      __construct_partially_static_array_from_sizes_tag_t,
+      __construct_partially_static_array_from_dynamic_sizes_tag_t,
       __repeated_with_idxs<_IdxsDynamicIdxs, _T> const &... __vals) noexcept
       : __base_n<_IdxsDynamic>(__base_n<_IdxsDynamic>{{__vals}})... {}
 
   MDSPAN_INLINE_FUNCTION constexpr explicit __partially_static_array_impl(
     array<_T, sizeof...(_Idxs)> const& __vals) noexcept
     : __partially_static_array_impl(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         ::std::get<_Idxs>(__vals)...) {}
 
   // clang-format off
@@ -173,8 +169,7 @@ public:
     /* requires */
       (sizeof...(_Idxs) != __size_dynamic)
   ): __partially_static_array_impl(
-       __construct_partially_static_array_from_sizes_tag,
-       __construct_partially_static_array_from_sizes_tag,
+       __construct_partially_static_array_from_dynamic_sizes_tag,
        ::std::get<_IdxsDynamicIdxs>(__vals)...) {}
   // clang-format on
 
@@ -185,7 +180,7 @@ public:
       _U, _UValsSeq, __u_sentinal, _UIdxsSeq,
      _UIdxsDynamicSeq, _UIdxsDynamicIdxsSeq> const &__rhs) noexcept
     : __partially_static_array_impl(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __rhs.template __get_n<_Idxs>()...) {}
 
   //--------------------------------------------------------------------------

--- a/include/experimental/__p0009_bits/static_array.hpp
+++ b/include/experimental/__p0009_bits/static_array.hpp
@@ -145,20 +145,20 @@ public:
 
   MDSPAN_INLINE_FUNCTION
   constexpr __partially_static_array_impl(
-      __construct_partially_static_array_from_all_sizes_tag_t,
+      __construct_psa_from_all_exts_values_tag_t,
       __repeated_with_idxs<_Idxs, _T> const &... __vals) noexcept
       : __base_n<_Idxs>(__base_n<_Idxs>{{__vals}})... {}
 
   MDSPAN_INLINE_FUNCTION
   constexpr __partially_static_array_impl(
-      __construct_partially_static_array_from_dynamic_sizes_tag_t,
+      __construct_psa_from_dynamic_exts_values_tag_t,
       __repeated_with_idxs<_IdxsDynamicIdxs, _T> const &... __vals) noexcept
       : __base_n<_IdxsDynamic>(__base_n<_IdxsDynamic>{{__vals}})... {}
 
   MDSPAN_INLINE_FUNCTION constexpr explicit __partially_static_array_impl(
     array<_T, sizeof...(_Idxs)> const& __vals) noexcept
     : __partially_static_array_impl(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         ::std::get<_Idxs>(__vals)...) {}
 
   // clang-format off
@@ -169,7 +169,7 @@ public:
     /* requires */
       (sizeof...(_Idxs) != __size_dynamic)
   ): __partially_static_array_impl(
-       __construct_partially_static_array_from_dynamic_sizes_tag,
+       __construct_psa_from_dynamic_exts_values_tag,
        ::std::get<_IdxsDynamicIdxs>(__vals)...) {}
   // clang-format on
 
@@ -180,7 +180,7 @@ public:
       _U, _UValsSeq, __u_sentinal, _UIdxsSeq,
      _UIdxsDynamicSeq, _UIdxsDynamicIdxsSeq> const &__rhs) noexcept
     : __partially_static_array_impl(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __rhs.template __get_n<_Idxs>()...) {}
 
   //--------------------------------------------------------------------------

--- a/include/experimental/__p0009_bits/submdspan.hpp
+++ b/include/experimental/__p0009_bits/submdspan.hpp
@@ -260,7 +260,7 @@ struct __assign_op_slice_handler<
          __partially_static_sizes<_Strides...>/* intentional space here to work around ICC bug*/> {
     return {
       __partially_static_sizes<_Offsets..., dynamic_extent>(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., __slice.slice),
       ::std::move(__exts),
       ::std::move(__strides)
@@ -279,13 +279,13 @@ struct __assign_op_slice_handler<
          __partially_static_sizes<_Strides..., _OldStaticStride>/* intentional space here to work around ICC bug*/> {
     return {
       __partially_static_sizes<_Offsets..., 0>(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., size_t(0)),
       __partially_static_sizes<_Exts..., _OldStaticExtent>(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __exts.template __get_n<_ExtIdxs>()..., __slice.old_extent),
       __partially_static_sizes<_Strides..., _OldStaticStride>(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __strides.template __get_n<_StrideIdxs>()..., __slice.old_stride)
     };
   }
@@ -302,13 +302,13 @@ struct __assign_op_slice_handler<
          __partially_static_sizes<_Strides..., _OldStaticStride>/* intentional space here to work around ICC bug*/> {
     return {
       __partially_static_sizes<_Offsets..., dynamic_extent>(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., ::std::get<0>(__slice.slice)),
       __partially_static_sizes<_Exts..., dynamic_extent>(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __exts.template __get_n<_ExtIdxs>()..., ::std::get<1>(__slice.slice) - ::std::get<0>(__slice.slice)),
       __partially_static_sizes<_Strides..., _OldStaticStride>(
-        __construct_partially_static_array_from_all_sizes_tag,
+        __construct_psa_from_all_exts_values_tag,
         __strides.template __get_n<_StrideIdxs>()..., __slice.old_stride)
     };
   }

--- a/include/experimental/__p0009_bits/submdspan.hpp
+++ b/include/experimental/__p0009_bits/submdspan.hpp
@@ -260,7 +260,7 @@ struct __assign_op_slice_handler<
          __partially_static_sizes<_Strides...>/* intentional space here to work around ICC bug*/> {
     return {
       __partially_static_sizes<_Offsets..., dynamic_extent>(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., __slice.slice),
       ::std::move(__exts),
       ::std::move(__strides)
@@ -279,13 +279,13 @@ struct __assign_op_slice_handler<
          __partially_static_sizes<_Strides..., _OldStaticStride>/* intentional space here to work around ICC bug*/> {
     return {
       __partially_static_sizes<_Offsets..., 0>(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., size_t(0)),
       __partially_static_sizes<_Exts..., _OldStaticExtent>(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __exts.template __get_n<_ExtIdxs>()..., __slice.old_extent),
       __partially_static_sizes<_Strides..., _OldStaticStride>(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __strides.template __get_n<_StrideIdxs>()..., __slice.old_stride)
     };
   }
@@ -302,13 +302,13 @@ struct __assign_op_slice_handler<
          __partially_static_sizes<_Strides..., _OldStaticStride>/* intentional space here to work around ICC bug*/> {
     return {
       __partially_static_sizes<_Offsets..., dynamic_extent>(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., ::std::get<0>(__slice.slice)),
       __partially_static_sizes<_Exts..., dynamic_extent>(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __exts.template __get_n<_ExtIdxs>()..., ::std::get<1>(__slice.slice) - ::std::get<0>(__slice.slice)),
       __partially_static_sizes<_Strides..., _OldStaticStride>(
-        __construct_partially_static_array_from_sizes_tag,
+        __construct_partially_static_array_from_all_sizes_tag,
         __strides.template __get_n<_StrideIdxs>()..., __slice.old_stride)
     };
   }


### PR DESCRIPTION
This addresses one of the changes in P0009R14: we should allow constructions of extents (and mdspan - but I haven't done that yet) from either just `dynamic_rank` values or `rank` values. Both for integer packs and array. 