### PR TITLE
Added new submdspan implementation

### DIFF
--- a/include/experimental/__p2630_bits/submdspan.hpp
+++ b/include/experimental/__p2630_bits/submdspan.hpp
@@ -9,9 +9,10 @@ constexpr auto
 submdspan(const mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy> &src,
           SliceSpecifiers... slices) {
   const auto sub_mapping_offset = submdspan_mapping(src.mapping(), slices...);
-  return mdspan(src.accessor().offset(src.data_handle(), sub_mapping_offset.offset),
-                sub_mapping_offset.mapping,
-                typename AccessorPolicy::offset_policy(src.accessor()));
+  return mdspan(
+      src.accessor().offset(src.data_handle(), sub_mapping_offset.offset),
+      sub_mapping_offset.mapping,
+      typename AccessorPolicy::offset_policy(src.accessor()));
 }
 } // namespace experimental
 } // namespace std

--- a/include/experimental/__p2630_bits/submdspan.hpp
+++ b/include/experimental/__p2630_bits/submdspan.hpp
@@ -1,0 +1,17 @@
+#include "submdspan_extents.hpp"
+#include "submdspan_mapping.hpp"
+
+namespace std {
+namespace experimental {
+template <class ElementType, class Extents, class LayoutPolicy,
+          class AccessorPolicy, class... SliceSpecifiers>
+constexpr auto
+submdspan(const mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy> &src,
+          SliceSpecifiers... slices) {
+  const auto sub_map_offset = submdspan_mapping(src.mapping(), slices...);
+  return mdspan(src.accessor().offset(src.data_handle(), sub_map_offset.offset),
+                sub_map_offset.map,
+                typename AccessorPolicy::offset_policy(src.accessor()));
+}
+} // namespace experimental
+} // namespace std

