### PR TITLE
Skip architecture check on the installed package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ configure_package_config_file(cmake/mdspanConfig.cmake.in
 )
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/mdspanConfigVersion.cmake
   COMPATIBILITY SameMajorVersion
+  ARCH_INDEPENDENT
 )
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/mdspanConfig.cmake ${CMAKE_CURRENT_BINARY_DIR}/mdspanConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.14)
 
 project(MDSpan
   VERSION 0.2.0


### PR DESCRIPTION
Skip architecture check on the installed package to make cross-compilation easier for projects that use mdspan as dependency. 
Currently if you `make install` mdspan on a 64-bit machine, you will not be able to `find_package` it on a 32-bit system even though the installed files are just header files copied from the source directory.

See https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file for more details on the `ARCH_INDEPENDENT` flag.