### PR TITLE
Add _MDSPAN_HAS_HIP preprocessor variable

### DIFF
--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -104,6 +104,12 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #  endif
 #endif
 
+#ifndef _MDSPAN_HAS_HIP
+#  if defined(__HIPCC__)
+#    define _MDSPAN_HAS_HIP __HIPCC__
+#  endif
+#endif
+
 #ifndef __has_cpp_attribute
 #  define __has_cpp_attribute(x) 0
 #endif


### PR DESCRIPTION
Add missing preprocessor variable that is used in `macros.hpp` https://github.com/kokkos/mdspan/blob/6a6f1d5362fa2bff7bd0fdb64feeba75b2c92777/include/experimental/__p0009_bits/macros.hpp#L52