### PR TITLE
Add operator bracket and makes test work with them 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Caveats
 
 This implementation is fully conforming with a few exceptions (most of which are extensions):
 
-### All Standards
+### C++20
 - implements `operator()` not `operator[]`
+  - note you can control which operator is available with defining `MDSPAN_USE_BRACKET_OPERATOR=[0,1]` and `MDSPAN_USE_PAREN_OPERATOR=[0,1]` irrespective of whether multi dimensional subscript support is detected.
 
 ### C++17 and C++14
 - the conditional explicit markup is missing, making certain constructors implicit

--- a/compilation_tests/ctest_constexpr_dereference.cpp
+++ b/compilation_tests/ctest_constexpr_dereference.cpp
@@ -63,7 +63,7 @@ simple_static_sum_test_1(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += s(row, col) * (row + add_to_row);
+      result += __MDSPAN_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -116,7 +116,7 @@ simple_dynamic_sum_test_2(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += s(row, col) * (row + add_to_row);
+      result += __MDSPAN_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -149,7 +149,7 @@ simple_mixed_layout_left_sum_test_3(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += s(row, col) * (row + add_to_row);
+      result += __MDSPAN_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -179,8 +179,8 @@ multidimensional_single_element_stress_test_impl_2(
   int data[] = { 42 };
   auto s = mdspan_t(data);
   auto s_dyn = dyn_mdspan_t(data, _repeated_ptrdiff_t<1, Idxs>...);
-  auto val = s(_repeated_ptrdiff_t<0, Idxs>...);
-  auto val_dyn = s_dyn(_repeated_ptrdiff_t<0, Idxs>...);
+  auto val = __MDSPAN_OP(s, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val_dyn = __MDSPAN_OP(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   constexpr_assert_equal(42, val);
   constexpr_assert_equal(42, val_dyn);
   return val == 42 && val_dyn == 42;
@@ -234,13 +234,13 @@ stress_test_2d_single_element_stress_test_impl_2(
   auto s12 = dyn_mdspan_t(data, Idx1, Idx2);
   for(ptrdiff_t i = 0; i < Idx1; ++i) {
     for(ptrdiff_t j = 0; j < Idx2; ++j) {
-      s(i, j) = s1(i, j) = s2(i, j) = s12(i, j) = 1;
+      __MDSPAN_OP(s, i, j) = __MDSPAN_OP(s1, i, j) = __MDSPAN_OP(s2, i, j) = __MDSPAN_OP(s12, i, j) = 1;
     }
   }
   int result = 0;
   for(ptrdiff_t i = 0; i < Idx1; ++i) {
     for(ptrdiff_t j = 0; j < Idx2; ++j) {
-      result += s(i, j) + s1(i, j) + s2(i, j) + s12(i, j);
+      result += __MDSPAN_OP(s, i, j) + __MDSPAN_OP(s1, i, j) + __MDSPAN_OP(s2, i, j) + __MDSPAN_OP(s12, i, j);
     }
   }
   result /= 4;

--- a/compilation_tests/ctest_constexpr_submdspan.cpp
+++ b/compilation_tests/ctest_constexpr_submdspan.cpp
@@ -370,12 +370,12 @@ submdspan_single_element_stress_test_impl_2(
   auto ss_dyn = stdex::submdspan(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   auto ss_all = stdex::submdspan(s, _repeated_with_idxs_t<stdex::full_extent_t, Idxs>{}...);
   auto ss_all_dyn = stdex::submdspan(s_dyn, _repeated_with_idxs_t<stdex::full_extent_t, Idxs>{}...);
-  auto val = __MDSPAN_OP(ss_all, _repeated_ptrdiff_t<0, Idxs>...);
-  auto val_dyn = __MDSPAN_OP(ss_all_dyn, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val = __MDSPAN_OP(ss_all, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_dyn = __MDSPAN_OP(ss_all_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
   auto ss_pair = stdex::submdspan(s, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
   auto ss_pair_dyn = stdex::submdspan(s_dyn, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
-  auto val_pair = __MDSPAN_OP(ss_pair, _repeated_ptrdiff_t<0, Idxs>...);
-  auto val_pair_dyn = __MDSPAN_OP(ss_pair_dyn, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val_pair = __MDSPAN_OP(ss_pair, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_pair_dyn = __MDSPAN_OP(ss_pair_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
   constexpr_assert_equal(42, ss());
   constexpr_assert_equal(42, ss_dyn());
   constexpr_assert_equal(42, val);

--- a/compilation_tests/ctest_constexpr_submdspan.cpp
+++ b/compilation_tests/ctest_constexpr_submdspan.cpp
@@ -61,7 +61,7 @@ dynamic_extent_1d() {
   int result = 0;
   for (int i = 0; i < s.extent(0); ++i) {
     auto ss = stdex::submdspan(s, i);
-    result += ss();
+    result += __MDSPAN_OP0(ss);
   }
   // 1 + 2 + 3 + 4 + 5
   constexpr_assert_equal(15, result);
@@ -87,7 +87,7 @@ dynamic_extent_1d_all_slice() {
   int result = 0;
   auto ss = stdex::submdspan(s, stdex::full_extent);
   for (int i = 0; i < s.extent(0); ++i) {
-    result += ss(i);
+    result += __MDSPAN_OP(ss, i);
   }
   // 1 + 2 + 3 + 4 + 5
   constexpr_assert_equal(15, result);
@@ -112,7 +112,7 @@ dynamic_extent_1d_pair_full() {
   int result = 0;
   auto ss = stdex::submdspan(s, std::pair<std::ptrdiff_t, std::ptrdiff_t>{0, 5});
   for (int i = 0; i < s.extent(0); ++i) {
-    result += ss(i);
+    result += __MDSPAN_OP(ss, i);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
@@ -131,7 +131,7 @@ dynamic_extent_1d_pair_each() {
   for (int i = 0; i < s.extent(0); ++i) {
     auto ss = stdex::submdspan(s,
       std::pair<std::ptrdiff_t, std::ptrdiff_t>{i, i+1});
-    result += ss(0);
+    result += __MDSPAN_OP(ss, 0);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
@@ -160,7 +160,7 @@ dynamic_extent_1d_all_three() {
   int result = 0;
   for (int i = 0; i < s.extent(0); ++i) {
     auto ss = stdex::submdspan(s2, i);
-    result += ss();
+    result += __MDSPAN_OP0(ss);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
@@ -186,7 +186,7 @@ dynamic_extent_2d_idx_idx() {
   for(int row = 0; row < s.extent(0); ++row) {
     for(int col = 0; col < s.extent(1); ++col) {
       auto ss = stdex::submdspan(s, row, col);
-      result += ss();
+      result += __MDSPAN_OP0(ss);
     }
   }
   constexpr_assert_equal(21, result);
@@ -207,8 +207,8 @@ dynamic_extent_2d_idx_all_idx() {
     auto srow = stdex::submdspan(s, row, stdex::full_extent);
     for(int col = 0; col < s.extent(1); ++col) {
       auto scol = stdex::submdspan(srow, col);
-      constexpr_assert_equal(scol(), srow(col));
-      result += scol();
+      constexpr_assert_equal(__MDSPAN_OP0(scol), __MDSPAN_OP(srow, col));
+      result += __MDSPAN_OP0(scol);
     }
   }
   constexpr_assert_equal(21, result);
@@ -236,7 +236,7 @@ simple_static_submdspan_test_1(int add_to_row) {
     auto scol = stdex::submdspan(s, stdex::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = stdex::submdspan(scol, row);
-      result += srow() * (row + add_to_row);
+      result += __MDSPAN_OP0(srow) * (row + add_to_row);
     }
   }
   return result;
@@ -278,7 +278,7 @@ mixed_submdspan_left_test_2() {
     auto scol = stdex::submdspan(s, stdex::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = stdex::submdspan(scol, row);
-      result += srow() * (row + 1);
+      result += __MDSPAN_OP0(srow) * (row + 1);
     }
   }
   // 1 + 2 + 3 + 2*(4 + 5 + 6) + 3*(7 + 8 + 9)= 108
@@ -287,7 +287,7 @@ mixed_submdspan_left_test_2() {
     auto srow = stdex::submdspan(s, row, stdex::full_extent);
     for(int col = 0; col < 5; ++col) {
       auto scol = stdex::submdspan(srow, col);
-      result += scol() * (row + 1);
+      result += __MDSPAN_OP0(scol) * (row + 1);
     }
   }
   result /= 2;
@@ -321,7 +321,7 @@ mixed_submdspan_test_3() {
     auto scol = stdex::submdspan(s, stdex::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = stdex::submdspan(scol, row);
-      result += srow() * (row + 1);
+      result += __MDSPAN_OP0(srow) * (row + 1);
     }
   }
   constexpr_assert_equal(71, result);
@@ -329,7 +329,7 @@ mixed_submdspan_test_3() {
     auto srow = stdex::submdspan(s, row, stdex::full_extent);
     for(int col = 0; col < 5; ++col) {
       auto scol = stdex::submdspan(srow, col);
-      result += scol() * (row + 1);
+      result += __MDSPAN_OP0(scol) * (row + 1);
     }
   }
   result /= 2;
@@ -370,19 +370,19 @@ submdspan_single_element_stress_test_impl_2(
   auto ss_dyn = stdex::submdspan(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   auto ss_all = stdex::submdspan(s, _repeated_with_idxs_t<stdex::full_extent_t, Idxs>{}...);
   auto ss_all_dyn = stdex::submdspan(s_dyn, _repeated_with_idxs_t<stdex::full_extent_t, Idxs>{}...);
-  auto val = ss_all(_repeated_ptrdiff_t<0, Idxs>...);
-  auto val_dyn = ss_all_dyn(_repeated_ptrdiff_t<0, Idxs>...);
+  auto val = __MDSPAN_OP(ss_all, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val_dyn = __MDSPAN_OP(ss_all_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   auto ss_pair = stdex::submdspan(s, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
   auto ss_pair_dyn = stdex::submdspan(s_dyn, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
-  auto val_pair = ss_pair(_repeated_ptrdiff_t<0, Idxs>...);
-  auto val_pair_dyn = ss_pair_dyn(_repeated_ptrdiff_t<0, Idxs>...);
+  auto val_pair = __MDSPAN_OP(ss_pair, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val_pair_dyn = __MDSPAN_OP(ss_pair_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   constexpr_assert_equal(42, ss());
   constexpr_assert_equal(42, ss_dyn());
   constexpr_assert_equal(42, val);
   constexpr_assert_equal(42, val_dyn);
   constexpr_assert_equal(42, val_pair);
   constexpr_assert_equal(42, val_pair_dyn);
-  return ss() == 42 && ss_dyn() == 42 && val == 42 && val_dyn == 42 && val_pair == 42 && val_pair_dyn == 42;
+  return __MDSPAN_OP0(ss) == 42 && __MDSPAN_OP0(ss_dyn) == 42 && val == 42 && val_dyn == 42 && val_pair == 42 && val_pair_dyn == 42;
 }
 
 template <class Layout, size_t... Sizes>

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -252,3 +252,28 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #  endif
 #endif
 
+#if MDSPAN_USE_BRACKET_OPERATOR
+#  define __MDSPAN_OP(mds,...) mds[__VA_ARGS__]
+// Corentins demo compiler for subscript chokes on empty [] call,
+// though I believe the proposal supports it?
+#ifdef MDSPAN_NO_EMPTY_BRACKET_OPERATOR
+#  define __MDSPAN_OP0(mds) mds.accessor().access(mds.data(),0)
+#else
+#  define __MDSPAN_OP0(mds) mds[]
+#endif
+#  define __MDSPAN_OP1(mds, a) mds[a]
+#  define __MDSPAN_OP2(mds, a, b) mds[a,b]
+#  define __MDSPAN_OP3(mds, a, b, c) mds[a,b,c]
+#  define __MDSPAN_OP4(mds, a, b, c, d) mds[a,b,c,d]
+#  define __MDSPAN_OP5(mds, a, b, c, d, e) mds[a,b,c,d,e]
+#  define __MDSPAN_OP6(mds, a, b, c, d, e, f) mds[a,b,c,d,e,f]
+#else
+#  define __MDSPAN_OP(mds,...) mds(__VA_ARGS__)
+#  define __MDSPAN_OP0(mds) mds()
+#  define __MDSPAN_OP1(mds, a) mds(a)
+#  define __MDSPAN_OP2(mds, a, b) mds(a,b)
+#  define __MDSPAN_OP3(mds, a, b, c) mds(a,b,c)
+#  define __MDSPAN_OP4(mds, a, b, c, d) mds(a,b,c,d)
+#  define __MDSPAN_OP5(mds, a, b, c, d, e) mds(a,b,c,d,e)
+#  define __MDSPAN_OP6(mds, a, b, c, d, e, f) mds(a,b,c,d,e,f)
+#endif

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -239,3 +239,16 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #    define MDSPAN_CONDITIONAL_EXPLICIT(COND)
 #  endif
 #endif
+
+#ifndef MDSPAN_USE_BRACKET_OPERATOR
+#  if defined(__cpp_multidimensional_subscript)
+#    define MDSPAN_USE_BRACKET_OPERATOR 1
+#  endif
+#endif
+
+#ifndef MDSPAN_USE_PAREN_OPERATOR
+#  if !MDSPAN_USE_BRACKET_OPERATOR
+#    define MDSPAN_USE_PAREN_OPERATOR 1
+#  endif
+#endif
+

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -243,12 +243,16 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #ifndef MDSPAN_USE_BRACKET_OPERATOR
 #  if defined(__cpp_multidimensional_subscript)
 #    define MDSPAN_USE_BRACKET_OPERATOR 1
+#  else
+#    define MDSPAN_USE_BRACKET_OPERATOR 0
 #  endif
 #endif
 
 #ifndef MDSPAN_USE_PAREN_OPERATOR
 #  if !MDSPAN_USE_BRACKET_OPERATOR
 #    define MDSPAN_USE_PAREN_OPERATOR 1
+#  else
+#    define MDSPAN_USE_PAREN_OPERATOR 0
 #  endif
 #endif
 

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -203,7 +203,7 @@ struct layout_left {
     }
     template<size_t N>
     constexpr size_type __stride() const noexcept {
-      return __get_stride<N>(__extents, make_index_sequence<__extents.rank()>());
+      return __get_stride<N>(__extents, make_index_sequence<extents_type::rank()>());
     }
 
 private:

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -206,7 +206,7 @@ struct layout_right {
     }
     template<size_t N>
     constexpr size_type __stride() const noexcept {
-      return __get_stride<N>(__extents, make_index_sequence<__extents.rank()>());
+      return __get_stride<N>(__extents, make_index_sequence<extents_type::rank()>());
     }
 
 private:

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -188,7 +188,7 @@ public:
   //--------------------------------------------------------------------------------
   // [mdspan.basic.mapping], mdspan mapping domain multidimensional index to access codomain element
 
-  #ifdef MDSPAN_USE_BRACKET_OPERATOR
+  #if MDSPAN_USE_BRACKET_OPERATOR
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
@@ -216,7 +216,7 @@ public:
     return __impl::template __callop<reference>(*this, indices);
   }
 
-  #if !defined(MDSPAN_USE_BRACKET_OPERATOR)
+  #if !MDSPAN_USE_BRACKET_OPERATOR
   MDSPAN_TEMPLATE_REQUIRES(
     class Index,
     /* requires */ (
@@ -231,7 +231,7 @@ public:
   }
   #endif
 
-  #ifdef MDSPAN_USE_PAREN_OPERATOR
+  #if MDSPAN_USE_PAREN_OPERATOR
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -188,6 +188,35 @@ public:
   //--------------------------------------------------------------------------------
   // [mdspan.basic.mapping], mdspan mapping domain multidimensional index to access codomain element
 
+  #ifdef MDSPAN_USE_BRACKET_OPERATOR
+  MDSPAN_TEMPLATE_REQUIRES(
+    class... SizeTypes,
+    /* requires */ (
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, size_type) /* && ... */) &&
+      extents_type::rank() == sizeof...(SizeTypes)
+    )
+  )
+  MDSPAN_FORCE_INLINE_FUNCTION
+  constexpr reference operator()(SizeTypes... indices) const noexcept
+  {
+    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(size_type(indices)...));
+  }
+  #endif
+
+  MDSPAN_TEMPLATE_REQUIRES(
+    class SizeType, size_t N,
+    /* requires */ (
+      _MDSPAN_TRAIT(is_convertible, SizeType, size_type) &&
+      N == extents_type::rank()
+    )
+  )
+  MDSPAN_FORCE_INLINE_FUNCTION
+  constexpr reference operator[](const array<SizeType, N>& indices) const noexcept
+  {
+    return __impl::template __callop<reference>(*this, indices);
+  }
+
+  #if !defined(MDSPAN_USE_BRACKET_OPERATOR)
   MDSPAN_TEMPLATE_REQUIRES(
     class Index,
     /* requires */ (
@@ -200,7 +229,9 @@ public:
   {
     return __accessor_ref().access(__ptr_ref(), __mapping_ref()(size_type(idx)));
   }
+  #endif
 
+  #ifdef MDSPAN_USE_PAREN_OPERATOR
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
@@ -226,6 +257,7 @@ public:
   {
     return __impl::template __callop<reference>(*this, indices);
   }
+  #endif
 
   MDSPAN_INLINE_FUNCTION constexpr
   accessor_type accessor() const { return __accessor_ref(); };

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -197,7 +197,7 @@ public:
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator()(SizeTypes... indices) const noexcept
+  constexpr reference operator[](SizeTypes... indices) const noexcept
   {
     return __accessor_ref().access(__ptr_ref(), __mapping_ref()(size_type(indices)...));
   }

--- a/tests/test_contiguous_layouts.cpp
+++ b/tests/test_contiguous_layouts.cpp
@@ -341,7 +341,7 @@ TYPED_TEST(TestLayoutConversion, implicit_conversion) {
   typename TestFixture::map_2_t map2 = this->create_map2(this->exts2);
   typename TestFixture::map_1_t map1;
   #if MDSPAN_HAS_CXX_20
-  static_assert(this->implicit ==
+  static_assert(TestFixture::implicit ==
    (
     (
      !std::is_same<typename TestFixture::layout_2_t, stdex::layout_stride>::value &&
@@ -358,8 +358,8 @@ TYPED_TEST(TestLayoutConversion, implicit_conversion) {
    )
   );
   static_assert(std::is_convertible<typename TestFixture::map_2_t, typename TestFixture::map_1_t>::value ==
-                this->implicit);
-  if constexpr(this->implicit)
+                TestFixture::implicit);
+  if constexpr(TestFixture::implicit)
     map1 = this->implicit_conv(map2);
   else
   #endif

--- a/tests/test_element_access.cpp
+++ b/tests/test_element_access.cpp
@@ -51,7 +51,7 @@ namespace stdex = std::experimental;
 TEST(TestElementAccess, element_access_with_std_array) {
     std::array<double, 6> a{};
     stdex::mdspan<double, stdex::extents<2, 3>> s(a.data());
-    ASSERT_EQ(s(std::array<int, 2>{1, 2}), 0);
-    s(std::array<int, 2>{0, 1}) = 3.14;
-    ASSERT_EQ(s(std::array<int, 2>{0, 1}), 3.14);
+    ASSERT_EQ(__MDSPAN_OP(s, (std::array<int, 2>{1, 2})), 0);
+    __MDSPAN_OP(s, (std::array<int, 2>{0, 1})) = 3.14;
+    ASSERT_EQ(__MDSPAN_OP(s, (std::array<int, 2>{0, 1})), 3.14);
 }

--- a/tests/test_mdspan_conversion.cpp
+++ b/tests/test_mdspan_conversion.cpp
@@ -53,7 +53,7 @@ TEST(TestMdspanConversionConst, test_mdspan_conversion_const) {
   std::array<double, 6> a{};
   stdex::mdspan<double, stdex::extents<2, 3>> s(a.data());
   ASSERT_EQ(s.data(), a.data());
-  s(0, 1) = 3.14;
+  __MDSPAN_OP(s, 0, 1) = 3.14;
   stdex::mdspan<double const, stdex::extents<2, 3>> c_s(s);
-  ASSERT_EQ(c_s(0, 1), 3.14);
+  ASSERT_EQ((__MDSPAN_OP(c_s, 0, 1)), 3.14);
 }

--- a/tests/test_mdspan_ctors.cpp
+++ b/tests/test_mdspan_ctors.cpp
@@ -57,7 +57,7 @@ TEST(TestMdspanCtorDataCArray, test_mdspan_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(m(0), 42);
+  ASSERT_EQ(__MDSPAN_OP(m, 0), 42);
   ASSERT_TRUE(m.is_contiguous());
 }
 
@@ -69,7 +69,7 @@ TEST(TestMdspanCtorDataStdArray, test_mdspan_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(m(0), 42);
+  ASSERT_EQ(__MDSPAN_OP(m, 0), 42);
   ASSERT_TRUE(m.is_contiguous());
 }
 
@@ -81,7 +81,7 @@ TEST(TestMdspanCtorDataVector, test_mdspan_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(m(0), 42);
+  ASSERT_EQ(__MDSPAN_OP(m, 0), 42);
   ASSERT_TRUE(m.is_contiguous());
 }
 
@@ -150,7 +150,6 @@ TEST(TestMdspanCTADExtentsPack, test_mdspan_ctad_extents_pack) {
   ASSERT_TRUE(m.is_contiguous());
 }
 
-// TODO @proposal-bug We're missing a `mdspan(T*, extents)` constructor.
 TEST(TestMdspanCTADExtentsObject, test_mdspan_ctad_extents_object) {
   std::array<int, 1> d{42};
   stdex::mdspan m{d.data(), stdex::extents{64, 128}};

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -52,57 +52,57 @@ _MDSPAN_INLINE_VARIABLE constexpr auto dyn = stdex::dynamic_extent;
 TEST(TestSubmdspanLayoutRightStaticSizedRankReducing3Dto1D, test_submdspan_layout_right_static_sized_rank_reducing_3d_to_1d) {
   std::vector<int> d(2 * 3 * 4, 0);
   stdex::mdspan<int, stdex::extents<2, 3, 4>> m(d.data());
-  m(1, 1, 1) = 42;
+  __MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = stdex::submdspan(m, 1, 1, stdex::full_extent);
   ASSERT_EQ(sub0.rank(),         1);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      4);
-  ASSERT_EQ(sub0(1),             42);
+  ASSERT_EQ((__MDSPAN_OP(sub0, 1)), 42);
 }
 
 TEST(TestSubmdspanLayoutLeftStaticSizedRankReducing3Dto1D, test_submdspan_layout_left_static_sized_rank_reducing_3d_to_1d) {
   std::vector<int> d(2 * 3 * 4, 0);
   stdex::mdspan<int, stdex::extents<2, 3, 4>, stdex::layout_left> m(d.data());
-  m(1, 1, 1) = 42;
+  __MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = stdex::submdspan(m, 1, 1, stdex::full_extent);
   ASSERT_EQ(sub0.rank(),         1);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      4);
-  ASSERT_EQ(sub0(1),             42);
+  ASSERT_EQ((__MDSPAN_OP(sub0, 1)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedRankReducingNested3Dto0D, test_submdspan_layout_right_static_sized_rank_reducing_nested_3d_to_0d) {
   std::vector<int> d(2 * 3 * 4, 0);
   stdex::mdspan<int, stdex::extents<2, 3, 4>> m(d.data());
-  m(1, 1, 1) = 42;
+  __MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = stdex::submdspan(m, 1, stdex::full_extent, stdex::full_extent);
   ASSERT_EQ(sub0.rank(),         2);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      3);
   ASSERT_EQ(sub0.extent(1),      4);
-  ASSERT_EQ(sub0(1, 1),          42);
+  ASSERT_EQ((__MDSPAN_OP(sub0, 1, 1)), 42);
   auto sub1 = stdex::submdspan(sub0, 1, stdex::full_extent);
   ASSERT_EQ(sub1.rank(),         1);
   ASSERT_EQ(sub1.rank_dynamic(), 0);
   ASSERT_EQ(sub1.extent(0),      4);
-  ASSERT_EQ(sub1(1),             42);
+  ASSERT_EQ((__MDSPAN_OP(sub1,1)),42);
   auto sub2 = stdex::submdspan(sub1, 1);
   ASSERT_EQ(sub2.rank(),         0);
   ASSERT_EQ(sub2.rank_dynamic(), 0);
-  ASSERT_EQ(sub2(),              42);
+  ASSERT_EQ((__MDSPAN_OP0(sub2)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedPairs, test_submdspan_layout_right_static_sized_pairs) {
   std::vector<int> d(2 * 3 * 4, 0);
   stdex::mdspan<int, stdex::extents<2, 3, 4>> m(d.data());
-  m(1, 1, 1) = 42;
+  __MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = stdex::submdspan(m, std::pair<int,int>{1, 2}, std::pair<int,int>{1, 3}, std::pair<int,int>{1, 4});
   ASSERT_EQ(sub0.rank(),         3);
   ASSERT_EQ(sub0.rank_dynamic(), 3);
   ASSERT_EQ(sub0.extent(0),      1);
   ASSERT_EQ(sub0.extent(1),      2);
   ASSERT_EQ(sub0.extent(2),      3);
-  ASSERT_EQ(sub0(0, 0, 0),       42);
+  ASSERT_EQ((__MDSPAN_OP(sub0, 0, 0, 0)), 42);
 }
 
 // TODO @proposal-bug We currently don't allow this, but we should.


### PR DESCRIPTION
Three kinda configure macros but not really (i.e. they are not CMake options, but you can override the autodetection) are included:
MDSPAN_USE_BRACKET_OPERATOR=[0,1] // enables bracket operator
MDSPAN_USE_PAREN_OPERATOR=[0,1] // enables paren operator
MDSPAN_NO_EMPTY_BRACKET_OPERATOR // disables use of [] without arguments

I do believe the latter is just not implemented in corentins compiler, but that we should support that ...



