### PR TITLE
Update mdspan with r14 changes

### DIFF
--- a/compilation_tests/ctest_constructor_sfinae.cpp
+++ b/compilation_tests/ctest_constructor_sfinae.cpp
@@ -50,7 +50,64 @@
 namespace stdex = std::experimental;
 
 //==============================================================================
-// <editor-fold desc="Test allowed pointer + extents ctors"> {{{1
+// <editor-fold des4c="Test allowed pointer + extents ctors"> {{{1
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        std::array<int,1>
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        std::array<int,2>
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        int
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        int, int64_t
+    >::value
+);
+
+// TODO @proposal-bug: not sure we really intended this???
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        std::array<float,2>
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        float, double
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::mdspan<int, stdex::extents<>>,
+        int*
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::mdspan<int, stdex::extents<2>>,
+        int*
+    >::value
+);
 
 MDSPAN_STATIC_TEST(
     std::is_constructible<
@@ -66,12 +123,53 @@ MDSPAN_STATIC_TEST(
     >::value
 );
 
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::mdspan<int, stdex::extents<2, stdex::dynamic_extent>>,
+        int*, int, int
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::mdspan<int, stdex::extents<stdex::dynamic_extent, 2, stdex::dynamic_extent>>,
+        int*, std::array<int,2>
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    std::is_constructible<
+        stdex::mdspan<int, stdex::extents<2, stdex::dynamic_extent>>,
+        int*, std::array<int,2>
+    >::value
+);
+
 // </editor-fold> end Test allowed pointer + extents ctors }}}1
 //==============================================================================
 
 
 //==============================================================================
 // <editor-fold desc="Test forbidden pointer + extents ctors"> {{{1
+MDSPAN_STATIC_TEST(
+    !std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        std::array<int, 4>
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    !std::is_constructible<
+        stdex::extents<2, stdex::dynamic_extent>,
+        int, int, int
+    >::value
+);
+
+MDSPAN_STATIC_TEST(
+    !std::is_constructible<
+        stdex::mdspan<int, stdex::extents<2, stdex::dynamic_extent>>,
+        int*, std::array<int, 4>
+    >::value
+);
 
 MDSPAN_STATIC_TEST(
     !std::is_constructible<
@@ -80,11 +178,33 @@ MDSPAN_STATIC_TEST(
     >::value
 );
 
+
 MDSPAN_STATIC_TEST(
     !std::is_constructible<
         stdex::mdspan<int, stdex::extents<2, stdex::dynamic_extent>>,
-        int*, int, int
+        int*, int, int, int
     >::value
+);
+
+MDSPAN_STATIC_TEST(
+   !std::is_constructible<
+        stdex::mdspan<int, stdex::dextents<2>, stdex::layout_stride>,
+        int*, int, int
+   >::value
+);
+
+MDSPAN_STATIC_TEST(
+   !std::is_constructible<
+        stdex::mdspan<int, stdex::dextents<2>, stdex::layout_stride>,
+        int*, std::array<int,2>
+   >::value
+);
+
+MDSPAN_STATIC_TEST(
+   !std::is_constructible<
+        stdex::mdspan<int, stdex::dextents<2>, stdex::layout_stride>,
+        int*, stdex::dextents<2>
+   >::value
 );
 
 // </editor-fold> end Test forbidden pointer + extents ctors }}}1

--- a/compilation_tests/ctest_no_unique_address.cpp
+++ b/compilation_tests/ctest_no_unique_address.cpp
@@ -92,11 +92,13 @@ MDSPAN_STATIC_TEST(
   >) == sizeof(size_t)
 );
 
+#if defined(__GNUC__) && (__GNUC__>8)
 MDSPAN_STATIC_TEST(
   std::is_empty<stdex::layout_right::template mapping<
     stdex::extents<42, 123, 73>
   >>::value
 );
