### PR TITLE
submdspan: static slices

### DIFF
--- a/include/experimental/__p0009_bits/submdspan.hpp
+++ b/include/experimental/__p0009_bits/submdspan.hpp
@@ -75,6 +75,20 @@ MDSPAN_INLINE_FUNCTION constexpr
 __slice_wrap<OldExtent, OldStaticStride, size_t>
 __wrap_slice(size_t val, size_t ext, size_t stride) { return { val, ext, stride }; }
 
+template <size_t OldExtent, size_t OldStaticStride, class IntegerType, IntegerType Value0>
+MDSPAN_INLINE_FUNCTION constexpr
+__slice_wrap<OldExtent, OldStaticStride, std::integral_constant<IntegerType, Value0>>
+__wrap_slice(size_t val, size_t ext, std::integral_constant<IntegerType, Value0> stride)
+{
+#ifdef MDSPAN_HAS_CXX_17
+  if constexpr (std::is_signed_v<IntegerType>) {
+    static_assert(Value0 >= IntegerType(0), "Invalid slice specifier");
+  }
+#endif // MDSPAN_HAS_CXX_17
+
+  return { val, ext, stride };
+}
+
 template <size_t OldExtent, size_t OldStaticStride>
 MDSPAN_INLINE_FUNCTION constexpr
 __slice_wrap<OldExtent, OldStaticStride, full_extent_t>
@@ -270,6 +284,33 @@ struct __assign_op_slice_handler<
       __partially_static_sizes<_IndexT, size_t, _Offsets..., dynamic_extent>(
         __construct_psa_from_all_exts_values_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., __slice.slice),
+      ::std::move(__exts),
+      ::std::move(__strides)
+    };
+  }
+
+  // Treat integral_constant slice like size_t slice, but with a compile-time offset.
+  // The result's extents_type can't take advantage of that,
+  // but it might help for specialized layouts.
+  template <size_t _OldStaticExtent, size_t _OldStaticStride, class IntegerType, IntegerType Value0>
+  MDSPAN_FORCE_INLINE_FUNCTION // NOLINT (misc-unconventional-assign-operator)
+  _MDSPAN_CONSTEXPR_14 auto
+  operator=(__slice_wrap<_OldStaticExtent, _OldStaticStride, std::integral_constant<IntegerType, Value0>>&& __slice) noexcept
+    -> __assign_op_slice_handler<
+         _IndexT,
+         typename _PreserveLayoutAnalysis::encounter_scalar,
+         __partially_static_sizes<_IndexT, size_t, _Offsets..., Value0>,
+         __partially_static_sizes<_IndexT, size_t, _Exts...>,
+         __partially_static_sizes<_IndexT, size_t, _Strides...>/* intentional space here to work around ICC bug*/> {
+#ifdef MDSPAN_HAS_CXX_17
+    if constexpr (std::is_signed_v<IntegerType>) {
+      static_assert(Value0 >= IntegerType(0), "Invalid slice specifier");
+    }
+#endif // MDSPAN_HAS_CXX_17
+    return {
+      __partially_static_sizes<_IndexT, size_t, _Offsets..., Value0>(
+        __construct_psa_from_all_exts_values_tag,
+        __offsets.template __get_n<_OffsetIdxs>()..., size_t(Value0)),
       ::std::move(__exts),
       ::std::move(__strides)
     };

--- a/include/experimental/__p0009_bits/submdspan.hpp
+++ b/include/experimental/__p0009_bits/submdspan.hpp
@@ -89,6 +89,16 @@ __wrap_slice(std::tuple<size_t, size_t> const& val, size_t ext, size_t stride)
   return { val, ext, stride };
 }
 
+template <size_t OldExtent, size_t OldStaticStride, size_t Value0, size_t Value1>
+MDSPAN_INLINE_FUNCTION constexpr
+  __slice_wrap<OldExtent, OldStaticStride,
+	       std::tuple<size_t, size_t>>
+__wrap_slice(std::tuple<std::integral_constant<size_t, Value0>, std::integral_constant<size_t, Value1>> const& val, size_t ext, size_t stride)
+{
+  static_assert(Value1 >= Value0, "Invalid slice tuple");
+  return { std::tuple<size_t, size_t>(Value0, Value1), ext, stride };
+}
+
 //--------------------------------------------------------------------------------
 
 

--- a/include/experimental/__p0009_bits/submdspan.hpp
+++ b/include/experimental/__p0009_bits/submdspan.hpp
@@ -89,12 +89,14 @@ __wrap_slice(std::tuple<size_t, size_t> const& val, size_t ext, size_t stride)
   return { val, ext, stride };
 }
 
-template <size_t OldExtent, size_t OldStaticStride, size_t Value0, size_t Value1>
+template <size_t OldExtent, size_t OldStaticStride,
+	  class IntegerType0, IntegerType0 Value0,
+	  class IntegerType1, IntegerType1 Value1>
 MDSPAN_INLINE_FUNCTION constexpr
   __slice_wrap<OldExtent, OldStaticStride,
