### PR TITLE
layout_left.hpp: Add layout_stride forward declaration

### DIFF
--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -52,6 +52,7 @@ namespace experimental {
 
 //==============================================================================
 struct layout_right;
+struct layout_stride;
 
 struct layout_left {
   template <class Extents>


### PR DESCRIPTION
Attempt to address https://github.com/kokkos/stdBLAS/issues/124
by adding a forward declaration of layout_stride to layout_left.hpp.
The header already has a forward declaration of layout_right.
layout_right.hpp has forward declarations
of both layout_left and layout_stride,
so this one change should suffice.