### PR TITLE
Address issue #229 and fix missing noexcept

### DIFF
--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -116,18 +116,20 @@ class layout_left::mapping {
     )
     MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
-    mapping(layout_stride::mapping<OtherExtents> const& other) // NOLINT(google-explicit-constructor)
+    mapping(layout_stride::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
       :__extents(other.extents())
     {
        /*
         * TODO: check precondition
         * other.required_span_size() is a representable value of type index_type
         */
-       #ifndef __CUDA_ARCH__
-       size_t stride = 1;
+       #if !defined(_MDSPAN_HAS_CUDA) && !defined(_MDSPAN_HAS_HIP) && !defined(NDEBUG)
+       index_type stride = 1;
        for(rank_type r=0; r<__extents.rank(); r++) {
-         if(stride != other.stride(r))
+         if(stride != static_cast<index_type>(other.stride(r))) {
+           // Note this throw will lead to a terminate if triggered since this function is marked noexcept
            throw std::runtime_error("Assigning layout_stride to layout_left with invalid strides.");
+         }
          stride *= __extents.extent(r);
        }
        #endif


### PR DESCRIPTION
The conversion operators from layout_stride for both layout_left and layout_right were missing a static_cast and also were not marked noexcept. I now guard the precondition check with NDEBUG.

Note: the throw in there is legal: it will result in a termination if triggered since the function is marked noexcept.