### PR TITLE
Add C++23 support in the configure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ option(MDSPAN_ENABLE_OPENMP "Enable OpenMP benchmarks if benchmarks are enabled.
 
 # Option to override which C++ standard to use
 set(MDSPAN_CXX_STANDARD DETECT CACHE STRING "Override the default CXX_STANDARD to compile with.")
-set_property(CACHE MDSPAN_CXX_STANDARD PROPERTY STRINGS DETECT 14 17 20)
+set_property(CACHE MDSPAN_CXX_STANDARD PROPERTY STRINGS DETECT 14 17 20 23)
 
 option(MDSPAN_ENABLE_CONCEPTS "Try to enable concepts support by giving extra flags." On)
 
@@ -48,8 +48,18 @@ elseif(MDSPAN_CXX_STANDARD STREQUAL "20")
   else()
     message(FATAL_ERROR "Requested MDSPAN_CXX_STANDARD \"20\" not supported by provided C++ compiler")
   endif()
+elseif(MDSPAN_CXX_STANDARD STREQUAL "23")
+  if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    message(STATUS "Using C++23 standard")
+    set(CMAKE_CXX_STANDARD 23)
+  else()
+    message(FATAL_ERROR "Requested MDSPAN_CXX_STANDARD \"23\" not supported by provided C++ compiler")
+  endif()
 else()
-  if("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+  if("cxx_std_23" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    set(CMAKE_CXX_STANDARD 23)
+    message(STATUS "Detected support for C++23 standard")
+  elseif("cxx_std_20" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
     set(CMAKE_CXX_STANDARD 20)
     message(STATUS "Detected support for C++20 standard")
   elseif("cxx_std_17" IN_LIST CMAKE_CXX_COMPILE_FEATURES)
@@ -66,7 +76,7 @@ endif()
 ################################################################################
 
 if(MDSPAN_ENABLE_CONCEPTS)
-  if(CMAKE_CXX_STANDARD STREQUAL "20")
+  if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
     include(CheckCXXCompilerFlag)
     check_cxx_compiler_flag("-fconcepts" COMPILER_SUPPORTS_FCONCEPTS)
     if(COMPILER_SUPPORTS_FCONCEPTS)


### PR DESCRIPTION
Clang main line of March or so (i.e. clang 15) supports the multi arg
bracket operator. However it does not have the feature macro
implemented, so mdspan will not automatically use it.
To use bracket operator configure with this:

-DCMAKE_CXX_FLAGS="-DMDSPAN_USE_BRACKET_OPERATOR=1 -Wno-pre-c++2b-compat"

Note the warning is there, because C++23 was not released yet. You would
get a lot of them if you don't turn this off, when doing -pedantic
builds.