### PR TITLE
Bring extents in line with R17

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -371,7 +371,7 @@ public:
   MDSPAN_CONDITIONAL_EXPLICIT(N != rank_dynamic())
   MDSPAN_INLINE_FUNCTION
   constexpr
-  extents(std::span<SizeType, N> const& exts) noexcept
+  extents(std::span<SizeType, N> exts) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     : __storage_{
 #else

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -344,8 +344,8 @@ public:
      */
   }
 
-#if MDSPAN_HAS_CXX_20
-  // TODO: check whether this works with newest NVCC, doesn't with 11.4
+#ifdef __cpp_lib_span
+  // TODO: check whether the below works with newest NVCC, doesn't with 11.4
 #ifdef __NVCC__
   // NVCC seems to pick up rank_dynamic from the wrong extents type???
   // NVCC chokes on the fold thingy here so wrote the workaround

--- a/include/experimental/__p0009_bits/standard_layout_static_array.hpp
+++ b/include/experimental/__p0009_bits/standard_layout_static_array.hpp
@@ -53,7 +53,7 @@
 #endif
 
 #include <array>
-#if MDSPAN_HAS_CXX_20
+#ifdef __cpp_lib_span
 #include <span>
 #endif
 #include <utility> // integer_sequence

--- a/include/experimental/__p0009_bits/standard_layout_static_array.hpp
+++ b/include/experimental/__p0009_bits/standard_layout_static_array.hpp
@@ -53,6 +53,9 @@
 #endif
 
 #include <array>
+#if MDSPAN_HAS_CXX_20
+#include <span>
+#endif
 #include <utility> // integer_sequence
 #include <cstddef>
 
@@ -254,6 +257,58 @@ struct __standard_layout_psa<
 #endif
   { }
 
+#if MDSPAN_HAS_CXX_20
+  template <class _U, size_t _N>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      span<_U, _N> const &__vals) noexcept
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+      : __next_{
+#else
+      : __base_t(__base_t{__next_t(
+#endif
+          __vals
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+        }
+#else
+        )})
+#endif
+  { }
+
+  template <class _U, size_t _NStatic>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      __construct_psa_from_all_exts_array_tag_t const & __tag,
+      span<_U, _NStatic> const &__vals) noexcept
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+      : __next_{
+#else
+      : __base_t(__base_t{__next_t(
+#endif
+          __tag, __vals
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+        }
+#else
+        )})
+#endif
+  { }
+
+  template <class _U, size_t _IDynamic, size_t _NDynamic>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic> __tag,
+      span<_U, _NDynamic> const &__vals) noexcept
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+      : __next_{
+#else
+      : __base_t(__base_t{__next_t(
+#endif
+          __tag, __vals
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+        }
+#else
+        )})
+#endif
+  { }
+#endif
+
   template <class _UTag, class _U, class _static_U, class _UValsSeq, _static_U __u_sentinal,
             class _IdxsSeq>
   MDSPAN_INLINE_FUNCTION constexpr __standard_layout_psa(
@@ -404,6 +459,31 @@ struct __standard_layout_psa<
             __next_t(__construct_psa_from_dynamic_exts_array_tag_t<_IDynamic + 1>{},
                      __vals)) {}
 
+#if MDSPAN_HAS_CXX_20
+  template <class _U, size_t _N>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      span<_U, _N> const &__vals) noexcept
+      : __value_pair(__vals[_Idx], __vals) {}
+
+  template <class _U, size_t _NStatic>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      __construct_psa_from_all_exts_array_tag_t __tag,
+      span<_U, _NStatic> const &__vals) noexcept
+      : __value_pair(
+            __vals[_Idx],
+            __next_t(__tag,
+                     __vals)) {}
+
+  template <class _U, size_t _IDynamic, size_t _NDynamic>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic>,
+      span<_U, _NDynamic> const &__vals) noexcept
+      : __value_pair(
+            __vals[_IDynamic],
+            __next_t(__construct_psa_from_dynamic_exts_array_tag_t<_IDynamic + 1>{},
+                     __vals)) {}
+#endif
+
   template <class _UTag, class _U, class _static_U, class _UValsSeq, _static_U __u_sentinal,
             class _UIdxsSeq>
   MDSPAN_INLINE_FUNCTION constexpr __standard_layout_psa(
@@ -509,6 +589,22 @@ struct __standard_layout_psa<_Tag, _T, _static_t, integer_sequence<_static_t>, _
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
       __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic>,
       array<_U, _NDynamic> const &) noexcept {}
