### PR TITLE
Make operator implementation standard conformant

### DIFF
--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -247,7 +247,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](SizeTypes... indices) const
   {
-    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(index_type(indices)...));
+    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(static_cast<index_type>(std::move(indices))...));
   }
   #endif
 
@@ -291,7 +291,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](Index idx) const
   {
-    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(index_type(idx)));
+    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(static_cast<index_type>(std::move(idx))));
   }
   #endif
 
@@ -307,7 +307,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(SizeTypes... indices) const
   {
-    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(indices...));
+    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(static_cast<index_type>(std::move(indices))...));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -320,7 +320,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr const_reference operator[](SizeTypes... indices) const noexcept
   {
-    return ctr_[map_(index_type(indices)...)];
+    return ctr_[map_(static_cast<index_type>(std::move(indices))...)];
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -333,7 +333,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](SizeTypes... indices) noexcept
   {
-    return ctr_[map_(index_type(indices)...)];
+    return ctr_[map_(static_cast<index_type>(std::move(indices))...)];
   }
   #endif
 
@@ -377,7 +377,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr const_reference operator()(SizeTypes... indices) const noexcept
   {
-    return ctr_[map_(index_type(indices)...)];
+    return ctr_[map_(static_cast<index_type>(std::move(indices))...)];
   }
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
@@ -389,7 +389,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(SizeTypes... indices) noexcept
   {
-    return ctr_[map_(index_type(indices)...)];
+    return ctr_[map_(static_cast<index_type>(std::move(indices))...)];
   }
 
 #if 0


### PR DESCRIPTION
applies to mdspan and mdarray.

Fixes #186 