### PR TITLE
Add explicit to mdspan deduction guide

### DIFF
--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -314,7 +314,7 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_integral, SizeTypes) /* && ... */) &&
   (sizeof...(SizeTypes) > 0)
 )
-mdspan(ElementType*, SizeTypes...)
+explicit mdspan(ElementType*, SizeTypes...)
   -> mdspan<ElementType, ::std::experimental::dextents<size_t, sizeof...(SizeTypes)>>;
 
 MDSPAN_TEMPLATE_REQUIRES(


### PR DESCRIPTION
`mdspan(ElementType*, SizeTypes...)` deduction guide has an `explicit` in P0009, but not in the implementation.

@crtrott @dalg24 @nliber