### PR TITLE
test icpx compiler

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,9 +8,30 @@ env:
 jobs:
   build-mdspan:
     runs-on: ubuntu-latest
-
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - compiler_driver: g++
+          compiler_prefix: /usr/bin
+        - compiler_driver: icpx
+          compiler_prefix: /opt/intel/oneapi/compiler/latest/linux/bin
+          compiler_url: https://registrationcenter-download.intel.com/akdlm/irc_nas/18209/l_dpcpp-cpp-compiler_p_2021.4.0.3201_offline.sh
+    name: ${{ matrix.compiler_driver }}
     steps:
 
+    - name: Cache icpx install
+      if: ${{ matrix.compiler_driver == 'icpx' }}
+      id: cache-icpx
+      uses: actions/cache@v2
+      with:
+        path: /opt/intel/oneapi
+        key: oneapi-${{ matrix.compile_url}}
+    - name: Install icpx
+      if: ${{ matrix.compiler_driver == 'icpx' && steps.cache-icpx.outputs.cache-hit != 'true' }}
+      run: |
+        curl  --url ${{ matrix.compiler_url }} --output download.sh
+        sudo sh -x download.sh -s -a -s --action install --eula accept
     - name: Install gtest manually
       run: sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a
 
@@ -25,12 +46,12 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/mdspan-build
-      run: cmake $GITHUB_WORKSPACE/mdspan-src -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/mdspan-install -DMDSPAN_ENABLE_TESTS=ON -DMDSPAN_ENABLE_EXAMPLES=ON
+      run: CXX=${{ matrix.compiler_prefix}}/${{ matrix.compiler_driver }} cmake $GITHUB_WORKSPACE/mdspan-src -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/mdspan-install -DMDSPAN_ENABLE_TESTS=ON -DMDSPAN_ENABLE_EXAMPLES=ON
       
     - name: Build
       shell: bash
       working-directory: ${{github.workspace}}/mdspan-build
-      run: make
+      run: make -j
       
     - name: Test
       working-directory: ${{github.workspace}}/mdspan-build


### PR DESCRIPTION
Text icpx. After 1st successful build, the compiler will be cached and take 30 seconds to install.
To update the compiler, get the URL from here:
https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html

Add more compilers by expanding the matrix and adding install steps. A cache step is only needed when the install is slow.