--- a/include/experimental/__p2630_bits/submdspan.hpp
+++ b/include/experimental/__p2630_bits/submdspan.hpp
@@ -8,9 +8,9 @@ template <class ElementType, class Extents, class LayoutPolicy,
 constexpr auto
 submdspan(const mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy> &src,
           SliceSpecifiers... slices) {
-  const auto sub_map_offset = submdspan_mapping(src.mapping(), slices...);
-  return mdspan(src.accessor().offset(src.data_handle(), sub_map_offset.offset),
-                sub_map_offset.map,
+  const auto sub_mapping_offset = submdspan_mapping(src.mapping(), slices...);
+  return mdspan(src.accessor().offset(src.data_handle(), sub_mapping_offset.offset),
+                sub_mapping_offset.mapping,
                 typename AccessorPolicy::offset_policy(src.accessor()));
 }
 } // namespace experimental

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -1,0 +1,238 @@
+namespace std {
+namespace experimental {
+
+// Slice Specifier allowing for strides and compile time extent
+template <class OffsetType, class ExtentType, class StrideType>
+struct strided_index_range {
+  using offset_type = OffsetType;
+  using extent_type = ExtentType;
+  using stride_type = StrideType;
+
+  OffsetType offset;
+  ExtentType extent;
+  StrideType stride;
+};
+
+namespace detail {
+
+// Mapping from submapping ranks to srcmapping ranks
+// InvMapRank is gonna be a index_sequence, which we build recursively
+// to contain the mapped indicies.
+template <size_t Counter, class InvMapRank, class... SliceSpecifiers>
+struct inv_map_rank;
+
+// specialization reducing rank by one (i.e. integral slice specifier)
+template <size_t Counter, class Slice, class... SliceSpecifiers,
+          size_t... MapIdxs>
+requires(is_convertible_v<Slice, size_t>) struct inv_map_rank<
+    Counter, index_sequence<MapIdxs...>, Slice, SliceSpecifiers...> {
+  using type = typename inv_map_rank<Counter + 1, index_sequence<MapIdxs...>,
+                                     SliceSpecifiers...>::type;
+};
+
+// specialization for slice specifiers expressing some form of range
+template <size_t Counter, class Slice, class... SliceSpecifiers,
+          size_t... MapIdxs>
+requires(!is_convertible_v<Slice, size_t>) struct inv_map_rank<
+    Counter, index_sequence<MapIdxs...>, Slice, SliceSpecifiers...> {
+  using type =
+      typename inv_map_rank<Counter + 1, index_sequence<MapIdxs..., Counter>,
+                            SliceSpecifiers...>::type;
+};
+
+// final specialziation containing the final index_sequence
+template <size_t Counter, size_t... MapIdxs>
+struct inv_map_rank<Counter, index_sequence<MapIdxs...>> {
+  using type = index_sequence<MapIdxs...>;
+};
+
+// Helper for identifying strided_index_range
+template <class T> struct is_strided_index_range : false_type {};
+
+template <class OffsetType, class ExtentType, class StrideType>
+struct is_strided_index_range<
+    strided_index_range<OffsetType, ExtentType, StrideType>> : true_type {};
+
+// first_of(slice): getting begin of slice specifier range
+template <class Integral>
+requires(is_convertible_v<Integral, size_t>) constexpr Integral
+    first_of(const Integral &i) {
+  return i;
+}
+
+constexpr integral_constant<size_t, 0>
+first_of(const experimental::full_extent_t &) {
+  return integral_constant<size_t, 0>();
+}
+
+template <class Slice>
+requires(
+    is_convertible_v<
+        Slice, tuple<size_t, size_t>>) constexpr auto first_of(const Slice &i) {
+  return get<0>(i);
+}
+
+template <class OffsetType, class ExtentType, class StrideType>
+constexpr OffsetType
+first_of(const strided_index_range<OffsetType, ExtentType, StrideType> &r) {
+  return r.offset;
+}
+
+// last_of(slice): getting end of slice sepcifier range
+template <size_t k, class Extents, class Integral>
+requires(is_convertible_v<Integral, size_t>) constexpr Integral
+    last_of(integral_constant<size_t, k>, const Extents &, const Integral &i) {
+  return i;
+}
+
+template <size_t k, class Extents, class Slice>
+requires(is_convertible_v<Slice, tuple<size_t, size_t>>) constexpr auto last_of(
+    integral_constant<size_t, k>, const Extents &, const Slice &i) {
+  return get<1>(i);
+}
+
+template <size_t k, class Extents>
+constexpr auto last_of(integral_constant<size_t, k>, const Extents &ext,
+                       experimental::full_extent_t) {
+  if constexpr (Extents::static_extent(k) == dynamic_extent) {
+    return ext.extent(k);
+  } else {
+    return integral_constant<size_t, Extents::static_extent(k)>();
+  }
+}
+
+template <size_t k, class Extents, class OffsetType, class ExtentType,
+          class StrideType>
+constexpr OffsetType
+last_of(integral_constant<size_t, k>, const Extents &,
+        const strided_index_range<OffsetType, ExtentType, StrideType> &r) {
+  return r.extent;
+}
+
+// get stride of slices
+template <class T> constexpr auto stride_of(const T &) {
+  return integral_constant<size_t, 1>();
+}
+
+template <class OffsetType, class ExtentType, class StrideType>
+constexpr auto
+stride_of(const strided_index_range<OffsetType, ExtentType, StrideType> &r) {
+  return r.stride;
+}
+
+// divide which can deal with integral constant preservation
+template <class IndexT, class T0, class T1>
+constexpr auto divide(const T0 &v0, const T1 &v1) {
+  return IndexT(v0) / IndexT(v1);
+}
+
+template <class IndexT, class T0, T0 v0, class T1, T1 v1>
+constexpr auto divide(const integral_constant<T0, v0> &,
+                      const integral_constant<T1, v1> &) {
+  return integral_constant<IndexT, v0 / v1>();
+}
+
+// multiply which can deal with integral constant preservation
+template <class IndexT, class T0, class T1>
+constexpr auto multiply(const T0 &v0, const T1 &v1) {
+  return IndexT(v0) * IndexT(v1);
+}
+
+template <class IndexT, class T0, T0 v0, class T1, T1 v1>
+constexpr auto multiply(const integral_constant<T0, v0> &,
+                        const integral_constant<T1, v1> &) {
+  return integral_constant<IndexT, v0 * v1>();
+}
+
+// compute new static extent from range, preserving static knowledge
+template <class Arg0, class Arg1> struct StaticExtent {
+  constexpr static size_t value = std::dynamic_extent;
+};
+
+template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
+struct StaticExtent<std::integral_constant<Integral0, val0>,
+                    std::integral_constant<Integral1, val1>> {
+  constexpr static size_t value = val1 - val0;
+};
+
+// creates new extents through recursive calls to next_extent member function
+// next_extent has different overloads for different types of stride specifiers
+template <size_t K, class Extents, size_t... NewExtents>
+struct extents_constructor {
+  template <class Slice, class... SliceSpecifiers>
+  requires(
+      !is_convertible_v<Slice, size_t> &&
+      !is_strided_index_range<Slice>::
+          value) constexpr static auto next_extent(const Extents &ext,
+                                                   const Slice &sl,
+                                                   SliceSpecifiers... slices) {
+    constexpr size_t new_static_extent =
+        StaticExtent<decltype(first_of(std::declval<Slice>())),
+                     decltype(last_of(
+                         integral_constant<size_t, Extents::rank() - K>(),
+                         std::declval<Extents>(),
+                         std::declval<Slice>()))>::value;
+
+    using next_t =
+        extents_constructor<K - 1, Extents, NewExtents..., new_static_extent>;
+    using index_t = typename Extents::index_type;
+    return next_t::next_extent(
+        ext, slices...,
+        index_t(last_of(integral_constant<size_t, Extents::rank() - K>(), ext,
+                        sl)) -
+            index_t(first_of(sl)));
+  }
+  template <class Slice, class... SliceSpecifiers>
+  requires(is_convertible_v<Slice, size_t>) constexpr static auto next_extent(
+      const Extents &ext, const Slice &, SliceSpecifiers... slices) {
+    using next_t = extents_constructor<K - 1, Extents, NewExtents...>;
+    return next_t::next_extent(ext, slices...);
+  }
+  template <class OffsetType, class ExtentType, class StrideType,
+            class... SliceSpecifiers>
+  constexpr static auto
+  next_extent(const Extents &ext,
+              const strided_index_range<OffsetType, ExtentType, StrideType> &r,
+              SliceSpecifiers... slices) {
+    using index_t = typename Extents::index_type;
+    if constexpr (StaticExtent<ExtentType, StrideType>::value ==
+                  dynamic_extent) {
+      using next_t =
+          extents_constructor<K - 1, Extents, NewExtents..., dynamic_extent>;
+      return next_t::next_extent(ext, slices...,
+                                 divide<index_t>(r.extent, r.stride));
+    } else {
+      constexpr size_t new_static_extent =
+          divide<size_t>(ExtentType(), StrideType());
+      using next_t =
+          extents_constructor<K - 1, Extents, NewExtents..., new_static_extent>;
+      return next_t::next_extent(
+          ext, slices..., index_t(divide<index_t>(ExtentType(), StrideType())));
+    }
+  }
+};
+
+template <class Extents, size_t... NewStaticExtents>
+struct extents_constructor<0, Extents, NewStaticExtents...> {
+
+  template <class... NewExtents>
+  constexpr static auto next_extent(const Extents &, NewExtents... new_exts) {
+    return extents<typename Extents::index_type, NewStaticExtents...>(
+        new_exts...);
+  }
+};
+
+} // namespace detail
+
+// submdspan_extents creates new extents given src extents and submdspan slice
+// specifiers
+template <class IndexType, size_t... Extents, class... SliceSpecifiers>
+constexpr auto submdspan_extents(const extents<IndexType, Extents...> &src_exts,
+                                 SliceSpecifiers... slices) {
+
+  using ext_t = extents<IndexType, Extents...>;
+  return detail::extents_constructor<ext_t::rank(), ext_t>::next_extent(
+      src_exts, slices...);
+}
+} // namespace experimental
+} // namespace std

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -16,12 +16,12 @@ struct strided_index_range {
 namespace detail {
 
 // Mapping from submapping ranks to srcmapping ranks
-// InvMapRank is gonna be a index_sequence, which we build recursively
-// to contain the mapped indicies.
+// InvMapRank is an index_sequence, which we build recursively
+// to contain the mapped indices.
 template <size_t Counter, class InvMapRank, class... SliceSpecifiers>
 struct inv_map_rank;
 
-// specialization reducing rank by one (i.e. integral slice specifier)
+// specialization reducing rank by one (i.e., integral slice specifier)
 template <size_t Counter, class Slice, class... SliceSpecifiers,
           size_t... MapIdxs>
 requires(is_convertible_v<Slice, size_t>) struct inv_map_rank<
@@ -40,7 +40,7 @@ requires(!is_convertible_v<Slice, size_t>) struct inv_map_rank<
                             SliceSpecifiers...>::type;
 };
 
-// final specialziation containing the final index_sequence
+// end of recursion specialization containing the final index_sequence
 template <size_t Counter, size_t... MapIdxs>
 struct inv_map_rank<Counter, index_sequence<MapIdxs...>> {
   using type = index_sequence<MapIdxs...>;
@@ -78,7 +78,7 @@ first_of(const strided_index_range<OffsetType, ExtentType, StrideType> &r) {
   return r.offset;
 }
 
-// last_of(slice): getting end of slice sepcifier range
+// last_of(slice): getting end of slice specifier range
 template <size_t k, class Extents, class Integral>
 requires(is_convertible_v<Integral, size_t>) constexpr Integral
     last_of(integral_constant<size_t, k>, const Extents &, const Integral &i) {

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -173,10 +173,10 @@ struct extents_constructor {
   template <class Slice, class... SliceSpecifiers>
   requires(
       !is_convertible_v<Slice, size_t> &&
-      !is_strided_index_range<Slice>::
-          value) constexpr static auto next_extent(const Extents &ext,
-                                                   const Slice &sl,
-                                                   SliceSpecifiers... slices) {
+      !is_strided_index_range<Slice>::value)
+  constexpr static auto next_extent(const Extents &ext,
+                                    const Slice &sl,
+                                    SliceSpecifiers... slices) {
     constexpr size_t new_static_extent =
         StaticExtentFromRange<decltype(first_of(std::declval<Slice>())),
                      decltype(last_of(
@@ -193,18 +193,21 @@ struct extents_constructor {
                         sl)) -
             index_t(first_of(sl)));
   }
+
   template <class Slice, class... SliceSpecifiers>
-  requires(is_convertible_v<Slice, size_t>) constexpr static auto next_extent(
-      const Extents &ext, const Slice &, SliceSpecifiers... slices) {
+  requires(is_convertible_v<Slice, size_t>)
+  constexpr static auto next_extent(const Extents &ext,
+                                    const Slice &,
+                                    SliceSpecifiers... slices) {
     using next_t = extents_constructor<K - 1, Extents, NewExtents...>;
     return next_t::next_extent(ext, slices...);
   }
+
   template <class OffsetType, class ExtentType, class StrideType,
             class... SliceSpecifiers>
-  constexpr static auto
-  next_extent(const Extents &ext,
-              const strided_index_range<OffsetType, ExtentType, StrideType> &r,
-              SliceSpecifiers... slices) {
+  constexpr static auto next_extent(const Extents &ext,
+                                    const strided_index_range<OffsetType, ExtentType, StrideType> &r,
+                                    SliceSpecifiers... slices) {
     using index_t = typename Extents::index_type;
     using new_static_extent_t = StaticExtentFromStridedRange<ExtentType, StrideType>;
     if constexpr (new_static_extent_t::value == dynamic_extent) {

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -24,8 +24,9 @@ struct inv_map_rank;
 // specialization reducing rank by one (i.e., integral slice specifier)
 template <size_t Counter, class Slice, class... SliceSpecifiers,
           size_t... MapIdxs>
-requires(is_convertible_v<Slice, size_t>) struct inv_map_rank<
-    Counter, index_sequence<MapIdxs...>, Slice, SliceSpecifiers...> {
+  requires(is_convertible_v<Slice, size_t>)
+struct inv_map_rank<Counter, index_sequence<MapIdxs...>, Slice,
+                    SliceSpecifiers...> {
   using type = typename inv_map_rank<Counter + 1, index_sequence<MapIdxs...>,
                                      SliceSpecifiers...>::type;
 };
@@ -33,8 +34,9 @@ requires(is_convertible_v<Slice, size_t>) struct inv_map_rank<
 // specialization for slice specifiers expressing some form of range
 template <size_t Counter, class Slice, class... SliceSpecifiers,
           size_t... MapIdxs>
-requires(!is_convertible_v<Slice, size_t>) struct inv_map_rank<
-    Counter, index_sequence<MapIdxs...>, Slice, SliceSpecifiers...> {
+  requires(!is_convertible_v<Slice, size_t>)
+struct inv_map_rank<Counter, index_sequence<MapIdxs...>, Slice,
+                    SliceSpecifiers...> {
   using type =
       typename inv_map_rank<Counter + 1, index_sequence<MapIdxs..., Counter>,
                             SliceSpecifiers...>::type;
@@ -55,8 +57,8 @@ struct is_strided_index_range<
 
 // first_of(slice): getting begin of slice specifier range
 template <class Integral>
-requires(is_convertible_v<Integral, size_t>) constexpr Integral
-    first_of(const Integral &i) {
+  requires(is_convertible_v<Integral, size_t>)
+constexpr Integral first_of(const Integral &i) {
   return i;
 }
 
@@ -66,9 +68,8 @@ first_of(const experimental::full_extent_t &) {
 }
 
 template <class Slice>
-requires(
-    is_convertible_v<
-        Slice, tuple<size_t, size_t>>) constexpr auto first_of(const Slice &i) {
+  requires(is_convertible_v<Slice, tuple<size_t, size_t>>)
+constexpr auto first_of(const Slice &i) {
   return get<0>(i);
 }
 
@@ -80,14 +81,16 @@ first_of(const strided_index_range<OffsetType, ExtentType, StrideType> &r) {
 
 // last_of(slice): getting end of slice specifier range
 template <size_t k, class Extents, class Integral>
-requires(is_convertible_v<Integral, size_t>) constexpr Integral
+  requires(is_convertible_v<Integral, size_t>)
+constexpr Integral
     last_of(integral_constant<size_t, k>, const Extents &, const Integral &i) {
   return i;
 }
 
 template <size_t k, class Extents, class Slice>
-requires(is_convertible_v<Slice, tuple<size_t, size_t>>) constexpr auto last_of(
-    integral_constant<size_t, k>, const Extents &, const Slice &i) {
+  requires(is_convertible_v<Slice, tuple<size_t, size_t>>)
+constexpr auto last_of(integral_constant<size_t, k>, const Extents &,
+                       const Slice &i) {
   return get<1>(i);
 }
 
@@ -151,19 +154,20 @@ template <class Arg0, class Arg1> struct StaticExtentFromRange {
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromRange<std::integral_constant<Integral0, val0>,
-                    std::integral_constant<Integral1, val1>> {
+                             std::integral_constant<Integral1, val1>> {
   constexpr static size_t value = val1 - val0;
 };
 
-// compute new static extent from strided_index_range, preserving static knowledge
+// compute new static extent from strided_index_range, preserving static
+// knowledge
 template <class Arg0, class Arg1> struct StaticExtentFromStridedRange {
   constexpr static size_t value = std::dynamic_extent;
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromStridedRange<std::integral_constant<Integral0, val0>,
-                    std::integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val0>0?1 + (val0-1) / val1:0;
+                                    std::integral_constant<Integral1, val1>> {
+  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / val1 : 0;
 };
 
 // creates new extents through recursive calls to next_extent member function
@@ -171,16 +175,13 @@ struct StaticExtentFromStridedRange<std::integral_constant<Integral0, val0>,
 template <size_t K, class Extents, size_t... NewExtents>
 struct extents_constructor {
   template <class Slice, class... SliceSpecifiers>
-  requires(
-      !is_convertible_v<Slice, size_t> &&
-      !is_strided_index_range<Slice>::value)
-  constexpr static auto next_extent(const Extents &ext,
-                                    const Slice &sl,
+    requires(!is_convertible_v<Slice, size_t> &&
+             !is_strided_index_range<Slice>::value)
+  constexpr static auto next_extent(const Extents &ext, const Slice &sl,
                                     SliceSpecifiers... slices) {
-    constexpr size_t new_static_extent =
-        StaticExtentFromRange<decltype(first_of(std::declval<Slice>())),
-                     decltype(last_of(
-                         integral_constant<size_t, Extents::rank() - K>(),
+    constexpr size_t new_static_extent = StaticExtentFromRange<
+        decltype(first_of(std::declval<Slice>())),
+        decltype(last_of(integral_constant<size_t, Extents::rank() - K>(),
                          std::declval<Extents>(),
                          std::declval<Slice>()))>::value;
 
@@ -195,9 +196,8 @@ struct extents_constructor {
   }
 
   template <class Slice, class... SliceSpecifiers>
-  requires(is_convertible_v<Slice, size_t>)
-  constexpr static auto next_extent(const Extents &ext,
-                                    const Slice &,
+    requires(is_convertible_v<Slice, size_t>)
+  constexpr static auto next_extent(const Extents &ext, const Slice &,
                                     SliceSpecifiers... slices) {
     using next_t = extents_constructor<K - 1, Extents, NewExtents...>;
     return next_t::next_extent(ext, slices...);
@@ -205,16 +205,19 @@ struct extents_constructor {
 
   template <class OffsetType, class ExtentType, class StrideType,
             class... SliceSpecifiers>
-  constexpr static auto next_extent(const Extents &ext,
-                                    const strided_index_range<OffsetType, ExtentType, StrideType> &r,
-                                    SliceSpecifiers... slices) {
+  constexpr static auto
+  next_extent(const Extents &ext,
+              const strided_index_range<OffsetType, ExtentType, StrideType> &r,
+              SliceSpecifiers... slices) {
     using index_t = typename Extents::index_type;
-    using new_static_extent_t = StaticExtentFromStridedRange<ExtentType, StrideType>;
+    using new_static_extent_t =
+        StaticExtentFromStridedRange<ExtentType, StrideType>;
     if constexpr (new_static_extent_t::value == dynamic_extent) {
       using next_t =
           extents_constructor<K - 1, Extents, NewExtents..., dynamic_extent>;
-      return next_t::next_extent(ext, slices...,
-                                 r.extent>0?1+divide<index_t>(r.extent-1, r.stride):0);
+      return next_t::next_extent(
+          ext, slices...,
+          r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, r.stride) : 0);
     } else {
       constexpr size_t new_static_extent = new_static_extent_t::value;
       using next_t =

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -211,7 +211,7 @@ struct extents_constructor {
       using next_t =
           extents_constructor<K - 1, Extents, NewExtents..., dynamic_extent>;
       return next_t::next_extent(ext, slices...,
-                                 divide<index_t>(r.extent, r.stride));
+                                 r.extent>0?1+divide<index_t>(r.extent-1, r.stride):0);
     } else {
       constexpr size_t new_static_extent = new_static_extent_t::value;
       using next_t =

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -1,4 +1,4 @@
-
+#include <tuple>
 namespace std {
 namespace experimental {
 

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -6,19 +6,19 @@ namespace experimental {
 // Return type of submdspan_mapping overloads
 //******************************************
 template <class Mapping> struct mapping_offset {
-  Mapping map;
+  Mapping mapping;
   size_t offset;
 };
 
 namespace detail {
 // constructs sub strides
 template <class SrcMapping, class ... slice_strides, size_t... InvMapIdxs>
-constexpr auto construct_sub_strides(const SrcMapping &src_map,
+constexpr auto construct_sub_strides(const SrcMapping &src_mapping,
                                      index_sequence<InvMapIdxs...>,
                                      const tuple<slice_strides...>& slices_stride_factor) {
   using index_type = typename SrcMapping::index_type;
   return array<typename SrcMapping::index_type, sizeof...(InvMapIdxs)>{
-      (static_cast<index_type>(src_map.stride(InvMapIdxs)) * static_cast<index_type>(get<InvMapIdxs>(slices_stride_factor)))...};
+      (static_cast<index_type>(src_mapping.stride(InvMapIdxs)) * static_cast<index_type>(get<InvMapIdxs>(slices_stride_factor)))...};
 }
 } // namespace detail
 
@@ -63,19 +63,19 @@ submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
       SliceSpecifiers...>::value;
   using dst_layout_t =
       conditional_t<preserve_layout, layout_left, layout_stride>;
-  using dst_map_t = typename dst_layout_t::template mapping<dst_ext_t>;
+  using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
   if constexpr (is_same_v<dst_layout_t, layout_left>) {
     // layout_left case
-    return mapping_offset<dst_map_t>{
-        dst_map_t(dst_ext),
+    return mapping_offset<dst_mapping_t>{
+        dst_mapping_t(dst_ext),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
     // layout_stride case
     using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
                                                     SliceSpecifiers...>::type;
-    return mapping_offset<dst_map_t>{
-        dst_map_t(
+    return mapping_offset<dst_mapping_t>{
+        dst_mapping_t(
             dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t(), tuple{detail::stride_of(slices)...})),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   }
@@ -123,19 +123,19 @@ submdspan_mapping(const layout_right::mapping<Extents> &src_mapping,
       SliceSpecifiers...>::value;
   using dst_layout_t =
       conditional_t<preserve_layout, layout_right, layout_stride>;
-  using dst_map_t = typename dst_layout_t::template mapping<dst_ext_t>;
+  using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
   if constexpr (is_same_v<dst_layout_t, layout_right>) {
     // layout_right case
-    return mapping_offset<dst_map_t>{
-        dst_map_t(dst_ext),
+    return mapping_offset<dst_mapping_t>{
+        dst_mapping_t(dst_ext),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
     // layout_stride case
     using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
                                                     SliceSpecifiers...>::type;
-    return mapping_offset<dst_map_t>{
-        dst_map_t(
+    return mapping_offset<dst_mapping_t>{
+        dst_mapping_t(
             dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t(), tuple{detail::stride_of(slices)...})),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   }
@@ -152,9 +152,9 @@ submdspan_mapping(const layout_stride::mapping<Extents> &src_mapping,
   using dst_ext_t = decltype(dst_ext);
   using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
                                                   SliceSpecifiers...>::type;
-  using dst_map_t = typename layout_stride::template mapping<dst_ext_t>;
-  return mapping_offset<dst_map_t>{
-      dst_map_t(
+  using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
+  return mapping_offset<dst_mapping_t>{
+      dst_mapping_t(
           dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t(), tuple{detail::stride_of(slices)...})),
       static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
 }

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -153,7 +153,7 @@ submdspan_mapping(const layout_stride::mapping<Extents> &src_mapping,
   using dst_map_t = typename layout_stride::template mapping<dst_ext_t>;
   return mapping_offset<dst_map_t>{
       dst_map_t(
-          dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t())),
+          dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t(),array{stride_of(slices)...}),
       static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
 }
 } // namespace experimental

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -61,18 +61,19 @@ submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
       SliceSpecifiers...>::value;
   using dst_layout_t =
       conditional_t<preserve_layout, layout_left, layout_stride>;
+  using dst_map_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
   if constexpr (is_same_v<dst_layout_t, layout_left>) {
-    // return layout_left again
-    return mapping_offset{
-        typename dst_layout_t::template mapping<dst_ext_t>(dst_ext),
+    // layout_left case
+    return mapping_offset<dst_map_t>{
+        dst_map_t(dst_ext),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
-    // return layout stride: need inv_mapping to get strides
+    // layout_stride case
     using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
                                                     SliceSpecifiers...>::type;
-    return mapping_offset{
-        typename dst_layout_t::template mapping<dst_ext_t>(
+    return mapping_offset<dst_map_t>{
+        dst_map_t(
             dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t())),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   }
@@ -120,18 +121,19 @@ submdspan_mapping(const layout_right::mapping<Extents> &src_mapping,
       SliceSpecifiers...>::value;
   using dst_layout_t =
       conditional_t<preserve_layout, layout_right, layout_stride>;
+  using dst_map_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
   if constexpr (is_same_v<dst_layout_t, layout_right>) {
     // layout_right case
-    return mapping_offset{
-        typename dst_layout_t::template mapping<dst_ext_t>(dst_ext),
+    return mapping_offset<dst_map_t>{
+        dst_map_t(dst_ext),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
     // layout_stride case
     using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
                                                     SliceSpecifiers...>::type;
-    return mapping_offset{
-        typename dst_layout_t::template mapping<dst_ext_t>(
+    return mapping_offset<dst_map_t>{
+        dst_map_t(
             dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t())),
         static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   }
@@ -148,8 +150,9 @@ submdspan_mapping(const layout_stride::mapping<Extents> &src_mapping,
   using dst_ext_t = decltype(dst_ext);
   using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
                                                   SliceSpecifiers...>::type;
-  return mapping_offset{
-      layout_stride::mapping<dst_ext_t>(
+  using dst_map_t = typename layout_stride::template mapping<dst_ext_t>;
+  return mapping_offset<dst_map_t>{
+      dst_map_t(
           dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t())),
       static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
 }

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -1,0 +1,157 @@
+
+namespace std {
+namespace experimental {
+
+//******************************************
+// Return type of submdspan_mapping overloads
+//******************************************
+template <class Mapping> struct mapping_offset {
+  Mapping map;
+  size_t offset;
+};
+
+namespace detail {
+// constructs sub strides
+template <class SrcMapping, size_t... InvMapIdxs>
+constexpr auto construct_sub_strides(const SrcMapping &src_map,
+                                     index_sequence<InvMapIdxs...>) {
+  return array<typename SrcMapping::index_type, sizeof...(InvMapIdxs)>{
+      src_map.stride(InvMapIdxs)...};
+}
+} // namespace detail
+
+//**********************************
+// layout_left submdspan_mapping
+//*********************************
+namespace detail {
+
+// Figure out whether to preserve layout_left
+template <class IndexSequence, size_t SubRank, class... SliceSpecifiers>
+struct preserve_layout_left_mapping;
+
+template <class... SliceSpecifiers, size_t... Idx, size_t SubRank>
+struct preserve_layout_left_mapping<index_sequence<Idx...>, SubRank,
+                                    SliceSpecifiers...> {
+  constexpr static bool value =
+      (SubRank == 0) ||
+      ((Idx < SubRank - 1
+            ? is_same_v<SliceSpecifiers, full_extent_t>
+            : (Idx == SubRank - 1 ? is_same_v<SliceSpecifiers, full_extent_t> ||
+                                        is_convertible_v<SliceSpecifiers,
+                                                         tuple<size_t, size_t>>
+                                  : true)) &&
+       ...);
+};
+} // namespace detail
+
+// Actual submdspan mapping call
+template <class Extents, class... SliceSpecifiers>
+constexpr auto
+submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
+                  SliceSpecifiers... slices) {
+
+  // compute sub extents
+  using src_ext_t = Extents;
+  auto dst_ext = submdspan_extents(src_mapping.extents(), slices...);
+  using dst_ext_t = decltype(dst_ext);
+
+  // figure out sub layout type
+  constexpr bool preserve_layout = detail::preserve_layout_left_mapping<
+      decltype(make_index_sequence<src_ext_t::rank()>()), dst_ext_t::rank(),
+      SliceSpecifiers...>::value;
+  using dst_layout_t =
+      conditional_t<preserve_layout, layout_left, layout_stride>;
+
+  if constexpr (is_same_v<dst_layout_t, layout_left>) {
+    // return layout_left again
+    return mapping_offset{
+        typename dst_layout_t::template mapping<dst_ext_t>(dst_ext),
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+  } else {
+    // return layout stride: need inv_mapping to get strides
+    using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
+                                                    SliceSpecifiers...>::type;
+    return mapping_offset{
+        typename dst_layout_t::template mapping<dst_ext_t>(
+            dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t())),
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+  }
+}
+
+//**********************************
+// layout_right submdspan_mapping
+//*********************************
+namespace detail {
+
+// Figure out whether to preserve layout_left
+template <class IndexSequence, size_t SubRank, class... SliceSpecifiers>
+struct preserve_layout_right_mapping;
+
+template <class... SliceSpecifiers, size_t... Idx, size_t SubRank>
+struct preserve_layout_right_mapping<index_sequence<Idx...>, SubRank,
+                                     SliceSpecifiers...> {
+  constexpr static size_t SrcRank = sizeof...(SliceSpecifiers);
+  constexpr static bool value =
+      (SubRank == 0) ||
+      ((Idx > SrcRank - SubRank
+            ? is_same_v<SliceSpecifiers, full_extent_t>
+            : (Idx == SrcRank - SubRank
+                   ? is_same_v<SliceSpecifiers, full_extent_t> ||
+                         is_convertible_v<SliceSpecifiers,
+                                          tuple<size_t, size_t>>
+                   : true)) &&
+       ...);
+};
+} // namespace detail
+
+template <class Extents, class... SliceSpecifiers>
+constexpr auto
+submdspan_mapping(const layout_right::mapping<Extents> &src_mapping,
+                  SliceSpecifiers... slices) {
+
+  // get sub extents
+  using src_ext_t = Extents;
+  auto dst_ext = submdspan_extents(src_mapping.extents(), slices...);
+  using dst_ext_t = decltype(dst_ext);
+
+  // determine new layout type
+  constexpr bool preserve_layout = detail::preserve_layout_right_mapping<
+      decltype(make_index_sequence<src_ext_t::rank()>()), dst_ext_t::rank(),
+      SliceSpecifiers...>::value;
+  using dst_layout_t =
+      conditional_t<preserve_layout, layout_right, layout_stride>;
+
+  if constexpr (is_same_v<dst_layout_t, layout_right>) {
+    // layout_right case
+    return mapping_offset{
+        typename dst_layout_t::template mapping<dst_ext_t>(dst_ext),
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+  } else {
+    // layout_stride case
+    using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
+                                                    SliceSpecifiers...>::type;
+    return mapping_offset{
+        typename dst_layout_t::template mapping<dst_ext_t>(
+            dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t())),
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+  }
+}
+
+//**********************************
+// layout_stride submdspan_mapping
+//*********************************
+template <class Extents, class... SliceSpecifiers>
+constexpr auto
+submdspan_mapping(const layout_stride::mapping<Extents> &src_mapping,
+                  SliceSpecifiers... slices) {
+  auto dst_ext = submdspan_extents(src_mapping.extents(), slices...);
+  using dst_ext_t = decltype(dst_ext);
+  using inv_map_t = typename detail::inv_map_rank<0, index_sequence<>,
+                                                  SliceSpecifiers...>::type;
+  return mapping_offset{
+      layout_stride::mapping<dst_ext_t>(
+          dst_ext, detail::construct_sub_strides(src_mapping, inv_map_t())),
+      static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+}
+} // namespace experimental
+} // namespace std

--- a/include/experimental/mdspan
+++ b/include/experimental/mdspan
@@ -53,4 +53,5 @@
 #include "__p0009_bits/layout_right.hpp"
 #include "__p0009_bits/macros.hpp"
 #include "__p0009_bits/static_array.hpp"
-#include "__p0009_bits/submdspan.hpp"
+//#include "__p0009_bits/submdspan.hpp"
+#include "__p2630_bits/submdspan.hpp"

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -183,7 +183,7 @@ struct TestSubMDSpan<
     return std::pair<int,int>(1,3);
   }
   static stdex::strided_index_range<int,int,int> create_slice_arg(stdex::strided_index_range<int,int,int>) {
-    return stdex::strided_index_range<int,int,int>(1,3,2);
+    return stdex::strided_index_range<int,int,int>{1,3,2};
   }
   static stdex::full_extent_t create_slice_arg(stdex::full_extent_t) {
     return stdex::full_extent;

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -148,11 +148,17 @@ using submdspan_test_types =
     , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,1>, stdex::strided_index_range<int,int,int>, int>
     , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::full_extent_t>
     , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::strided_index_range<int,int,int>>
-    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::strided_index_range<int,int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, stdex::strided_index_range<int,int,int>, std::pair<int,int>>
     , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, stdex::strided_index_range<int,int,int>, stdex::strided_index_range<int,int,int>>
     , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,6,dyn,8>, stdex::full_extent_t, int, std::pair<int,int>, int, int, stdex::full_extent_t>
     , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,4,dyn,7>, int, stdex::full_extent_t, std::pair<int,int>, int, stdex::full_extent_t, int>
     // layout_right to layout_stride
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::dextents<size_t,1>,          args_t<10>,          stdex::dextents<size_t,1>, stdex::strided_index_range<int,int,int>>
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,1>, stdex::strided_index_range<int,int,int>, int>
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, stdex::full_extent_t, std::pair<int,int>>
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::strided_index_range<int,int,int>>
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, stdex::strided_index_range<int,int,int>, std::pair<int,int>>
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, stdex::strided_index_range<int,int,int>, stdex::strided_index_range<int,int,int>>
     , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,6,dyn,8>, stdex::full_extent_t, int, std::pair<int,int>, int, int, stdex::full_extent_t>
     , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,4,dyn,7>, int, stdex::full_extent_t, std::pair<int,int>, int, stdex::full_extent_t, int>
     >;

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -143,7 +143,16 @@ using submdspan_test_types =
     , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, stdex::extents<size_t,dyn,7,8>, int, int, int, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
     , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, stdex::extents<size_t,dyn,8>, int, int, int, int, std::pair<int,int>, stdex::full_extent_t>
     , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, stdex::extents<size_t,8>, int, int, int, int, int, stdex::full_extent_t>
-
+    // LayoutLeft to LayoutStride
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,1>,          args_t<10>,          stdex::dextents<size_t,1>, stdex::strided_index_range<int,int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,1>, stdex::strided_index_range<int,int,int>, int>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::strided_index_range<int,int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::strided_index_range<int,int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::dextents<size_t,2>,          args_t<10,20>,       stdex::dextents<size_t,2>, stdex::strided_index_range<int,int,int>, stdex::strided_index_range<int,int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,6,dyn,8>, stdex::full_extent_t, int, std::pair<int,int>, int, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_left, stdex::layout_stride,  stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,4,dyn,7>, int, stdex::full_extent_t, std::pair<int,int>, int, stdex::full_extent_t, int>
+    // layout_right to layout_stride
     , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,6,dyn,8>, stdex::full_extent_t, int, std::pair<int,int>, int, int, stdex::full_extent_t>
     , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,4,dyn,7>, int, stdex::full_extent_t, std::pair<int,int>, int, stdex::full_extent_t, int>
     >;
@@ -173,6 +182,9 @@ struct TestSubMDSpan<
   static std::pair<int,int> create_slice_arg(std::pair<int,int>) {
     return std::pair<int,int>(1,3);
   }
+  static stdex::strided_index_range<int,int,int> create_slice_arg(stdex::strided_index_range<int,int,int>) {
+    return stdex::strided_index_range<int,int,int>(1,3,2);
+  }
   static stdex::full_extent_t create_slice_arg(stdex::full_extent_t) {
     return stdex::full_extent;
   }
@@ -184,6 +196,10 @@ struct TestSubMDSpan<
   template<class SrcExtents, class SubExtents, class ... SliceArgs>
   static bool match_expected_extents(int src_idx, int sub_idx, SrcExtents src_ext, SubExtents sub_ext, std::pair<int,int> p, SliceArgs ... slices) {
     return (sub_ext.extent(sub_idx)==p.second-p.first) && match_expected_extents(++src_idx, ++sub_idx, src_ext, sub_ext, slices...);
+  }
+  template<class SrcExtents, class SubExtents, class ... SliceArgs>
+  static bool match_expected_extents(int src_idx, int sub_idx, SrcExtents src_ext, SubExtents sub_ext, stdex::strided_index_range<int,int,int> p, SliceArgs ... slices) {
+    return (sub_ext.extent(sub_idx)==(p.extent+p.stride-1)/p.stride) && match_expected_extents(++src_idx, ++sub_idx, src_ext, sub_ext, slices...);
   }
   template<class SrcExtents, class SubExtents, class ... SliceArgs>
   static bool match_expected_extents(int src_idx, int sub_idx, SrcExtents src_ext, SubExtents sub_ext, stdex::full_extent_t, SliceArgs ... slices) {

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -18,6 +18,8 @@
 
 #include <gtest/gtest.h>
 
+#include <utility>
+
 namespace stdex = std::experimental;
 _MDSPAN_INLINE_VARIABLE constexpr auto dyn = stdex::dynamic_extent;
 
@@ -95,61 +97,65 @@ TEST(TestSubmdspanLayoutRightStaticSizedTuples, test_submdspan_layout_right_stat
 //template<class LayoutOrg, class LayoutSub, class ExtentsOrg, class ExtentsSub, class ... SubArgs>
 
 
+template<size_t ... Args>
+using args_t = std::index_sequence<Args...>;
+
 using submdspan_test_types =
   ::testing::Types<
       // LayoutLeft to LayoutLeft
-      std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,1>,stdex::dextents<size_t,1>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,1>,stdex::dextents<size_t,1>, std::pair<int,int>>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,1>,stdex::dextents<size_t,0>, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,2>,stdex::dextents<size_t,2>, stdex::full_extent_t, stdex::full_extent_t>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,2>,stdex::dextents<size_t,2>, stdex::full_extent_t, std::pair<int,int>>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,2>,stdex::dextents<size_t,1>, stdex::full_extent_t, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>,stdex::dextents<size_t,3>, stdex::full_extent_t, stdex::full_extent_t, std::pair<int,int>>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>,stdex::dextents<size_t,2>, stdex::full_extent_t, std::pair<int,int>, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>,stdex::dextents<size_t,1>, stdex::full_extent_t, int, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>,stdex::dextents<size_t,1>, std::pair<int,int>, int, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>,stdex::dextents<size_t,3>, stdex::full_extent_t, stdex::full_extent_t, std::pair<int,int>, int, int, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>,stdex::dextents<size_t,2>, stdex::full_extent_t, std::pair<int,int>, int, int, int, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>,stdex::dextents<size_t,1>, stdex::full_extent_t, int, int, int ,int, int>
-    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>,stdex::dextents<size_t,1>, std::pair<int,int>, int, int, int, int, int>
+      std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,1>, args_t<10>,          stdex::dextents<size_t,1>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,1>, args_t<10>,          stdex::dextents<size_t,1>, std::pair<int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,1>, args_t<10>,          stdex::dextents<size_t,0>, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,2>, args_t<10,20>,       stdex::dextents<size_t,2>, stdex::full_extent_t, stdex::full_extent_t>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,2>, args_t<10,20>,       stdex::dextents<size_t,2>, stdex::full_extent_t, std::pair<int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,2>, args_t<10,20>,       stdex::dextents<size_t,1>, stdex::full_extent_t, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>, args_t<10,20,30>,    stdex::dextents<size_t,3>, stdex::full_extent_t, stdex::full_extent_t, std::pair<int,int>>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>, args_t<10,20,30>,    stdex::dextents<size_t,2>, stdex::full_extent_t, std::pair<int,int>, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>, args_t<10,20,30>,    stdex::dextents<size_t,1>, stdex::full_extent_t, int, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,3>, args_t<10,20,30>,    stdex::dextents<size_t,1>, std::pair<int,int>, int, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>, args_t<6,4,5,6,7,8>, stdex::dextents<size_t,3>, stdex::full_extent_t, stdex::full_extent_t, std::pair<int,int>, int, int, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>, args_t<6,4,5,6,7,8>, stdex::dextents<size_t,2>, stdex::full_extent_t, std::pair<int,int>, int, int, int, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>, args_t<6,4,5,6,7,8>, stdex::dextents<size_t,1>, stdex::full_extent_t, int, int, int ,int, int>
+    , std::tuple<stdex::layout_left, stdex::layout_left, stdex::dextents<size_t,6>, args_t<6,4,5,6,7,8>, stdex::dextents<size_t,1>, std::pair<int,int>, int, int, int, int, int>
     // LayoutRight to LayoutRight
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,1>,stdex::dextents<size_t,1>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,1>,stdex::dextents<size_t,1>, std::pair<int,int>>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,1>,stdex::dextents<size_t,0>, int>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,2>,stdex::dextents<size_t,2>, stdex::full_extent_t, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,2>,stdex::dextents<size_t,2>, std::pair<int,int>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,2>,stdex::dextents<size_t,1>, int, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,3>,stdex::dextents<size_t,3>, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,3>,stdex::dextents<size_t,2>, int, std::pair<int,int>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,3>,stdex::dextents<size_t,1>, int, int, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,6>,stdex::dextents<size_t,3>, int, int, int, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,6>,stdex::dextents<size_t,2>, int, int, int, int, std::pair<int,int>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,6>,stdex::dextents<size_t,1>, int, int, int, int, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,1>, args_t<10>,          stdex::dextents<size_t,1>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,1>, args_t<10>,          stdex::dextents<size_t,1>, std::pair<int,int>>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,1>, args_t<10>,          stdex::dextents<size_t,0>, int>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,2>, args_t<10,20>,       stdex::dextents<size_t,2>, stdex::full_extent_t, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,2>, args_t<10,20>,       stdex::dextents<size_t,2>, std::pair<int,int>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,2>, args_t<10,20>,       stdex::dextents<size_t,1>, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,3>, args_t<10,20,30>,    stdex::dextents<size_t,3>, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,3>, args_t<10,20,30>,    stdex::dextents<size_t,2>, int, std::pair<int,int>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,3>, args_t<10,20,30>,    stdex::dextents<size_t,1>, int, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,6>, args_t<6,4,5,6,7,8>, stdex::dextents<size_t,3>, int, int, int, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,6>, args_t<6,4,5,6,7,8>, stdex::dextents<size_t,2>, int, int, int, int, std::pair<int,int>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::dextents<size_t,6>, args_t<6,4,5,6,7,8>, stdex::dextents<size_t,1>, int, int, int, int, int, stdex::full_extent_t>
     // LayoutRight to LayoutRight Check Extents Preservation
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1>,stdex::extents<size_t,1>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1>,stdex::extents<size_t,dyn>, std::pair<int,int>>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1>,stdex::extents<size_t>, int>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2>,stdex::extents<size_t,1,2>, stdex::full_extent_t, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2>,stdex::extents<size_t,dyn,2>, std::pair<int,int>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2>,stdex::extents<size_t,2>, int, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2,3>,stdex::extents<size_t,dyn,2,3>, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2,3>,stdex::extents<size_t,dyn,3>, int, std::pair<int,int>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2,3>,stdex::extents<size_t,3>, int, int, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2,3,4,5,6>,stdex::extents<size_t,dyn,5,6>, int, int, int, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2,3,4,5,6>,stdex::extents<size_t,dyn,6>, int, int, int, int, std::pair<int,int>, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,1,2,3,4,5,6>,stdex::extents<size_t,6>, int, int, int, int, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10>,           args_t<10>,          stdex::extents<size_t,10>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10>,           args_t<10>,          stdex::extents<size_t,dyn>, std::pair<int,int>>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10>,           args_t<10>,          stdex::extents<size_t>, int>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10,20>,        args_t<10,20>,       stdex::extents<size_t,10,20>, stdex::full_extent_t, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10,20>,        args_t<10,20>,       stdex::extents<size_t,dyn,20>, std::pair<int,int>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10,20>,        args_t<10,20>,       stdex::extents<size_t,20>, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10,20,30>,     args_t<10,20,30>,    stdex::extents<size_t,dyn,20,30>, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10,20,30>,     args_t<10,20,30>,    stdex::extents<size_t,dyn,30>, int, std::pair<int,int>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,10,20,30>,     args_t<10,20,30>,    stdex::extents<size_t,30>, int, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, stdex::extents<size_t,dyn,7,8>, int, int, int, std::pair<int,int>, stdex::full_extent_t, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, stdex::extents<size_t,dyn,8>, int, int, int, int, std::pair<int,int>, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_right, stdex::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, stdex::extents<size_t,8>, int, int, int, int, int, stdex::full_extent_t>
 
-    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,1,2,3,4,5,6>,stdex::extents<size_t,1,dyn,6>, stdex::full_extent_t, int, std::pair<int,int>, int, int, stdex::full_extent_t>
-    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,1,2,3,4,5,6>,stdex::extents<size_t,2,dyn,5>, int, stdex::full_extent_t, std::pair<int,int>, int, stdex::full_extent_t, int>
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,6,dyn,8>, stdex::full_extent_t, int, std::pair<int,int>, int, int, stdex::full_extent_t>
+    , std::tuple<stdex::layout_right, stdex::layout_stride, stdex::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, stdex::extents<size_t,4,dyn,7>, int, stdex::full_extent_t, std::pair<int,int>, int, stdex::full_extent_t, int>
     >;
 
 template<class T> struct TestSubMDSpan;
 
-template<class LayoutOrg, class LayoutSub, class ExtentsOrg, class ExtentsSub, class ... SubArgs>
+template<class LayoutOrg, class LayoutSub, class ExtentsOrg, class ExtentsSub, class ... SubArgs, size_t ... ConstrArgs>
 struct TestSubMDSpan<
   std::tuple<LayoutOrg,
              LayoutSub,
              ExtentsOrg,
+	     std::index_sequence<ConstrArgs...>,
              ExtentsSub,
              SubArgs...>>
   : public ::testing::Test {
@@ -161,6 +167,40 @@ struct TestSubMDSpan<
   using mds_sub_deduced_t = decltype(stdex::submdspan(mds_org_t(nullptr, map_t()), SubArgs()...));
   using sub_args_t = std::tuple<SubArgs...>;
 
+  static int create_slice_arg(int) {
+    return 2;
+  }
+  static std::pair<int,int> create_slice_arg(std::pair<int,int>) {
+    return std::pair<int,int>(1,3);
+  }
+  static stdex::full_extent_t create_slice_arg(stdex::full_extent_t) {
+    return stdex::full_extent;
+  }
+
+  template<class SrcExtents, class SubExtents, class ... SliceArgs>
+  static bool match_expected_extents(int src_idx, int sub_idx, SrcExtents src_ext, SubExtents sub_ext, int, SliceArgs ... slices) {
+    return match_expected_extents(++src_idx, sub_idx, src_ext, sub_ext, slices...);
+  }
+  template<class SrcExtents, class SubExtents, class ... SliceArgs>
+  static bool match_expected_extents(int src_idx, int sub_idx, SrcExtents src_ext, SubExtents sub_ext, std::pair<int,int> p, SliceArgs ... slices) {
+    return (sub_ext.extent(sub_idx)==p.second-p.first) && match_expected_extents(++src_idx, ++sub_idx, src_ext, sub_ext, slices...);
+  }
+  template<class SrcExtents, class SubExtents, class ... SliceArgs>
+  static bool match_expected_extents(int src_idx, int sub_idx, SrcExtents src_ext, SubExtents sub_ext, stdex::full_extent_t, SliceArgs ... slices) {
+    return (sub_ext.extent(sub_idx)==src_ext.extent(src_idx)) && match_expected_extents(++src_idx, ++sub_idx, src_ext, sub_ext, slices...);
+  }
+  template<class SrcExtents, class SubExtents>
+  static bool match_expected_extents(int, int, SrcExtents, SubExtents) { return true; }
+
+  static void run() {
+    typename mds_org_t::mapping_type map(typename mds_org_t::extents_type(ConstrArgs...));
+    int data[25000];
+    mds_org_t src(data, map);
+    auto sub = stdex::submdspan(src, create_slice_arg(SubArgs())...);
+    bool match = match_expected_extents(0, 0, src.extents(), sub.extents(), create_slice_arg(SubArgs())...);
+    EXPECT_TRUE(match);
+  }
+
 };
 
 
@@ -170,5 +210,5 @@ TYPED_TEST(TestSubMDSpan, submdspan_return_type) {
   static_assert(std::is_same<typename TestFixture::mds_sub_t,
                              typename TestFixture::mds_sub_deduced_t>::value,
                 "SubMDSpan: wrong return type");
-
+  TestFixture::run();
 }


### PR DESCRIPTION
This uses ADL customization point design.

It doesn't use the backward compatibility stuff yet to improve readability for an initial review, i.e. it will only work on host with C++20 and C++23.

It also doesn't implement yet correct stride calculation when using strided_index_range