-               std::tuple<std::integral_constant<size_t, Value0>,
-                          std::integral_constant<size_t, Value1>>>
-__wrap_slice(std::tuple<std::integral_constant<size_t, Value0>, std::integral_constant<size_t, Value1>> const& val, size_t ext, size_t stride)
+               std::tuple<std::integral_constant<IntegerType0, Value0>,
+                          std::integral_constant<IntegerType1, Value1>>>
+__wrap_slice(std::tuple<std::integral_constant<IntegerType0, Value0>, std::integral_constant<IntegerType1, Value1>> const& val, size_t ext, size_t stride)
 {
   static_assert(Value1 >= Value0, "Invalid slice tuple");
   return { val, ext, stride };
@@ -321,25 +323,29 @@ struct __assign_op_slice_handler<
     };
   }
 
-  // Treat a std::tuple of std::integral_constant as a tuple of size_t for now.
-  template <size_t _OldStaticExtent, size_t _OldStaticStride, size_t Value0, size_t Value1>
+  // For a std::tuple of two std::integral_constant, do something like
+  // we did above for a tuple of two size_t, but make sure the
+  // result's extents type make the values compile-time constants.
+  template <size_t _OldStaticExtent, size_t _OldStaticStride,
+	    class IntegerType0, IntegerType0 Value0,
+	    class IntegerType1, IntegerType1 Value1>
   MDSPAN_FORCE_INLINE_FUNCTION // NOLINT (misc-unconventional-assign-operator)
   _MDSPAN_CONSTEXPR_14 auto
-  operator=(__slice_wrap<_OldStaticExtent, _OldStaticStride, tuple<std::integral_constant<size_t, Value0>, std::integral_constant<size_t, Value1>>>&& __slice) noexcept
+  operator=(__slice_wrap<_OldStaticExtent, _OldStaticStride, tuple<std::integral_constant<IntegerType0, Value0>, std::integral_constant<IntegerType1, Value1>>>&& __slice) noexcept
     -> __assign_op_slice_handler<
          _IndexT,
          typename _PreserveLayoutAnalysis::encounter_pair,