+#endif
 
 MDSPAN_STATIC_TEST(
   sizeof(stdex::layout_stride::template mapping<

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -233,7 +233,7 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #endif
 
 #ifndef MDSPAN_CONDITIONAL_EXPLICIT
-#  if (defined(MDSPAN_HAS_CXX_20))
+#  if MDSPAN_HAS_CXX_20
 #    define MDSPAN_CONDITIONAL_EXPLICIT(COND) explicit(COND)
 #  else
 #    define MDSPAN_CONDITIONAL_EXPLICIT(COND)

--- a/include/experimental/__p0009_bits/default_accessor.hpp
+++ b/include/experimental/__p0009_bits/default_accessor.hpp
@@ -52,7 +52,7 @@ namespace experimental {
 
 template <class ElementType>
 struct default_accessor {
-  
+
   using offset_policy = default_accessor;
   using element_type = ElementType;
   using reference = ElementType&;
@@ -64,7 +64,7 @@ struct default_accessor {
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherElementType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, typename default_accessor<OtherElementType>::pointer, pointer)
+      _MDSPAN_TRAIT(is_convertible, typename default_accessor<OtherElementType>::element_type(*)[], element_type(*)[])
     )
   )
   MDSPAN_INLINE_FUNCTION

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -242,6 +242,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class SizeType, size_t N,
     /* requires */ (
+      (N == rank() || N == rank_dynamic()) &&
       _MDSPAN_TRAIT(is_convertible, SizeType, size_type)
     )
   )

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -188,7 +188,7 @@ struct layout_left {
     }
 
     // In C++ 20 the not equal exists if equal is found
-#ifndef MDSPAN_HAS_CXX20
+#if MDSPAN_HAS_CXX_20
     template<class OtherExtents>
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator!=(mapping const& lhs, mapping<OtherExtents> const& rhs) noexcept {

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -105,7 +105,7 @@ struct layout_left {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, OtherExtents, Extents)
+        _MDSPAN_TRAIT(is_constructible, Extents, OtherExtents)
       )
     )
     MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, Extents>::value)) // needs two () due to comma
@@ -117,6 +117,7 @@ struct layout_left {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherMapping,
       /* requires */ (
+        _MDSPAN_TRAIT(is_constructible, Extents, typename OtherMapping::extents_type) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type, layout_right) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type::template mapping<typename OtherMapping::extents_type>, OtherMapping) &&
         (Extents::rank() <= 1)
@@ -131,8 +132,9 @@ struct layout_left {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherMapping,
       /* requires */ (
+        _MDSPAN_TRAIT(is_constructible, Extents, typename OtherMapping::extents_type) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type, layout_stride) &&
-        _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type::template mapping<typename OtherMapping::extents_type>, OtherMapping) 
+        _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type::template mapping<typename OtherMapping::extents_type>, OtherMapping)
       )
     )
     MDSPAN_CONDITIONAL_EXPLICIT((Extents::rank()!=0))
@@ -148,18 +150,6 @@ struct layout_left {
        }
     }
 
-    MDSPAN_TEMPLATE_REQUIRES(
-      class OtherExtents,
-      /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, Extents, OtherExtents)
-      )
-    )
-    MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
-    mapping& operator=(mapping<OtherExtents> const& other) noexcept
-    {
-      __extents = Extents(other.extents());
-      return *this;
-    }
     //--------------------------------------------------------------------------------
 
     template <class... Indices>

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -110,7 +110,7 @@ struct layout_right {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, OtherExtents, Extents)
+        _MDSPAN_TRAIT(is_constructible, Extents, OtherExtents)
       )
     )
     MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, Extents>::value)) // needs two () due to comma
@@ -122,6 +122,7 @@ struct layout_right {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherMapping,
       /* requires */ (
+        _MDSPAN_TRAIT(is_constructible, Extents, typename OtherMapping::extents_type) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type, layout_left) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type::template mapping<typename OtherMapping::extents_type>, OtherMapping) &&
         (Extents::rank() <= 1)
@@ -135,6 +136,7 @@ struct layout_right {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherMapping,
       /* requires */ (
+        _MDSPAN_TRAIT(is_constructible, Extents, typename OtherMapping::extents_type) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type, layout_stride) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type::template mapping<typename OtherMapping::extents_type>, OtherMapping)
       )
@@ -152,18 +154,6 @@ struct layout_right {
        }
     }
 
-    MDSPAN_TEMPLATE_REQUIRES(
-      class OtherExtents,
-      /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, Extents, OtherExtents)
-      )
-    )
-    MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
-    mapping& operator=(mapping<OtherExtents> const& other) noexcept
-    {
-      __extents = Extents(other.extents());
-      return *this;
-    }
     //--------------------------------------------------------------------------------
 
     template <class... Indices>

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -191,7 +191,7 @@ struct layout_right {
     }
 
     // In C++ 20 the not equal exists if equal is found
