### PR TITLE
Test with SYCL in the CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
           # To get new URL, look here:
           # https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#inpage-nav-6-undefined
           compiler_url: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh
-          cxx_flags_extra: "-DMDSPAN_USE_BRACKET_OPERATOR=0 -Wextra-semi -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments"
+          cxx_flags_extra: "-DMDSPAN_USE_BRACKET_OPERATOR=0 -Wextra-semi -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments -fsycl"
         - enable_benchmark: ON
         - stdcxx: 14
           enable_benchmark: OFF

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,6 +29,7 @@ jobs:
           # https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#inpage-nav-6-undefined
           compiler_url: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh
           cxx_flags_extra: "-DMDSPAN_USE_BRACKET_OPERATOR=0 -Wextra-semi -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments -fsycl"
+          set_up_environment: ". /opt/intel/oneapi/setvars.sh"
         - enable_benchmark: ON
         - stdcxx: 14
           enable_benchmark: OFF
@@ -73,17 +74,23 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/mdspan-build
-      run: CXX=${{ matrix.compiler_prefix}}/${{ matrix.compiler_driver }} cmake $GITHUB_WORKSPACE/mdspan-src -DMDSPAN_CXX_STANDARD=${{ matrix.stdcxx }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/mdspan-install -DMDSPAN_ENABLE_TESTS=ON -DMDSPAN_ENABLE_EXAMPLES=ON -DMDSPAN_ENABLE_BENCHMARKS=${{matrix.enable_benchmark}} -DMDSPAN_ENABLE_COMP_BENCH=ON -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic ${{matrix.cxx_flags_extra}}"
+      run: |
+        ${{ matrix.set_up_environment }}
+        CXX=${{ matrix.compiler_prefix}}/${{ matrix.compiler_driver }} cmake $GITHUB_WORKSPACE/mdspan-src -DMDSPAN_CXX_STANDARD=${{ matrix.stdcxx }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/mdspan-install -DMDSPAN_ENABLE_TESTS=ON -DMDSPAN_ENABLE_EXAMPLES=ON -DMDSPAN_ENABLE_BENCHMARKS=${{matrix.enable_benchmark}} -DMDSPAN_ENABLE_COMP_BENCH=ON -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic ${{matrix.cxx_flags_extra}}"
 
     - name: Build
       shell: bash
       working-directory: ${{github.workspace}}/mdspan-build
-      run: make -j
+      run: |
+        ${{ matrix.set_up_environment }}
+         make -j
 
     - name: Test
       working-directory: ${{github.workspace}}/mdspan-build
       shell: bash
-      run: ctest --output-on-failure
+      run: |
+        ${{ matrix.set_up_environment }}
+        ctest --output-on-failure
 
     - name: Install
       shell: bash
@@ -94,6 +101,7 @@ jobs:
       shell: bash
       working-directory: ${{github.workspace}}/mdspan-src
       run: |
+        ${{ matrix.set_up_environment }}
         cmake -S ./examples -B /tmp/build-mdspan-examples -Dmdspan_ROOT=${{github.workspace}}/mdspan-build
         cmake --build /tmp/build-mdspan-examples
         rm -rf /tmp/build-mdspan-examples
@@ -102,6 +110,7 @@ jobs:
       shell: bash
       working-directory: ${{github.workspace}}/mdspan-src
       run: |
+        ${{ matrix.set_up_environment }}
         cmake -S ./examples -B /tmp/build-mdspan-examples -Dmdspan_ROOT=${{github.workspace}}/mdspan-install
         cmake --build /tmp/build-mdspan-examples
         rm -rf /tmp/build-mdspan-examples

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,6 +40,8 @@ jobs:
           stdcxx: 23
         - compiler_driver: g++-10
           stdcxx: 23
+        - compiler_driver: icpx
+          stdcxx: 14
     name: ${{ matrix.compiler_driver }} C++${{ matrix.stdcxx }}
     steps:
 

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -208,6 +208,8 @@ check_mul_result_is_nonnegative_and_representable(T a, T b) {
 // FIXME_SYCL The code below compiles to old_llvm.umul.with.overflow.i64
 // which isn't defined in device code
 #ifdef __SYCL_DEVICE_ONLY__
+  (void) a;
+  (void) b;
   return true;
 #else
   if (b == 0 || a == 0)


### PR DESCRIPTION
Based on top of #234. This pull request makes the `icpx` test with `SYCL`.
I also added `--output-on-failure` to `CTest` and needed to allow `CL/sycl.hpp` instead of `sycl/sycl.hpp` for older `oneAPI` releases. The header checks needs `C++17` but `SYCL` needs C++17 support anyway.