### PR TITLE
Fix build on MacOS: don't use std::aligned_alloc

### DIFF
--- a/examples/aligned_accessor/aligned_accessor.cpp
+++ b/examples/aligned_accessor/aligned_accessor.cpp
@@ -230,7 +230,7 @@ allocate_raw(const std::size_t num_elements)
   // MSVC 19.32 (or "latest" on godbolt.org) does NOT have aligned_alloc,
   // even with /std:c++latest.  Instead, we use MSVC-specific _aligned_malloc.
   ptr = _aligned_malloc(num_bytes, byte_alignment);
-#elif __cplusplus < 201703L || defined(__APPLE__)
+#elif __cplusplus < 201703L || (defined(__APPLE__) && defined(__apple_build_version__))
   // aligned_alloc is a C11 function.  Apple Clang and GCC do not provide it with
   // -std=c++14.  We have coverage for the Windows case (at least with MSVC) above,
   // so we can resort to the POSIX function posix_memalign.

--- a/examples/aligned_accessor/aligned_accessor.cpp
+++ b/examples/aligned_accessor/aligned_accessor.cpp
@@ -231,8 +231,8 @@ allocate_raw(const std::size_t num_elements)
   // even with /std:c++latest.  Instead, we use MSVC-specific _aligned_malloc.
   ptr = _aligned_malloc(num_bytes, byte_alignment);
 #elif __cplusplus < 201703L || defined(__APPLE__)
-  // aligned_alloc is a C11 function.  GCC does not provide it with -std=c++14.
-  // We have coverage for the Windows case (at least with MSVC) above,
+  // aligned_alloc is a C11 function.  Apple Clang and GCC do not provide it with
+  // -std=c++14.  We have coverage for the Windows case (at least with MSVC) above,
   // so we can resort to the POSIX function posix_memalign.
   const int err = posix_memalign(&ptr, byte_alignment, num_bytes);
   if(err != 0) {

--- a/examples/aligned_accessor/aligned_accessor.cpp
+++ b/examples/aligned_accessor/aligned_accessor.cpp
@@ -230,7 +230,7 @@ allocate_raw(const std::size_t num_elements)
   // MSVC 19.32 (or "latest" on godbolt.org) does NOT have aligned_alloc,
   // even with /std:c++latest.  Instead, we use MSVC-specific _aligned_malloc.
   ptr = _aligned_malloc(num_bytes, byte_alignment);
-#elif __cplusplus < 201703L
+#elif __cplusplus < 201703L || defined(__APPLE__)
   // aligned_alloc is a C11 function.  GCC does not provide it with -std=c++14.
   // We have coverage for the Windows case (at least with MSVC) above,
   // so we can resort to the POSIX function posix_memalign.


### PR DESCRIPTION
Apple Clang does not yet offer `std::aligned_alloc`, even with C++14 enabled. (https://forum.qt.io/topic/100242/aligned_alloc-is-not-available-despite-c-17-flag)