-         __partially_static_sizes<_IndexT, size_t, _Offsets..., Value0>,
-         __partially_static_sizes<_IndexT, size_t, _Exts..., Value1 - Value0>,
+         __partially_static_sizes<_IndexT, size_t, _Offsets..., size_t(Value0)>,
+         __partially_static_sizes<_IndexT, size_t, _Exts..., size_t(Value1 - Value0)>,
          __partially_static_sizes<_IndexT, size_t, _Strides..., _OldStaticStride>/* intentional space here to work around ICC bug*/> {
     static_assert(Value1 >= Value0, "Invalid slice specifier");
     return {
       // We're still turning the template parameters Value0 and Value1
       // into (constexpr) run-time values here.
-      __partially_static_sizes<_IndexT, size_t, _Offsets..., Value0>(
+      __partially_static_sizes<_IndexT, size_t, _Offsets..., size_t(Value0) > (
         __construct_psa_from_all_exts_values_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., Value0),
-      __partially_static_sizes<_IndexT, size_t, _Exts..., Value1 - Value0>(
+      __partially_static_sizes<_IndexT, size_t, _Exts..., size_t(Value1 - Value0) > (
         __construct_psa_from_all_exts_values_tag,
         __exts.template __get_n<_ExtIdxs>()..., Value1 - Value0),
       __partially_static_sizes<_IndexT, size_t, _Strides..., _OldStaticStride>(

--- a/include/experimental/__p0009_bits/submdspan.hpp
+++ b/include/experimental/__p0009_bits/submdspan.hpp
@@ -329,16 +329,17 @@ struct __assign_op_slice_handler<
     -> __assign_op_slice_handler<
          _IndexT,
          typename _PreserveLayoutAnalysis::encounter_pair,
-         __partially_static_sizes<_IndexT, size_t, _Offsets..., dynamic_extent>,
-         __partially_static_sizes<_IndexT, size_t, _Exts..., dynamic_extent>,
+         __partially_static_sizes<_IndexT, size_t, _Offsets..., Value0>,
+         __partially_static_sizes<_IndexT, size_t, _Exts..., Value1 - Value0>,
          __partially_static_sizes<_IndexT, size_t, _Strides..., _OldStaticStride>/* intentional space here to work around ICC bug*/> {
+    static_assert(Value1 >= Value0, "Invalid slice specifier");
     return {
       // We're still turning the template parameters Value0 and Value1
       // into (constexpr) run-time values here.
-      __partially_static_sizes<_IndexT, size_t, _Offsets..., dynamic_extent>(
+      __partially_static_sizes<_IndexT, size_t, _Offsets..., Value0>(
         __construct_psa_from_all_exts_values_tag,
         __offsets.template __get_n<_OffsetIdxs>()..., Value0),
-      __partially_static_sizes<_IndexT, size_t, _Exts..., dynamic_extent>(
+      __partially_static_sizes<_IndexT, size_t, _Exts..., Value1 - Value0>(
         __construct_psa_from_all_exts_values_tag,
         __exts.template __get_n<_ExtIdxs>()..., Value1 - Value0),
       __partially_static_sizes<_IndexT, size_t, _Strides..., _OldStaticStride>(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,4 +52,4 @@ mdspan_add_test(test_layout_ctors)
 mdspan_add_test(test_layout_stride)
 mdspan_add_test(test_submdspan)
 mdspan_add_test(test_mdarray_ctors)
-
+mdspan_add_test(test_submdspan_static_slice)

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -110,7 +110,8 @@ TEST(TestMdspan, submdspan_static_slice_full_tuple) {
 
   input_extents_type input_extents{3, 4};
   test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::size_t, std::size_t>{1, 3});
-  // This doesn't compile yet.
+  // This won't compile out of the box, but with the
+  // included changes to submdspan, it does compile.
   test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>> {} );
 }
 

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -52,14 +52,16 @@ namespace {
 
 namespace stdex = std::experimental;
 
+template<class Integral, Integral Value>
+using IC = std::integral_constant<Integral, Value>;
+
 template<class ExpectedOutputMdspan, class InputMdspan, class ... Slices>
 void test_submdspan_static_slice(
-  typename InputMdspan::extents_type input_extents,
+  typename InputMdspan::mapping_type input_mapping,
   Slices&&... slices)
 {
   using input_type = InputMdspan;
   using input_mapping_type = typename input_type::mapping_type;
-  input_mapping_type input_mapping(input_extents);
   std::vector<typename InputMdspan::value_type> storage(input_mapping.required_span_size());
 
   input_type input(storage.data(), input_mapping);
@@ -70,11 +72,23 @@ void test_submdspan_static_slice(
   static_assert(std::is_same_v<output_mdspan_type, ExpectedOutputMdspan>, "submdspan return types don't match.");
 }
 
-TEST(TestMdspan, submdspan_static_slice_full_full_index) {
-  static_assert(std::is_convertible<std::integral_constant<std::size_t, 1>, std::size_t>::value, "Just a check.");
-  static_assert(std::is_convertible<std::integral_constant<int32_t, 1>, std::size_t>::value, "Just a check.");
-  static_assert(std::is_convertible<std::integral_constant<uint32_t, 1>, std::size_t>::value, "Just a check.");
+template<class ExpectedOutputMdspan, class InputMdspan, class ... Slices>
+void test_submdspan_static_slice(
+  typename InputMdspan::extents_type input_extents,
+  Slices&&... slices)
+{
+  using input_mapping_type = typename InputMdspan::mapping_type;
+  input_mapping_type input_mapping(input_extents);
+  test_submdspan_static_slice<ExpectedOutputMdspan, InputMdspan>(input_mapping, std::forward<Slices>(slices)...);
+}
 
+TEST(TestMdspan, StaticAsserts) {
+  static_assert(std::is_convertible<IC<std::size_t, 1>, std::size_t>::value, "Just a check.");
+  static_assert(std::is_convertible<IC<int32_t, 1>, std::size_t>::value, "Just a check.");
+  static_assert(std::is_convertible<IC<uint32_t, 1>, std::size_t>::value, "Just a check.");
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_iddd_FullFullIndex) {
   using input_extents_type = stdex::dextents<int, 3>;
   using input_layout_type = stdex::layout_left;
   using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
@@ -84,28 +98,478 @@ TEST(TestMdspan, submdspan_static_slice_full_full_index) {
     using expected_extents_type = stdex::dextents<int, 2>;
     using expected_layout_type = stdex::layout_left;
     using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, 1);
-  }
-  {
-    using expected_extents_type = stdex::dextents<int, 2>;
-    using expected_layout_type = stdex::layout_left;
-    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<int, 1>{});
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<std::size_t, 1>{});
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<int64_t, 1>{});
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<uint32_t, 1>{});
+
+    auto runTest = [&] (auto integralConstant) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+	input_extents, stdex::full_extent, stdex::full_extent, integralConstant);
+    };
+    runTest(int(1));
+    runTest(std::size_t(1));
+    runTest(std::int64_t(1));
+    runTest(std::uint32_t(1));
+    runTest(IC<int, 1>{});
+    runTest(IC<std::size_t, 1>{});
+    runTest(IC<std::int64_t, 1>{});
+    runTest(IC<std::uint32_t, 1>{});
   }
 }
 
-TEST(TestMdspan, submdspan_static_slice_full_tuple) {
-  // tuple of two integral_constant is convertible to tuple of two
-  // size_t.  Nevertheless, submdspan needs special handling to be
-  // able to compile with the former as a slice specifier.
-  static_assert(std::is_convertible<
-      std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>>,
-      std::tuple<std::size_t, std::size_t>
-    >::value, "Just a check.");
-  std::tuple<std::size_t, std::size_t> t = std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>>{};
+TEST(TestMdspan, SubmdspanStaticSlice_Left_i345_FullFullIndex) {
+  using input_extents_type = stdex::extents<int, 3, 4, 5>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents;
+
+  {
+    using expected_extents_type = stdex::extents<int, 3, 4>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto integralConstant) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+	input_extents, stdex::full_extent, stdex::full_extent, integralConstant);
+    };
+    runTest(int(1));
+    runTest(std::size_t(1));
+    runTest(std::int64_t(1));
+    runTest(std::uint32_t(1));
+    runTest(IC<int, 1>{});
+    runTest(IC<std::size_t, 1>{});
+    runTest(IC<std::int64_t, 1>{});
+    runTest(IC<std::uint32_t, 1>{});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_iddd_FullFullIndex) {
+  using input_extents_type = stdex::dextents<int, 3>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents{3, 4, 5};
+
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+	input_extents, stdex::full_extent, stdex::full_extent, sliceSpec);
+    };
+    runTest(int(1));
+    runTest(std::size_t(1));
+    runTest(std::int64_t(1));
+    runTest(std::uint32_t(1));
+    runTest(IC<int, 1>{});
+    runTest(IC<std::size_t, 1>{});
+    runTest(IC<std::int64_t, 1>{});
+    runTest(IC<std::uint32_t, 1>{});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_i345_FullFullIndex) {
+  using input_extents_type = stdex::extents<int, 3, 4, 5>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents;
+
+  {
+    using expected_extents_type = stdex::extents<int, 3, 4>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto integralConstant) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+	input_extents, stdex::full_extent, stdex::full_extent, integralConstant);
+    };
+    runTest(int(1));
+    runTest(std::size_t(1));
+    runTest(std::int64_t(1));
+    runTest(std::uint32_t(1));
+    runTest(IC<int, 1>{});
+    runTest(IC<std::size_t, 1>{});
+    runTest(IC<std::int64_t, 1>{});
+    runTest(IC<std::uint32_t, 1>{});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_iddd_FullIndexFull) {
+  using input_extents_type = stdex::dextents<int, 3>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents{3, 4, 5};
+
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto integralConstant) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, integralConstant, stdex::full_extent);
+    };
+    runTest(int(1));
+    runTest(std::size_t(1));
+    runTest(std::int64_t(1));
+    runTest(std::uint32_t(1));
+    runTest(IC<int, 1>{});
+    runTest(IC<std::size_t, 1>{});
+    runTest(IC<std::int64_t, 1>{});
+    runTest(IC<std::uint32_t, 1>{});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_i345_FullIndexFull) {
+  using input_extents_type = stdex::extents<int, 3, 4, 5>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents;
+
+  {
+    using expected_extents_type = stdex::extents<int, 3, 5>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto integralConstant) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, integralConstant, stdex::full_extent);
+    };
+    runTest(int(1));
+    runTest(std::size_t(1));
+    runTest(std::int64_t(1));
+    runTest(std::uint32_t(1));
+    runTest(IC<int, 1>{});
+    runTest(IC<std::size_t, 1>{});
+    runTest(IC<std::int64_t, 1>{});
+    runTest(IC<std::uint32_t, 1>{});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_iddd_FullTupleFull) {
+  using std::tuple;
+  using input_extents_type = stdex::dextents<int, 3>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents{3, 4, 5};
+
+  {
+    using expected_extents_type = stdex::dextents<int, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{int(1), int{3}});
+    runTest(tuple{std::size_t(1), std::size_t(3)});
+    runTest(tuple{std::int64_t(1), std::int64_t(3)});
+    runTest(tuple{std::uint32_t(1), std::uint32_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_i345_FullTupleFull) {
+  using std::tuple;
+  using input_extents_type = stdex::extents<int, 3, 4, 5>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents;
+
+  {
+    using expected_extents_type = stdex::extents<int, 3, stdex::dynamic_extent, 5>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{int(1), int{3}});
+    runTest(tuple{std::size_t(1), std::size_t(3)});
+    runTest(tuple{std::int64_t(1), std::int64_t(3)});
+    runTest(tuple{std::uint32_t(1), std::uint32_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 3, 2, 5>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_iddd_FullTupleFull) {
+  using std::tuple;
+  using input_extents_type = stdex::dextents<int, 3>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents{3, 4, 5};
+
+  {
+    using expected_extents_type = stdex::dextents<int, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{int(1), int{3}});
+    runTest(tuple{std::size_t(1), std::size_t(3)});
+    runTest(tuple{std::int64_t(1), std::int64_t(3)});
+    runTest(tuple{std::uint32_t(1), std::uint32_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_i345_FullTupleFull) {
+  using std::tuple;
+  using input_extents_type = stdex::extents<int, 3, 4, 5>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents;
+
+  {
+    using expected_extents_type = stdex::extents<int, 3, stdex::dynamic_extent, 5>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{int(1), int{3}});
+    runTest(tuple{std::size_t(1), std::size_t(3)});
+    runTest(tuple{std::int64_t(1), std::int64_t(3)});
+    runTest(tuple{std::uint32_t(1), std::uint32_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 3, 2, 5>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, stdex::full_extent, sliceSpec, stdex::full_extent);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_iddd_TupleFullTuple) {
+  using std::tuple;
+  using input_extents_type = stdex::dextents<int, 3>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents{3, 4, 5};
+
+  {
+    using expected_extents_type = stdex::dextents<int, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{int{1}, int{3}}, tuple{int{1}, int{4}});
+    runTest(tuple{std::size_t{1}, std::size_t{3}}, tuple{std::size_t{1}, std::size_t{4}});
+    runTest(tuple{std::int64_t{1}, std::int64_t{3}}, tuple{std::int64_t{1}, std::int64_t{4}});
+    runTest(tuple{std::uint32_t{1}, std::uint32_t{3}}, tuple{std::uint32_t{1}, std::uint32_t{4}});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2, stdex::dynamic_extent, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}},
+	    tuple{IC<int, 1>{}, IC<int, 4>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}},
+	    tuple{IC<std::size_t, 1>{}, IC<std::size_t, 4>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}},
+	    tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 4>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}},
+	    tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 4>{}});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_i345_TupleFullTuple) {
+  using std::tuple;
+  using input_extents_type = stdex::extents<int, 3, 4, 5>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents;
+
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 4, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{int{1}, int{3}}, tuple{int{1}, int{4}});
+    runTest(tuple{std::size_t{1}, std::size_t{3}}, tuple{std::size_t{1}, std::size_t{4}});
+    runTest(tuple{std::int64_t{1}, std::int64_t{3}}, tuple{std::int64_t{1}, std::int64_t{4}});
+    runTest(tuple{std::uint32_t{1}, std::uint32_t{3}}, tuple{std::uint32_t{1}, std::uint32_t{4}});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2, 4, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}},
+	    tuple{IC<int, 1>{}, IC<int, 4>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}},
+	    tuple{IC<std::size_t, 1>{}, IC<std::size_t, 4>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}},
+	    tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 4>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}},
+	    tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 4>{}});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_iddd_TupleFullTuple) {
+  using std::tuple;
+  using input_extents_type = stdex::dextents<int, 3>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents{3, 4, 5};
+
+  {
+    using expected_extents_type = stdex::dextents<int, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{int{1}, int{3}}, tuple{int{1}, int{4}});
+    runTest(tuple{std::size_t{1}, std::size_t{3}}, tuple{std::size_t{1}, std::size_t{4}});
+    runTest(tuple{std::int64_t{1}, std::int64_t{3}}, tuple{std::int64_t{1}, std::int64_t{4}});
+    runTest(tuple{std::uint32_t{1}, std::uint32_t{3}}, tuple{std::uint32_t{1}, std::uint32_t{4}});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2, stdex::dynamic_extent, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}},
+	    tuple{IC<int, 1>{}, IC<int, 4>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}},
+	    tuple{IC<std::size_t, 1>{}, IC<std::size_t, 4>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}},
+	    tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 4>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}},
+	    tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 4>{}});
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_i345_TupleFullTuple) {
+  using std::tuple;
+  using input_extents_type = stdex::extents<int, 3, 4, 5>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents;
+
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 4, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{int{1}, int{3}}, tuple{int{1}, int{4}});
+    runTest(tuple{std::size_t{1}, std::size_t{3}}, tuple{std::size_t{1}, std::size_t{4}});
+    runTest(tuple{std::int64_t{1}, std::int64_t{3}}, tuple{std::int64_t{1}, std::int64_t{4}});
+    runTest(tuple{std::uint32_t{1}, std::uint32_t{3}}, tuple{std::uint32_t{1}, std::uint32_t{4}});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2, 4, 3>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(
+        input_extents, sliceSpec0, stdex::full_extent, sliceSpec1);
+    };
+    runTest(tuple{IC<int, 1>{}, IC<int, 3>{}},
+	    tuple{IC<int, 1>{}, IC<int, 4>{}});
+    runTest(tuple{IC<std::size_t, 1>{}, IC<std::size_t, 3>{}},
+	    tuple{IC<std::size_t, 1>{}, IC<std::size_t, 4>{}});
+    runTest(tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 3>{}},
+	    tuple{IC<std::int64_t, 1>{}, IC<std::int64_t, 4>{}});
+    runTest(tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 3>{}},
+	    tuple{IC<std::uint32_t, 1>{}, IC<std::uint32_t, 4>{}});
+  }
+}
+
+// Simpler, rank-2 tests follow.  If you have a build regression,
+// it may help to comment out all the tests but the ones below.
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_idd_FullTuple) {
+  // tuple of two integral_constant is convertible to tuple of two size_t.
+  // Nevertheless, submdspan needs special handling to be able to compile
+  // with a tuple of two integral_constant as a slice specifier.
+  // For example, mdspan needs an overload of
+  // __assign_op_slice_handler::operator=
+  // in order for the output's extents type to be able to encode
+  // the compile-time slice information.
+  std::tuple<std::size_t, std::size_t> t =
+    std::tuple<IC<std::size_t, 1>,
+	       IC<std::size_t, 3>>{};
 
   using input_extents_type = stdex::dextents<int, 2>;
   using input_layout_type = stdex::layout_left;
@@ -116,47 +580,305 @@ TEST(TestMdspan, submdspan_static_slice_full_tuple) {
     using expected_extents_type = stdex::dextents<int, 2>;
     using expected_layout_type = stdex::layout_left;
     using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::size_t, std::size_t>{1, 3});
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, sliceSpec);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
   }
   {
-    // Need an __assign_op_slice_handler::operator= overload for the
-    // output's extents type to be able to encode the compile-time slice
-    // information.
-    //using expected_extents_type = stdex::dextents<int, 2>;
     using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2>;
     using expected_layout_type = stdex::layout_left;
     using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
 
-    // This won't compile out of the box, but with the
-    // included changes to submdspan, it does compile.
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>> {} );
-  }
-  {
-    // Need an __assign_op_slice_handler::operator= overload for the
-    // output's extents type to be able to encode the compile-time slice
-    // information.
-    //using expected_extents_type = stdex::dextents<int, 2>;
-    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2>;
-    using expected_layout_type = stdex::layout_left;
-    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
-
-    // This won't compile out of the box, but with the
-    // included changes to submdspan, it does compile.
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<int, 1>, std::integral_constant<int, 3>> {} );
-  }
-  {
-    // Need an __assign_op_slice_handler::operator= overload for the
-    // output's extents type to be able to encode the compile-time slice
-    // information.
-    //using expected_extents_type = stdex::dextents<int, 2>;
-    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2>;
-    using expected_layout_type = stdex::layout_left;
-    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
-
-    // This won't compile out of the box, but with the
-    // included changes to submdspan, it does compile.
-    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<uint32_t, 1>, std::integral_constant<int32_t, 3>> {} );
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, sliceSpec);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<uint32_t, 1>, IC<uint32_t, 3>> {} );
+    runTest(std::tuple<IC<int64_t, 1>, IC<int64_t, 3>> {} );
   }
 }
 
