### PR TITLE
Fix warning about variable macro args with no args

### DIFF
--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -76,8 +76,6 @@
 //==============================================================================
 // <editor-fold desc="Preprocessor helpers"> {{{1
 
-#if defined(_MDSPAN_COMPILER_MSVC) // Microsoft compilers
-
 #define MDSPAN_PP_COUNT(...) \
   _MDSPAN_PP_INTERNAL_EXPAND_ARGS_PRIVATE( \
     _MDSPAN_PP_INTERNAL_ARGS_AUGMENTER(__VA_ARGS__) \
@@ -106,29 +104,6 @@
     _60, _61, _62, _63, _64, _65, _66, _67, _68, _69, \
     _70, count, ...) count \
     /**/
-
-#else // Non-Microsoft compilers
-
-# define MDSPAN_PP_COUNT(...) \
-   _MDSPAN_PP_INTERNAL_COUNT_PRIVATE( \
-     0, ## __VA_ARGS__, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61,  \
-     60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, \
-     45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, \
-     30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, \
-     15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0) \
-     /**/
-# define _MDSPAN_PP_INTERNAL_COUNT_PRIVATE( \
-    _0_, _1_, _2_, _3_, _4_, _5_, _6_, _7_, _8_, _9_, \
-    _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, \
-    _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, \
-    _30, _31, _32, _33, _34, _35, _36, _37, _38, _39, \
-    _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, \
-    _50, _51, _52, _53, _54, _55, _56, _57, _58, _59, \
-    _60, _61, _62, _63, _64, _65, _66, _67, _68, _69, \
-    _70, count, ...) count \
-    /**/
-
-#endif
 
 #define MDSPAN_PP_STRINGIFY_IMPL(x) #x
 #define MDSPAN_PP_STRINGIFY(x) MDSPAN_PP_STRINGIFY_IMPL(x)

--- a/tests/test_mdarray_ctors.cpp
+++ b/tests/test_mdarray_ctors.cpp
@@ -117,8 +117,10 @@ struct mdarray_values<2> {
   template<class MDA>
   static void check(const MDA& m) {
     for(int i=0; i<m.extent(0); i++)
-      for(int j=0; j<m.extent(1); j++)
-        ASSERT_EQ(__MDSPAN_OP(m,i,j), 42 + i*1000 + j);
+      for(int j=0; j<m.extent(1); j++) {
+        auto tmp = __MDSPAN_OP(m,i,j);
+        ASSERT_EQ(tmp, 42 + i*1000 + j);
+      }
   }
   template<class pointer, class extents_type>
   static void fill(const pointer& ptr, const extents_type& ext, bool is_layout_right) {
@@ -137,8 +139,10 @@ struct mdarray_values<3> {
   static void check(const MDA& m) {
     for(int i=0; i<m.extent(0); i++)
       for(int j=0; j<m.extent(1); j++)
-        for(int k=0; k<m.extent(2); k++)
-          ASSERT_EQ(__MDSPAN_OP(m,i,j,k), 42 + i*1000000 + j*1000 + k);
+        for(int k=0; k<m.extent(2); k++) {
+          auto tmp = __MDSPAN_OP(m,i,j,k);
+          ASSERT_EQ(tmp, 42 + i*1000000 + j*1000 + k);
+        }
   }
   template<class pointer, class extents_type>
   static void fill(const pointer& ptr, const extents_type& ext, bool is_layout_right) {


### PR DESCRIPTION
Turns out we have to go through the somewhat more complex
MSVC variant of counting args, in order to avoid the warning.

Addresses #131