### PR TITLE
Fix an ICE on MSVC 14.3X 

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -50,14 +50,20 @@ static constexpr std::false_type _check_compatible_extents(
   std::false_type, std::integer_sequence<size_t, Extents...>, std::integer_sequence<size_t, OtherExtents...>
 ) noexcept { return { }; }
 
+// This helper prevents ICE's on MSVC.
+template <size_t Lhs, size_t Rhs>
+struct _compare_extent_compatible : std::integral_constant<bool,
+    Lhs == dynamic_extent ||
+    Rhs == dynamic_extent ||
+    Lhs == Rhs>
+{};
+
 template <size_t... Extents, size_t... OtherExtents>
 static std::integral_constant<
   bool,
   _MDSPAN_FOLD_AND(
     (
-      Extents == dynamic_extent
-        || OtherExtents == dynamic_extent
-        || Extents == OtherExtents
+      _compare_extent_compatible<Extents, OtherExtents>::value
     ) /* && ... */
   )
 >

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -163,7 +163,7 @@ class layout_left::mapping {
     )
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
-      return __compute_offset(__rank_count<0, extents_type::rank()>(), idxs...);
+      return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 
 

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -168,7 +168,7 @@ class layout_right::mapping {
     )
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
-      return __compute_offset(__rank_count<0, extents_type::rank()>(), idxs...);
+      return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 
     MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept { return true; }

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -415,7 +415,7 @@ struct layout_stride {
     )
     MDSPAN_FORCE_INLINE_FUNCTION
     constexpr index_type operator()(Indices... idxs) const noexcept {
-      return __impl::_call_op_impl(*this, static_cast<index_type>(idxs)...);
+      return static_cast<index_type>(__impl::_call_op_impl(*this, static_cast<index_type>(idxs)...));
     }
 
     MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept { return true; }


### PR DESCRIPTION
These changes were ported from [libcudacxx.](https://github.com/NVIDIA/libcudacxx/pull/391)

MSVC has an issue parsing the aggregate expression comparing extents. Fixed by adding a small helper.

Left and right layout changes fixed a warning we were seeing in testing and seem to be conforming. 