+TEST(TestMdspan, SubmdspanStaticSlice_Right_idd_FullTuple) {
+  using input_extents_type = stdex::dextents<int, 2>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents{3, 4};
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, sliceSpec);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, sliceSpec);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<uint32_t, 1>, IC<uint32_t, 3>> {} );
+    runTest(std::tuple<IC<int64_t, 1>, IC<int64_t, 3>> {} );
+  }
 }
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_idd_TupleFull) {
+  using input_extents_type = stdex::dextents<int, 2>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents{3, 4};
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec, stdex::full_extent);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec, stdex::full_extent);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<std::uint32_t, 1>, IC<std::uint32_t, 3>> {} );
+    runTest(std::tuple<IC<std::int64_t, 1>, IC<std::int64_t, 3>> {} );
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_idd_TupleFull) {
+  using input_extents_type = stdex::dextents<int, 2>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents{3, 4};
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_right;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec, stdex::full_extent);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_right;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec, stdex::full_extent);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<std::uint32_t, 1>, IC<std::uint32_t, 3>> {} );
+    runTest(std::tuple<IC<std::int64_t, 1>, IC<std::int64_t, 3>> {} );
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Stride_idd_TupleFull) {
+  using input_extents_type = stdex::dextents<int, 2>;
+  using input_layout_type = stdex::layout_stride;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents{3, 4};
+  std::array<int, 2> input_strides{1, 4}; // like layout_left
+  using input_mapping_type = typename input_mdspan_type::mapping_type;
+  input_mapping_type input_mapping(input_extents, input_strides);
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_mapping, sliceSpec, stdex::full_extent);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_stride;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_mapping, sliceSpec, stdex::full_extent);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<std::uint32_t, 1>, IC<std::uint32_t, 3>> {} );
+    runTest(std::tuple<IC<std::int64_t, 1>, IC<std::int64_t, 3>> {} );
+  }
+}
+
+// Rank 1 tests
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_id_Tuple) {
+  using input_extents_type = stdex::extents<int, stdex::dynamic_extent>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents{5};
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<std::uint32_t, 1>, IC<std::uint32_t, 3>> {} );
+    runTest(std::tuple<IC<std::int64_t, 1>, IC<std::int64_t, 3>> {} );
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Left_i5_Tuple) {
+  using input_extents_type = stdex::extents<int, 5>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents;
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<std::uint32_t, 1>, IC<std::uint32_t, 3>> {} );
+    runTest(std::tuple<IC<std::int64_t, 1>, IC<std::int64_t, 3>> {} );
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_id_Tuple) {
+  using input_extents_type = stdex::extents<int, stdex::dynamic_extent>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents{5};
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_right;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2>;
+    using expected_layout_type = stdex::layout_right;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<std::uint32_t, 1>, IC<std::uint32_t, 3>> {} );
+    runTest(std::tuple<IC<std::int64_t, 1>, IC<std::int64_t, 3>> {} );
+  }
+}
+
+TEST(TestMdspan, SubmdspanStaticSlice_Right_i5_Tuple) {
+  using input_extents_type = stdex::extents<int, 5>;
+  using input_layout_type = stdex::layout_right;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  input_extents_type input_extents;
+  {
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent>;
+    using expected_layout_type = stdex::layout_right;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple{int(1), int(3)});
+    runTest(std::tuple{std::size_t(1), std::size_t(3)});
+    runTest(std::tuple{std::uint32_t(1), std::uint32_t(3)});
+    runTest(std::tuple{std::int64_t(1), std::int64_t(3)});
+  }
+  {
+    using expected_extents_type = stdex::extents<int, 2>;
+    using expected_layout_type = stdex::layout_right;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    auto runTest = [&](auto sliceSpec) {
+      test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, sliceSpec);
+    };
+    runTest(std::tuple<IC<int, 1>, IC<int, 3>> {} );
+    runTest(std::tuple<IC<std::size_t, 1>, IC<std::size_t, 3>> {} );
+    runTest(std::tuple<IC<std::uint32_t, 1>, IC<std::uint32_t, 3>> {} );
+    runTest(std::tuple<IC<std::int64_t, 1>, IC<std::int64_t, 3>> {} );
+  }
+}
+
+} // namespace (anonymous)

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -51,7 +51,6 @@
 namespace {
 
 namespace stdex = std::experimental;
-_MDSPAN_INLINE_VARIABLE constexpr auto dyn = stdex::dynamic_extent;
 
 template<class ExpectedOutputMdspan, class InputMdspan, class ... Slices>
 void test_submdspan_static_slice(
@@ -71,7 +70,7 @@ void test_submdspan_static_slice(
   static_assert(std::is_same_v<output_mdspan_type, ExpectedOutputMdspan>, "submdspan return types don't match.");
 }
 
-TEST(TestMdspan, submdspan_static_slice) {
+TEST(TestMdspan, submdspan_static_slice_full_index) {
   static_assert(std::is_convertible<std::integral_constant<std::size_t, 1>, std::size_t>::value, "Just a check.");
   static_assert(std::is_convertible<std::integral_constant<int32_t, 1>, std::size_t>::value, "Just a check.");
   static_assert(std::is_convertible<std::integral_constant<uint32_t, 1>, std::size_t>::value, "Just a check.");
@@ -84,11 +83,35 @@ TEST(TestMdspan, submdspan_static_slice) {
   using expected_layout_type = stdex::layout_left;
   using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
 
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, 1);
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<int, 1>{});
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<std::size_t, 1>{});
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<int64_t, 1>{});
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<uint32_t, 1>{});
+  input_extents_type input_extents{3, 4};
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, 1);
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<int, 1>{});
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<std::size_t, 1>{});
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<int64_t, 1>{});
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<uint32_t, 1>{});
+}
+
+TEST(TestMdspan, submdspan_static_slice_full_tuple) {
+  // tuple of integral_constant, integral_constant is convertible to tuple of size_t, size_t.
+  // Nevertheless, submdspan won't compile out of the box with the former.
+  static_assert(std::is_convertible<
+      std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>>,
+      std::tuple<std::size_t, std::size_t>
+    >::value, "Just a check.");
+  std::tuple<std::size_t, std::size_t> t = std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>>{};
+
+  using input_extents_type = stdex::dextents<int, 2>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  using expected_extents_type = stdex::dextents<int, 2>;
+  using expected_layout_type = stdex::layout_left;
+  using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+  input_extents_type input_extents{3, 4};
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::size_t, std::size_t>{1, 3});
+  // This doesn't compile yet.
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>> {} );
 }
 
 }

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -1,0 +1,94 @@
+/*
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 2.0
+//              Copyright (2019) Sandia Corporation
+//
+// Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
+// the U.S. Government retains certain rights in this software.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Christian R. Trott (crtrott@sandia.gov)
+//
+// ************************************************************************
+//@HEADER
+*/
+
+#include <experimental/mdspan>
+#include <cstdint>
+#include <type_traits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+namespace stdex = std::experimental;
+_MDSPAN_INLINE_VARIABLE constexpr auto dyn = stdex::dynamic_extent;
+
+template<class ExpectedOutputMdspan, class InputMdspan, class ... Slices>
+void test_submdspan_static_slice(
+  typename InputMdspan::extents_type input_extents,
+  Slices&&... slices)
+{
+  using input_type = InputMdspan;
+  using input_mapping_type = typename input_type::mapping_type;
+  input_mapping_type input_mapping(input_extents);
+  std::vector<typename InputMdspan::value_type> storage(input_mapping.required_span_size());
+
+  input_type input(storage.data(), input_mapping);
+  auto output = stdex::submdspan(input, std::forward<Slices>(slices)...);
+  using output_mdspan_type = decltype(output);
+  static_assert(std::is_same_v<typename output_mdspan_type::extents_type, typename ExpectedOutputMdspan::extents_type>, "Extents don't match.");
+  static_assert(std::is_same_v<typename output_mdspan_type::layout_type, typename ExpectedOutputMdspan::layout_type>, "Layouts don't match.");
+  static_assert(std::is_same_v<output_mdspan_type, ExpectedOutputMdspan>, "submdspan return types don't match.");
+}
+
+TEST(TestMdspan, submdspan_static_slice) {
+  static_assert(std::is_convertible<std::integral_constant<std::size_t, 1>, std::size_t>::value, "Just a check.");
+  static_assert(std::is_convertible<std::integral_constant<int32_t, 1>, std::size_t>::value, "Just a check.");
+  static_assert(std::is_convertible<std::integral_constant<uint32_t, 1>, std::size_t>::value, "Just a check.");
+
+  using input_extents_type = stdex::dextents<int, 2>;
+  using input_layout_type = stdex::layout_left;
+  using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+
+  using expected_extents_type = stdex::dextents<int, 1>;
+  using expected_layout_type = stdex::layout_left;
+  using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, 1);
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<int, 1>{});
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<std::size_t, 1>{});
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<int64_t, 1>{});
+  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents_type{3, 4}, stdex::full_extent, std::integral_constant<uint32_t, 1>{});
+}
+
+}

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -70,25 +70,31 @@ void test_submdspan_static_slice(
   static_assert(std::is_same_v<output_mdspan_type, ExpectedOutputMdspan>, "submdspan return types don't match.");
 }
 
