### PR TITLE
Work around __make_dynamic_extent compiler bug

### DIFF
--- a/include/experimental/__p0009_bits/dynamic_extent.hpp
+++ b/include/experimental/__p0009_bits/dynamic_extent.hpp
@@ -53,20 +53,6 @@ namespace experimental {
 
 _MDSPAN_INLINE_VARIABLE constexpr auto dynamic_extent = std::numeric_limits<size_t>::max();
 
-namespace detail {
-
-template <class>
-constexpr auto __make_dynamic_extent() {
-  return dynamic_extent;
-}
-
-template <size_t>
-constexpr auto __make_dynamic_extent_integral() {
-  return dynamic_extent;
-}
-
-} // end namespace detail
-
 } // end namespace experimental
 } // namespace std
 

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -510,7 +510,7 @@ using dextents = typename detail::__make_dextents<IndexType, Rank>::type;
 #if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 template <class... IndexTypes>
 extents(IndexTypes...)
-  -> extents<size_t, detail::__make_dynamic_extent<IndexTypes>()...>;
+  -> extents<size_t, size_t((IndexTypes(), ::std::experimental::dynamic_extent))...>;
 #endif
 
 namespace detail {


### PR DESCRIPTION
Some compilers can't do CTAD correctly with extents.  Replacing `__make_dynamic_extent<IndexTypes>()` with an explicit expression in the deduction guide's parameter pack expansion works around the issue.

The resulting change means that nothing in mdspan uses `__make_dynamic_extent`.  I've left `__make_dynamic_extent` defined, just in case downstream projects rely on it.

Fixes #177.  @youyu3 