### PR TITLE
restrict_accessor missing include

### DIFF
--- a/examples/restrict_accessor/restrict_accessor.cpp
+++ b/examples/restrict_accessor/restrict_accessor.cpp
@@ -47,6 +47,7 @@
 #include <chrono>
 #include <iostream>
 #include <type_traits>
+#include <vector>
 
 // mfh 2022/08/04: This is based on my comments on reference mdspan
 // implementation issue https://github.com/kokkos/mdspan/issues/169.


### PR DESCRIPTION
g++ 11.2.0 requires <vector> to be included in restrict_accessor