-TEST(TestMdspan, submdspan_static_slice_full_index) {
+TEST(TestMdspan, submdspan_static_slice_full_full_index) {
   static_assert(std::is_convertible<std::integral_constant<std::size_t, 1>, std::size_t>::value, "Just a check.");
   static_assert(std::is_convertible<std::integral_constant<int32_t, 1>, std::size_t>::value, "Just a check.");
   static_assert(std::is_convertible<std::integral_constant<uint32_t, 1>, std::size_t>::value, "Just a check.");
 
-  using input_extents_type = stdex::dextents<int, 2>;
+  using input_extents_type = stdex::dextents<int, 3>;
   using input_layout_type = stdex::layout_left;
   using input_mdspan_type = stdex::mdspan<float, input_extents_type, input_layout_type>;
+  input_extents_type input_extents{3, 4, 5};
 
-  using expected_extents_type = stdex::dextents<int, 1>;
-  using expected_layout_type = stdex::layout_left;
-  using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
-
-  input_extents_type input_extents{3, 4};
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, 1);
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<int, 1>{});
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<std::size_t, 1>{});
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<int64_t, 1>{});
-  test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::integral_constant<uint32_t, 1>{});
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, 1);
+  }
+  {
+    using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<int, 1>{});
+    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<std::size_t, 1>{});
+    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<int64_t, 1>{});
+    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, stdex::full_extent, std::integral_constant<uint32_t, 1>{});
+  }
 }
 
 TEST(TestMdspan, submdspan_static_slice_full_tuple) {

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -125,6 +125,32 @@ TEST(TestMdspan, submdspan_static_slice_full_tuple) {
     // included changes to submdspan, it does compile.
     test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<std::size_t, 1>, std::integral_constant<std::size_t, 3>> {} );
   }