-#ifndef MDSPAN_HAS_CXX20
+#if MDSPAN_HAS_CXX_20
     template<class OtherExtents>
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator!=(mapping const& lhs, mapping<OtherExtents> const& rhs) noexcept {

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -263,6 +263,7 @@ struct layout_stride {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherMapping,
       /* requires */ (
+        _MDSPAN_TRAIT(is_constructible, Extents, typename OtherMapping::extents_type) &&
         _MDSPAN_TRAIT(is_same, typename OtherMapping::layout_type::template mapping<typename OtherMapping::extents_type>, OtherMapping) &&
         OtherMapping::is_always_unique() &&
         OtherMapping::is_always_strided()

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -378,7 +378,7 @@ struct layout_stride {
       return __impl::_eq_impl(lhs, rhs);
     }
 
-#ifdef MDSPAN_HAS_CXX20
+#if MDSPAN_HAS_CXX_20
     template<class OtherExtents>
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator!=(mapping const& lhs, mapping<OtherExtents> const& rhs) noexcept {

--- a/tests/test_contiguous_layouts.cpp
+++ b/tests/test_contiguous_layouts.cpp
@@ -340,6 +340,7 @@ TYPED_TEST_SUITE(TestLayoutConversion, layout_conversion_test_types);
 TYPED_TEST(TestLayoutConversion, implicit_conversion) {
   typename TestFixture::map_2_t map2 = this->create_map2(this->exts2);
   typename TestFixture::map_1_t map1;
+  #if MDSPAN_HAS_CXX_20
   static_assert(this->implicit ==
    (
     (
@@ -358,7 +359,6 @@ TYPED_TEST(TestLayoutConversion, implicit_conversion) {
   );
   static_assert(std::is_convertible<typename TestFixture::map_2_t, typename TestFixture::map_1_t>::value ==
                 this->implicit);
-  #if MDSPAN_HAS_CXX_17
   if constexpr(this->implicit)
     map1 = this->implicit_conv(map2);
   else

--- a/tests/test_contiguous_layouts.cpp
+++ b/tests/test_contiguous_layouts.cpp
@@ -297,10 +297,10 @@ struct TestLayoutConversion<
   static constexpr bool implicit = Implicit;
   using layout_1_t = Layout1;
   using exts_1_t = Extents1;
-  using map_1_t = Layout1::template mapping<exts_1_t>;
+  using map_1_t = typename Layout1::template mapping<exts_1_t>;
   using layout_2_t = Layout2;
   using exts_2_t = Extents2;
-  using map_2_t = Layout2::template mapping<exts_2_t>;
+  using map_2_t = typename Layout2::template mapping<exts_2_t>;
   exts_1_t exts1 { AllSizes... };
   exts_2_t exts2 { AllSizes... };
 
@@ -358,7 +358,7 @@ TYPED_TEST(TestLayoutConversion, implicit_conversion) {
   );
   static_assert(std::is_convertible<typename TestFixture::map_2_t, typename TestFixture::map_1_t>::value ==
                 this->implicit);
-  #ifdef MDSPAN_HAS_CXX_17
+  #if MDSPAN_HAS_CXX_17
   if constexpr(this->implicit)
     map1 = this->implicit_conv(map2);
   else

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -310,13 +310,13 @@ TEST(TestExtentsCtorStdArrayConvertibleToSizeT, test_extents_ctor_std_array_conv
 }
 
 TYPED_TEST(TestExtentsCompatCtors, construct_from_dynamic_sizes) {
-  using e1_t = TestFixture::extents_type1;
+  using e1_t = typename TestFixture::extents_type1;
   constexpr bool e1_last_ext_static = e1_t::rank()>0?e1_t::static_extent(e1_t::rank()-1)!=stdex::dynamic_extent:true;
   e1_t e1 = TestFixture::template make_extents<e1_t,e1_t::rank(),false,e1_last_ext_static>::construct();
   for(int r=0; r<e1.rank(); r++)
     ASSERT_EQ(e1.extent(r), (r+1)*5);
 
-  using e2_t = TestFixture::extents_type2;
+  using e2_t = typename TestFixture::extents_type2;
   constexpr bool e2_last_ext_static = e2_t::rank()>0?e2_t::static_extent(e2_t::rank()-1)!=stdex::dynamic_extent:true;
   e2_t e2 = TestFixture::template make_extents<e2_t,e2_t::rank(),false,e2_last_ext_static>::construct();
   for(int r=0; r<e2.rank(); r++)
@@ -324,19 +324,19 @@ TYPED_TEST(TestExtentsCompatCtors, construct_from_dynamic_sizes) {
 }
 
 TYPED_TEST(TestExtentsCompatCtors, construct_from_all_sizes) {
-  using e1_t = TestFixture::extents_type1;
+  using e1_t = typename TestFixture::extents_type1;
   e1_t e1 = TestFixture::template make_extents<e1_t,e1_t::rank(),true,true>::construct();
   for(int r=0; r<e1.rank(); r++)
     ASSERT_EQ(e1.extent(r), (r+1)*5);
 
-  using e2_t = TestFixture::extents_type2;
+  using e2_t = typename TestFixture::extents_type2;
   e2_t e2 = TestFixture::template make_extents<e2_t,e1_t::rank(),true,true>::construct();
   for(int r=0; r<e2.rank(); r++)
     ASSERT_EQ(e2.extent(r), (r+1)*5);
 }
 
 TYPED_TEST(TestExtentsCompatCtors, construct_from_dynamic_array) {
-  using e1_t = TestFixture::extents_type1;
+  using e1_t = typename TestFixture::extents_type1;
   std::array<int, e1_t::rank_dynamic()> ext1_array_dynamic;
 
   int dyn_idx = 0;
@@ -350,7 +350,7 @@ TYPED_TEST(TestExtentsCompatCtors, construct_from_dynamic_array) {
   for(int r=0; r<e1.rank(); r++)
     ASSERT_EQ(e1.extent(r), (r+1)*5);
 
-  using e2_t = TestFixture::extents_type2;
+  using e2_t = typename TestFixture::extents_type2;
   std::array<int, e2_t::rank_dynamic()> ext2_array_dynamic;
 
   dyn_idx = 0;
@@ -366,7 +366,7 @@ TYPED_TEST(TestExtentsCompatCtors, construct_from_dynamic_array) {
 }
 
 TYPED_TEST(TestExtentsCompatCtors, construct_from_all_array) {
-  using e1_t = TestFixture::extents_type1;
+  using e1_t = typename TestFixture::extents_type1;
   std::array<int, e1_t::rank()> ext1_array_all;
 
   for(int r=0; r<e1_t::rank(); r++) ext1_array_all[r] = (r+1)*5;
@@ -374,7 +374,7 @@ TYPED_TEST(TestExtentsCompatCtors, construct_from_all_array) {
   for(int r=0; r<e1.rank(); r++)
     ASSERT_EQ(e1.extent(r), (r+1)*5);
 
-  using e2_t = TestFixture::extents_type2;
+  using e2_t = typename TestFixture::extents_type2;
   std::array<int, e2_t::rank()> ext2_array_all;
 
   for(int r=0; r<e2_t::rank(); r++) ext2_array_all[r] = (r+1)*5;

--- a/tests/test_layout_ctors.cpp
+++ b/tests/test_layout_ctors.cpp
@@ -180,22 +180,42 @@ TYPED_TEST(TestLayoutRightCompatCtors, compatible_construct_2) {
 }
 
 TYPED_TEST(TestLayoutLeftCompatCtors, compatible_assign_1) {
-  this->map1 = this->map2;
+  #ifdef MDSPAN_HAS_CXX_17
+  if constexpr (std::is_convertible_v<typename TestFixture::mapping_type2, typename TestFixture::mapping_type1>)
+    this->map1 = this->map2;
+  else
+  #endif
+    this->map1 = typename TestFixture::mapping_type1(this->map2);
   ASSERT_EQ(this->map1.extents(), this->map2.extents());
 }
 
 TYPED_TEST(TestLayoutRightCompatCtors, compatible_assign_1) {
-  this->map1 = this->map2;
+  #ifdef MDSPAN_HAS_CXX_17
+  if constexpr (std::is_convertible_v<typename TestFixture::mapping_type2, typename TestFixture::mapping_type1>)
+    this->map1 = this->map2;
+  else
+  #endif
+    this->map1 = typename TestFixture::mapping_type1(this->map2);
   ASSERT_EQ(this->map1.extents(), this->map2.extents());
 }
 
 TYPED_TEST(TestLayoutLeftCompatCtors, compatible_assign_2) {
-  this->map2 = this->map1;
+  #ifdef MDSPAN_HAS_CXX_17
+  if constexpr (std::is_convertible_v<typename TestFixture::mapping_type1, typename TestFixture::mapping_type2>)
+    this->map2 = this->map1;
+  else
+  #endif
+    this->map2 = typename TestFixture::mapping_type2(this->map1);
   ASSERT_EQ(this->map1.extents(), this->map2.extents());
 }
 
 TYPED_TEST(TestLayoutRightCompatCtors, compatible_assign_2) {
-  this->map2 = this->map1;
+  #ifdef MDSPAN_HAS_CXX_17
+  if constexpr (std::is_convertible_v<typename TestFixture::mapping_type1, typename TestFixture::mapping_type2>)
+    this->map2 = this->map1;
+  else
+  #endif
+    this->map2 = typename TestFixture::mapping_type2(this->map1);
   ASSERT_EQ(this->map1.extents(), this->map2.extents());
 }
 

--- a/tests/test_layout_ctors.cpp
+++ b/tests/test_layout_ctors.cpp
@@ -180,7 +180,7 @@ TYPED_TEST(TestLayoutRightCompatCtors, compatible_construct_2) {
 }
 
 TYPED_TEST(TestLayoutLeftCompatCtors, compatible_assign_1) {
-  #ifdef MDSPAN_HAS_CXX_17
+  #if MDSPAN_HAS_CXX_17
   if constexpr (std::is_convertible_v<typename TestFixture::mapping_type2, typename TestFixture::mapping_type1>)
     this->map1 = this->map2;
   else
@@ -190,7 +190,7 @@ TYPED_TEST(TestLayoutLeftCompatCtors, compatible_assign_1) {
 }
 
 TYPED_TEST(TestLayoutRightCompatCtors, compatible_assign_1) {
-  #ifdef MDSPAN_HAS_CXX_17
+  #if MDSPAN_HAS_CXX_17
   if constexpr (std::is_convertible_v<typename TestFixture::mapping_type2, typename TestFixture::mapping_type1>)
     this->map1 = this->map2;
   else
@@ -200,7 +200,7 @@ TYPED_TEST(TestLayoutRightCompatCtors, compatible_assign_1) {
 }
 
 TYPED_TEST(TestLayoutLeftCompatCtors, compatible_assign_2) {
-  #ifdef MDSPAN_HAS_CXX_17
+  #if MDSPAN_HAS_CXX_17
   if constexpr (std::is_convertible_v<typename TestFixture::mapping_type1, typename TestFixture::mapping_type2>)
     this->map2 = this->map1;
   else
@@ -210,7 +210,7 @@ TYPED_TEST(TestLayoutLeftCompatCtors, compatible_assign_2) {
 }
 
 TYPED_TEST(TestLayoutRightCompatCtors, compatible_assign_2) {
-  #ifdef MDSPAN_HAS_CXX_17
+  #if MDSPAN_HAS_CXX_17
   if constexpr (std::is_convertible_v<typename TestFixture::mapping_type1, typename TestFixture::mapping_type2>)
     this->map2 = this->map1;
   else

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -96,7 +96,7 @@ TEST(TestSubmdspanLayoutRightStaticSizedPairs, test_submdspan_layout_right_stati
   std::vector<int> d(2 * 3 * 4, 0);
   stdex::mdspan<int, stdex::extents<2, 3, 4>> m(d.data());
   m(1, 1, 1) = 42;
-  auto sub0 = stdex::submdspan(m, std::pair{1, 2}, std::pair{1, 3}, std::pair{1, 4});
+  auto sub0 = stdex::submdspan(m, std::pair<int,int>{1, 2}, std::pair<int,int>{1, 3}, std::pair<int,int>{1, 4});
   ASSERT_EQ(sub0.rank(),         3);
   ASSERT_EQ(sub0.rank_dynamic(), 3);
   ASSERT_EQ(sub0.extent(0),      1);


### PR DESCRIPTION
- Removes converting assignment for layout_left/right
- Removes converting assignment for mdspan itself
- Removes unique_size
- adds tests for conversion
- also fixes C++14 build issues