+
+#if MDSPAN_HAS_CXX_20
+  template <class _U, size_t _N>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      span<_U, _N> const &) noexcept {}
+
+  template <class _U, size_t _NStatic>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      __construct_psa_from_all_exts_array_tag_t,
+      span<_U, _NStatic> const &) noexcept {}
+
+  template <class _U, size_t _IDynamic, size_t _NDynamic>
+  MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
+      __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic>,
+      span<_U, _NDynamic> const &) noexcept {}
+#endif
 
   template <class _UTag, class _U, class _static_U, class _UValsSeq, _static_U __u_sentinal,
             class _UIdxsSeq>

--- a/include/experimental/__p0009_bits/standard_layout_static_array.hpp
+++ b/include/experimental/__p0009_bits/standard_layout_static_array.hpp
@@ -257,7 +257,7 @@ struct __standard_layout_psa<
 #endif
   { }
 
-#if MDSPAN_HAS_CXX_20
+#ifdef __cpp_lib_span
   template <class _U, size_t _N>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
       span<_U, _N> const &__vals) noexcept
@@ -459,7 +459,7 @@ struct __standard_layout_psa<
             __next_t(__construct_psa_from_dynamic_exts_array_tag_t<_IDynamic + 1>{},
                      __vals)) {}
 
-#if MDSPAN_HAS_CXX_20
+#ifdef __cpp_lib_span
   template <class _U, size_t _N>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
       span<_U, _N> const &__vals) noexcept
@@ -590,7 +590,7 @@ struct __standard_layout_psa<_Tag, _T, _static_t, integer_sequence<_static_t>, _
       __construct_psa_from_dynamic_exts_array_tag_t<_IDynamic>,
       array<_U, _NDynamic> const &) noexcept {}
 
-#if MDSPAN_HAS_CXX_20
+#ifdef __cpp_lib_span
   template <class _U, size_t _N>
   MDSPAN_INLINE_FUNCTION constexpr explicit __standard_layout_psa(
       span<_U, _N> const &) noexcept {}

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -362,7 +362,7 @@ TEST(TestExtentsCtorStdArrayConvertibleToSizeT, test_extents_ctor_std_array_conv
   ASSERT_EQ(e.extent(1), 2);
 }
 
-#if MDSPAN_HAS_CXX_20
+#ifdef __cpp_lib_span
 TEST(TestExtentsCtorStdArrayConvertibleToSizeT, test_extents_ctor_std_span_convertible_to_size_t) {
   std::array<int, 2> i{2, 2};
   std::span<int ,2> s(i.data(),2);

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -362,6 +362,18 @@ TEST(TestExtentsCtorStdArrayConvertibleToSizeT, test_extents_ctor_std_array_conv
   ASSERT_EQ(e.extent(1), 2);
 }
 
+#if MDSPAN_HAS_CXX_20
+TEST(TestExtentsCtorStdArrayConvertibleToSizeT, test_extents_ctor_std_span_convertible_to_size_t) {
+  std::array<int, 2> i{2, 2};
+  std::span<int ,2> s(i.data(),2);
+  stdex::dextents<size_t,2> e{s};
+  ASSERT_EQ(e.rank(), 2);
+  ASSERT_EQ(e.rank_dynamic(), 2);
+  ASSERT_EQ(e.extent(0), 2);
+  ASSERT_EQ(e.extent(1), 2);
+}
+#endif
+
 TYPED_TEST(TestExtentsCompatCtors, construct_from_dynamic_sizes) {
   using e1_t = typename TestFixture::extents_type1;
   constexpr bool e1_last_ext_static = e1_t::rank()>0?e1_t::static_extent(e1_t::rank()-1)!=stdex::dynamic_extent:true;

--- a/tests/test_mdarray_ctors.cpp
+++ b/tests/test_mdarray_ctors.cpp
@@ -193,7 +193,7 @@ void test_mdarray_ctor_data_carray() {
   errors[0] = 0;
 
   dispatch([=] _MDSPAN_HOST_DEVICE () {
-    stdex::mdarray<int, stdex::extents<int,1>> m(stdex::extents<size_t,1>{});
+    stdex::mdarray<int, stdex::extents<size_t,1>> m(stdex::extents<int,1>{});
     __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
     __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), 1);


### PR DESCRIPTION
The biggest changes are removal of defaulted constructors/assignment
and adding from span constructor.