+  {
+    // Need an __assign_op_slice_handler::operator= overload for the
+    // output's extents type to be able to encode the compile-time slice
+    // information.
+    //using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    // This won't compile out of the box, but with the
+    // included changes to submdspan, it does compile.
+    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<int, 1>, std::integral_constant<int, 3>> {} );
+  }
+  {
+    // Need an __assign_op_slice_handler::operator= overload for the
+    // output's extents type to be able to encode the compile-time slice
+    // information.
+    //using expected_extents_type = stdex::dextents<int, 2>;
+    using expected_extents_type = stdex::extents<int, stdex::dynamic_extent, 2>;
+    using expected_layout_type = stdex::layout_left;
+    using expected_output_mdspan_type = stdex::mdspan<float, expected_extents_type, expected_layout_type>;
+
+    // This won't compile out of the box, but with the
+    // included changes to submdspan, it does compile.
+    test_submdspan_static_slice<expected_output_mdspan_type, input_mdspan_type>(input_extents, stdex::full_extent, std::tuple<std::integral_constant<uint32_t, 1>, std::integral_constant<int32_t, 3>> {} );
+  }
 }
 
 }


### PR DESCRIPTION
1. When `submdspan` is given a `tuple<integral_constant<T0, Value0>, integral_constant<T1, Value1>>` as a slice specifier, preserve the compile-time values in the returned `mdspan`'s `extents_type`.
2. When `submdspan` is given an `integral_constant<T, Val>` as a slice specifier, preserve the compile-time values in the returned `mdspan`'s `extents_type`.
 
Change (1) can turn a dynamic extent into a static extent.  For example, for a rank-3 `dextents<int, 3>` mdspan `m`, `submdspan(m, full_extent, full_extent, tuple{integral_constant<int, 1>{}, integral_constant<int, 3>{}})` has `extents<int, dynamic_extent, dynamic_extent, 2>`.  Since the mapping is templated on the `extents` type, a custom layout could bake all the extents information into the type as non-type template parameters, rather than relying on `constexpr` for compile-time evaluation.  This could be helpful when crossing a compilation unit boundary without link-time optimization, for example.

Change (2) only affects the offset computation.  It might still be helpful for specific custom layouts, though.  It's also an easy change that just imitates (1).