### PR TITLE
#254: qualify `std` namespace

### DIFF
--- a/include/experimental/__p0009_bits/default_accessor.hpp
+++ b/include/experimental/__p0009_bits/default_accessor.hpp
@@ -17,7 +17,7 @@
 
 #include "macros.hpp"
 
-#include <cstddef> // size_t
+#include <cstddef> // std::size_t
 
 namespace std {
 namespace experimental {
@@ -35,7 +35,7 @@ struct default_accessor {
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherElementType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, OtherElementType(*)[], element_type(*)[])
+      _MDSPAN_TRAIT(std::is_convertible, OtherElementType(*)[], element_type(*)[])
     )
   )
   MDSPAN_INLINE_FUNCTION
@@ -43,12 +43,12 @@ struct default_accessor {
 
   MDSPAN_INLINE_FUNCTION
   constexpr data_handle_type
-  offset(data_handle_type p, size_t i) const noexcept {
+  offset(data_handle_type p, std::size_t i) const noexcept {
     return p + i;
   }
 
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference access(data_handle_type p, size_t i) const noexcept {
+  constexpr reference access(data_handle_type p, std::size_t i) const noexcept {
     return p[i];
   }
 

--- a/include/experimental/__p0009_bits/default_accessor.hpp
+++ b/include/experimental/__p0009_bits/default_accessor.hpp
@@ -17,7 +17,7 @@
 
 #include "macros.hpp"
 
-#include <cstddef> // std::size_t
+#include <cstddef> // size_t
 
 namespace std {
 namespace experimental {
@@ -43,12 +43,12 @@ struct default_accessor {
 
   MDSPAN_INLINE_FUNCTION
   constexpr data_handle_type
-  offset(data_handle_type p, std::size_t i) const noexcept {
+  offset(data_handle_type p, size_t i) const noexcept {
     return p + i;
   }
 
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference access(data_handle_type p, std::size_t i) const noexcept {
+  constexpr reference access(data_handle_type p, size_t i) const noexcept {
     return p[i];
   }
 

--- a/include/experimental/__p0009_bits/dynamic_extent.hpp
+++ b/include/experimental/__p0009_bits/dynamic_extent.hpp
@@ -17,13 +17,13 @@
 
 #include "macros.hpp"
 
-#include <cstddef>  // std::size_t
+#include <cstddef>  // size_t
 #include <limits>   // numeric_limits
 
 namespace std {
 namespace experimental {
 
-_MDSPAN_INLINE_VARIABLE constexpr auto dynamic_extent = std::numeric_limits<std::size_t>::max();
+_MDSPAN_INLINE_VARIABLE constexpr auto dynamic_extent = std::numeric_limits<size_t>::max();
 
 } // end namespace experimental
 } // namespace std

--- a/include/experimental/__p0009_bits/dynamic_extent.hpp
+++ b/include/experimental/__p0009_bits/dynamic_extent.hpp
@@ -17,13 +17,13 @@
 
 #include "macros.hpp"
 
-#include <cstddef>  // size_t
+#include <cstddef>  // std::size_t
 #include <limits>   // numeric_limits
 
 namespace std {
 namespace experimental {
 
-_MDSPAN_INLINE_VARIABLE constexpr auto dynamic_extent = std::numeric_limits<size_t>::max();
+_MDSPAN_INLINE_VARIABLE constexpr auto dynamic_extent = std::numeric_limits<std::size_t>::max();
 
 } // end namespace experimental
 } // namespace std

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -30,29 +30,29 @@ namespace detail {
 
 // Function used to check compatibility of extents in converting constructor
 // can't be a private member function for some reason.
-template <size_t... Extents, size_t... OtherExtents>
+template <std::size_t... Extents, std::size_t... OtherExtents>
 static constexpr std::integral_constant<bool, false> __check_compatible_extents(
     std::integral_constant<bool, false>,
-    std::integer_sequence<size_t, Extents...>,
-    std::integer_sequence<size_t, OtherExtents...>) noexcept {
+    std::integer_sequence<std::size_t, Extents...>,
+    std::integer_sequence<std::size_t, OtherExtents...>) noexcept {
   return {};
 }
 
 // This helper prevents ICE's on MSVC.
-template <size_t Lhs, size_t Rhs>
+template <std::size_t Lhs, std::size_t Rhs>
 struct __compare_extent_compatible : std::integral_constant<bool,
      Lhs == dynamic_extent ||
      Rhs == dynamic_extent ||
      Lhs == Rhs>
 {};
 
-template <size_t... Extents, size_t... OtherExtents>
+template <std::size_t... Extents, std::size_t... OtherExtents>
 static constexpr std::integral_constant<
     bool, _MDSPAN_FOLD_AND(__compare_extent_compatible<Extents, OtherExtents>::value)>
 __check_compatible_extents(
     std::integral_constant<bool, true>,
-    std::integer_sequence<size_t, Extents...>,
-    std::integer_sequence<size_t, OtherExtents...>) noexcept {
+    std::integer_sequence<std::size_t, Extents...>,
+    std::integer_sequence<std::size_t, OtherExtents...>) noexcept {
   return {};
 }
 
@@ -64,18 +64,18 @@ __check_compatible_extents(
 // function and operator [].
 
 // Implementation of Static Array with recursive implementation of get.
-template <size_t R, class T, T... Extents> struct static_array_impl;
+template <std::size_t R, class T, T... Extents> struct static_array_impl;
 
-template <size_t R, class T, T FirstExt, T... Extents>
+template <std::size_t R, class T, T FirstExt, T... Extents>
 struct static_array_impl<R, T, FirstExt, Extents...> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static T get(size_t r) {
+  constexpr static T get(std::size_t r) {
     if (r == R)
       return FirstExt;
     else
       return static_array_impl<R + 1, T, Extents...>::get(r);
   }
-  template <size_t r> MDSPAN_INLINE_FUNCTION constexpr static T get() {
+  template <std::size_t r> MDSPAN_INLINE_FUNCTION constexpr static T get() {
 #if MDSPAN_HAS_CXX_17
     if constexpr (r == R)
       return FirstExt;
@@ -88,11 +88,11 @@ struct static_array_impl<R, T, FirstExt, Extents...> {
 };
 
 // End the recursion
-template <size_t R, class T, T FirstExt>
+template <std::size_t R, class T, T FirstExt>
 struct static_array_impl<R, T, FirstExt> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static T get(size_t) { return FirstExt; }
-  template <size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
+  constexpr static T get(std::size_t) { return FirstExt; }
+  template <std::size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
     return FirstExt;
   }
 };
@@ -100,8 +100,8 @@ struct static_array_impl<R, T, FirstExt> {
 // Don't start recursion if size 0
 template <class T> struct static_array_impl<0, T> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static T get(size_t) { return T(); }
-  template <size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
+  constexpr static T get(std::size_t) { return T(); }
+  template <std::size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
     return T();
   }
 };
@@ -114,7 +114,7 @@ public:
   using value_type = T;
 
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t size() { return sizeof...(Values); }
+  constexpr static std::size_t size() { return sizeof...(Values); }
 };
 
 
@@ -126,12 +126,12 @@ public:
 // and get<r>() which return the sum of the first r-1 values.
 
 // Recursive implementation for get
-template <size_t R, size_t... Values> struct index_sequence_scan_impl;
+template <std::size_t R, std::size_t... Values> struct index_sequence_scan_impl;
 
-template <size_t R, size_t FirstVal, size_t... Values>
+template <std::size_t R, std::size_t FirstVal, std::size_t... Values>
 struct index_sequence_scan_impl<R, FirstVal, Values...> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t get(size_t r) {
+  constexpr static std::size_t get(std::size_t r) {
     if (r > R)
       return FirstVal + index_sequence_scan_impl<R + 1, Values...>::get(r);
     else
@@ -139,23 +139,23 @@ struct index_sequence_scan_impl<R, FirstVal, Values...> {
   }
 };
 
-template <size_t R, size_t FirstVal>
+template <std::size_t R, std::size_t FirstVal>
 struct index_sequence_scan_impl<R, FirstVal> {
 #if defined(__NVCC__) || defined(__NVCOMPILER)
   // NVCC warns about pointless comparison with 0 for R==0 and r being const
   // evaluatable and also 0.
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t get(size_t r) {
+  constexpr static std::size_t get(std::size_t r) {
     return static_cast<int64_t>(R) > static_cast<int64_t>(r) ? FirstVal : 0;
   }
 #else
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t get(size_t r) { return R > r ? FirstVal : 0; }
+  constexpr static std::size_t get(std::size_t r) { return R > r ? FirstVal : 0; }
 #endif
 };
 template <> struct index_sequence_scan_impl<0> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t get(size_t) { return 0; }
+  constexpr static std::size_t get(std::size_t) { return 0; }
 };
 
 // ------------------------------------------------------------------
@@ -167,19 +167,19 @@ template <> struct index_sequence_scan_impl<0> {
 // This is needed to make the maybe_static_array be truly empty, for
 // all static values.
 
-template <class T, size_t N> struct possibly_empty_array {
+template <class T, std::size_t N> struct possibly_empty_array {
   T vals[N];
   MDSPAN_INLINE_FUNCTION
-  constexpr T &operator[](size_t r) { return vals[r]; }
+  constexpr T &operator[](std::size_t r) { return vals[r]; }
   MDSPAN_INLINE_FUNCTION
-  constexpr const T &operator[](size_t r) const { return vals[r]; }
+  constexpr const T &operator[](std::size_t r) const { return vals[r]; }
 };
 
 template <class T> struct possibly_empty_array<T, 0> {
   MDSPAN_INLINE_FUNCTION
-  constexpr T operator[](size_t) { return T(); }
+  constexpr T operator[](std::size_t) { return T(); }
   MDSPAN_INLINE_FUNCTION
-  constexpr const T operator[](size_t) const { return T(); }
+  constexpr const T operator[](std::size_t) const { return T(); }
 };
 
 // ------------------------------------------------------------------
@@ -193,14 +193,14 @@ template <class T> struct possibly_empty_array<T, 0> {
 template <class TDynamic, class TStatic, TStatic dyn_tag, TStatic... Values>
 struct maybe_static_array {
 
-  static_assert(is_convertible<TStatic, TDynamic>::value, "maybe_static_array: TStatic must be convertible to TDynamic");
-  static_assert(is_convertible<TDynamic, TStatic>::value, "maybe_static_array: TDynamic must be convertible to TStatic");
+  static_assert(std::is_convertible<TStatic, TDynamic>::value, "maybe_static_array: TStatic must be convertible to TDynamic");
+  static_assert(std::is_convertible<TDynamic, TStatic>::value, "maybe_static_array: TDynamic must be convertible to TStatic");
 
 private:
   // Static values member
   using static_vals_t = static_array<TStatic, Values...>;
-  constexpr static size_t m_size = sizeof...(Values);
-  constexpr static size_t m_size_dynamic =
+  constexpr static std::size_t m_size = sizeof...(Values);
+  constexpr static std::size_t m_size_dynamic =
       _MDSPAN_FOLD_PLUS_RIGHT((Values == dyn_tag), 0);
 
   // Dynamic values member
@@ -208,7 +208,7 @@ private:
       m_dyn_vals;
 
   // static mapping of indices to the position in the dynamic values array
-  using dyn_map_t = index_sequence_scan_impl<0, static_cast<size_t>(Values == dyn_tag)...>;
+  using dyn_map_t = index_sequence_scan_impl<0, static_cast<std::size_t>(Values == dyn_tag)...>;
 public:
 
   // two types for static and dynamic values
@@ -237,25 +237,25 @@ public:
       : m_dyn_vals{static_cast<TDynamic>(vals)...} {}
 
 
-  MDSPAN_TEMPLATE_REQUIRES(class T, size_t N,
+  MDSPAN_TEMPLATE_REQUIRES(class T, std::size_t N,
                            /* requires */ (N == m_size_dynamic && N > 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::array<T, N> &vals) {
-    for (size_t r = 0; r < N; r++)
+    for (std::size_t r = 0; r < N; r++)
       m_dyn_vals[r] = static_cast<TDynamic>(vals[r]);
   }
 
-  MDSPAN_TEMPLATE_REQUIRES(class T, size_t N,
+  MDSPAN_TEMPLATE_REQUIRES(class T, std::size_t N,
                            /* requires */ (N == m_size_dynamic && N == 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::array<T, N> &) : m_dyn_vals{} {}
 
 #ifdef __cpp_lib_span
-  MDSPAN_TEMPLATE_REQUIRES(class T, size_t N,
+  MDSPAN_TEMPLATE_REQUIRES(class T, std::size_t N,
                            /* requires */ (N == m_size_dynamic))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::span<T, N> &vals) {
-    for (size_t r = 0; r < N; r++)
+    for (std::size_t r = 0; r < N; r++)
       m_dyn_vals[r] = static_cast<TDynamic>(vals[r]);
   }
 #endif
@@ -269,7 +269,7 @@ public:
   constexpr maybe_static_array(DynVals... vals) {
     static_assert((sizeof...(DynVals) == m_size), "Invalid number of values.");
     TDynamic values[m_size]{static_cast<TDynamic>(vals)...};
-    for (size_t r = 0; r < m_size; r++) {
+    for (std::size_t r = 0; r < m_size; r++) {
       TStatic static_val = static_vals_t::get(r);
       if (static_val == dyn_tag) {
         m_dyn_vals[dyn_map_t::get(r)] = values[r];
@@ -284,7 +284,7 @@ public:
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-      class T, size_t N,
+      class T, std::size_t N,
       /* requires */ (N != m_size_dynamic && m_size_dynamic > 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::array<T, N> &vals) {
@@ -293,7 +293,7 @@ public:
 #ifdef _MDSPAN_DEBUG
     assert(N == m_size);
 #endif
-    for (size_t r = 0; r < m_size; r++) {
+    for (std::size_t r = 0; r < m_size; r++) {
       TStatic static_val = static_vals_t::get(r);
       if (static_val == dyn_tag) {
         m_dyn_vals[dyn_map_t::get(r)] = static_cast<TDynamic>(vals[r]);
@@ -310,7 +310,7 @@ public:
 
 #ifdef __cpp_lib_span
   MDSPAN_TEMPLATE_REQUIRES(
-      class T, size_t N,
+      class T, std::size_t N,
       /* requires */ (N != m_size_dynamic && m_size_dynamic > 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::span<T, N> &vals) {
@@ -318,7 +318,7 @@ public:
 #ifdef _MDSPAN_DEBUG
     assert(N == m_size);
 #endif
-    for (size_t r = 0; r < m_size; r++) {
+    for (std::size_t r = 0; r < m_size; r++) {
       TStatic static_val = static_vals_t::get(r);
       if (static_val == dyn_tag) {
         m_dyn_vals[dyn_map_t::get(r)] = static_cast<TDynamic>(vals[r]);
@@ -335,23 +335,23 @@ public:
 
   // access functions
   MDSPAN_INLINE_FUNCTION
-  constexpr static TStatic static_value(size_t r) { return static_vals_t::get(r); }
+  constexpr static TStatic static_value(std::size_t r) { return static_vals_t::get(r); }
 
   MDSPAN_INLINE_FUNCTION
-  constexpr TDynamic value(size_t r) const {
+  constexpr TDynamic value(std::size_t r) const {
     TStatic static_val = static_vals_t::get(r);
     return static_val == dyn_tag ? m_dyn_vals[dyn_map_t::get(r)]
                                         : static_cast<TDynamic>(static_val);
   }
   MDSPAN_INLINE_FUNCTION
-  constexpr TDynamic operator[](size_t r) const { return value(r); }
+  constexpr TDynamic operator[](std::size_t r) const { return value(r); }
 
 
   // observers
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t size() { return m_size; }
+  constexpr static std::size_t size() { return m_size; }
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t size_dynamic() { return m_size_dynamic; }
+  constexpr static std::size_t size_dynamic() { return m_size_dynamic; }
 };
 
 } // namespace detail
@@ -369,12 +369,12 @@ namespace experimental {
 // Used by mdspan, mdarray and layout mappings.
 // See ISO C++ standard [mdspan.extents]
 
-template <class IndexType, size_t... Extents> class extents {
+template <class IndexType, std::size_t... Extents> class extents {
 public:
   // typedefs for integral types used
   using index_type = IndexType;
-  using size_type = make_unsigned_t<index_type>;
-  using rank_type = size_t;
+  using size_type = std::make_unsigned_t<index_type>;
+  using rank_type = std::size_t;
 
   static_assert(std::is_integral<index_type>::value && !std::is_same<index_type, bool>::value,
                 "extents::index_type must be a signed or unsigned integer type");
@@ -385,7 +385,7 @@ private:
 
   // internal storage type using maybe_static_array
   using vals_t =
-      detail::maybe_static_array<IndexType, size_t, dynamic_extent, Extents...>;
+      detail::maybe_static_array<IndexType, std::size_t, dynamic_extent, Extents...>;
   _MDSPAN_NO_UNIQUE_ADDRESS vals_t m_vals;
 
 public:
@@ -398,7 +398,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr index_type extent(rank_type r) const noexcept { return m_vals.value(r); }
   MDSPAN_INLINE_FUNCTION
-  constexpr static size_t static_extent(rank_type r) noexcept {
+  constexpr static std::size_t static_extent(rank_type r) noexcept {
     return vals_t::static_value(r);
   }
 
@@ -411,9 +411,9 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
       class... OtherIndexTypes,
       /* requires */ (
-          _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, OtherIndexTypes,
+          _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, OtherIndexTypes,
                                          index_type) /* && ... */) &&
-          _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_nothrow_constructible, index_type,
+          _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_nothrow_constructible, index_type,
                                          OtherIndexTypes) /* && ... */) &&
           (sizeof...(OtherIndexTypes) == m_rank ||
            sizeof...(OtherIndexTypes) == m_rank_dynamic)))
@@ -422,28 +422,28 @@ public:
       : m_vals(static_cast<index_type>(dynvals)...) {}
 
   MDSPAN_TEMPLATE_REQUIRES(
-      class OtherIndexType, size_t N,
+      class OtherIndexType, std::size_t N,
       /* requires */
       (
-          _MDSPAN_TRAIT(is_convertible, OtherIndexType, index_type) &&
-          _MDSPAN_TRAIT(is_nothrow_constructible, index_type,
+          _MDSPAN_TRAIT(std::is_convertible, OtherIndexType, index_type) &&
+          _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type,
               OtherIndexType) &&
           (N == m_rank || N == m_rank_dynamic)))
   MDSPAN_INLINE_FUNCTION
   MDSPAN_CONDITIONAL_EXPLICIT(N != m_rank_dynamic)
-  constexpr extents(const array<OtherIndexType, N> &exts) noexcept
+  constexpr extents(const std::array<OtherIndexType, N> &exts) noexcept
       : m_vals(std::move(exts)) {}
 
 #ifdef __cpp_lib_span
   MDSPAN_TEMPLATE_REQUIRES(
-      class OtherIndexType, size_t N,
+      class OtherIndexType, std::size_t N,
       /* requires */
-      (_MDSPAN_TRAIT(is_convertible, OtherIndexType, index_type) &&
-       _MDSPAN_TRAIT(is_nothrow_constructible, index_type, OtherIndexType) &&
+      (_MDSPAN_TRAIT(std::is_convertible, OtherIndexType, index_type) &&
+       _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, OtherIndexType) &&
        (N == m_rank || N == m_rank_dynamic)))
   MDSPAN_INLINE_FUNCTION
   MDSPAN_CONDITIONAL_EXPLICIT(N != m_rank_dynamic)
-  constexpr extents(const span<OtherIndexType, N> &exts) noexcept
+  constexpr extents(const std::span<OtherIndexType, N> &exts) noexcept
       : m_vals(std::move(exts)) {}
 #endif
 
@@ -453,38 +453,38 @@ private:
   // in which case you don't need all the requires clauses.
   // in C++ 14 mode that doesn't work due to infinite recursion
   MDSPAN_TEMPLATE_REQUIRES(
-      size_t DynCount, size_t R, class OtherExtents, class... DynamicValues,
+      std::size_t DynCount, std::size_t R, class OtherExtents, class... DynamicValues,
       /* requires */ ((R < m_rank) && (static_extent(R) == dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
-  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
-                                       std::integral_constant<size_t, R>,
+  vals_t __construct_vals_from_extents(std::integral_constant<std::size_t, DynCount>,
+                                       std::integral_constant<std::size_t, R>,
                                        const OtherExtents &exts,
                                        DynamicValues... dynamic_values) noexcept {
     return __construct_vals_from_extents(
-        std::integral_constant<size_t, DynCount + 1>(),
-        std::integral_constant<size_t, R + 1>(), exts, dynamic_values...,
+        std::integral_constant<std::size_t, DynCount + 1>(),
+        std::integral_constant<std::size_t, R + 1>(), exts, dynamic_values...,
         exts.extent(R));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-      size_t DynCount, size_t R, class OtherExtents, class... DynamicValues,
+      std::size_t DynCount, std::size_t R, class OtherExtents, class... DynamicValues,
       /* requires */ ((R < m_rank) && (static_extent(R) != dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
-  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
-                                       std::integral_constant<size_t, R>,
+  vals_t __construct_vals_from_extents(std::integral_constant<std::size_t, DynCount>,
+                                       std::integral_constant<std::size_t, R>,
                                        const OtherExtents &exts,
                                        DynamicValues... dynamic_values) noexcept {
     return __construct_vals_from_extents(
-        std::integral_constant<size_t, DynCount>(),
-        std::integral_constant<size_t, R + 1>(), exts, dynamic_values...);
+        std::integral_constant<std::size_t, DynCount>(),
+        std::integral_constant<std::size_t, R + 1>(), exts, dynamic_values...);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-      size_t DynCount, size_t R, class OtherExtents, class... DynamicValues,
+      std::size_t DynCount, std::size_t R, class OtherExtents, class... DynamicValues,
       /* requires */ ((R == m_rank) && (DynCount == m_rank_dynamic)))
   MDSPAN_INLINE_FUNCTION
-  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
-                                       std::integral_constant<size_t, R>,
+  vals_t __construct_vals_from_extents(std::integral_constant<std::size_t, DynCount>,
+                                       std::integral_constant<std::size_t, R>,
                                        const OtherExtents &,
                                        DynamicValues... dynamic_values) noexcept {
     return vals_t{static_cast<index_type>(dynamic_values)...};
@@ -494,7 +494,7 @@ public:
 
   // Converting constructor from other extents specializations
   MDSPAN_TEMPLATE_REQUIRES(
-      class OtherIndexType, size_t... OtherExtents,
+      class OtherIndexType, std::size_t... OtherExtents,
       /* requires */
       (
           /* multi-stage check to protect from invalid pack expansion when sizes
@@ -502,8 +502,8 @@ public:
           decltype(detail::__check_compatible_extents(
               std::integral_constant<bool, sizeof...(Extents) ==
                                                sizeof...(OtherExtents)>{},
-              std::integer_sequence<size_t, Extents...>{},
-              std::integer_sequence<size_t, OtherExtents...>{}))::value))
+              std::integer_sequence<std::size_t, Extents...>{},
+              std::integer_sequence<std::size_t, OtherExtents...>{}))::value))
   MDSPAN_INLINE_FUNCTION
   MDSPAN_CONDITIONAL_EXPLICIT((((Extents != dynamic_extent) &&
                                 (OtherExtents == dynamic_extent)) ||
@@ -512,11 +512,11 @@ public:
                                std::numeric_limits<OtherIndexType>::max()))
   constexpr extents(const extents<OtherIndexType, OtherExtents...> &other) noexcept
       : m_vals(__construct_vals_from_extents(
-            std::integral_constant<size_t, 0>(),
-            std::integral_constant<size_t, 0>(), other)) {}
+            std::integral_constant<std::size_t, 0>(),
+            std::integral_constant<std::size_t, 0>(), other)) {}
 
   // Comparison operator
-  template <class OtherIndexType, size_t... OtherExtents>
+  template <class OtherIndexType, std::size_t... OtherExtents>
   MDSPAN_INLINE_FUNCTION friend constexpr bool
   operator==(const extents &lhs,
              const extents<OtherIndexType, OtherExtents...> &rhs) noexcept {
@@ -527,7 +527,7 @@ public:
   }
 
 #if !(MDSPAN_HAS_CXX_20)
-  template <class OtherIndexType, size_t... OtherExtents>
+  template <class OtherIndexType, std::size_t... OtherExtents>
   MDSPAN_INLINE_FUNCTION friend constexpr bool
   operator!=(extents const &lhs,
              extents<OtherIndexType, OtherExtents...> const &rhs) noexcept {
@@ -539,11 +539,11 @@ public:
 // Recursive helper classes to implement dextents alias for extents
 namespace detail {
 
-template <class IndexType, size_t Rank,
+template <class IndexType, std::size_t Rank,
           class Extents = ::std::experimental::extents<IndexType>>
 struct __make_dextents;
 
-template <class IndexType, size_t Rank, size_t... ExtentsPack>
+template <class IndexType, std::size_t Rank, std::size_t... ExtentsPack>
 struct __make_dextents<
     IndexType, Rank, ::std::experimental::extents<IndexType, ExtentsPack...>> {
   using type = typename __make_dextents<
@@ -553,7 +553,7 @@ struct __make_dextents<
                                    ExtentsPack...>>::type;
 };
 
-template <class IndexType, size_t... ExtentsPack>
+template <class IndexType, std::size_t... ExtentsPack>
 struct __make_dextents<
     IndexType, 0, ::std::experimental::extents<IndexType, ExtentsPack...>> {
   using type = ::std::experimental::extents<IndexType, ExtentsPack...>;
@@ -562,15 +562,15 @@ struct __make_dextents<
 } // end namespace detail
 
 // [mdspan.extents.dextents], alias template
-template <class IndexType, size_t Rank>
+template <class IndexType, std::size_t Rank>
 using dextents = typename detail::__make_dextents<IndexType, Rank>::type;
 
 // Deduction guide for extents
 #if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 template <class... IndexTypes>
 extents(IndexTypes...)
-    -> extents<size_t,
-               size_t((IndexTypes(), ::std::experimental::dynamic_extent))...>;
+    -> extents<std::size_t,
+               std::size_t((IndexTypes(), ::std::experimental::dynamic_extent))...>;
 #endif
 
 // Helper type traits for identifying a class as extents.
@@ -578,7 +578,7 @@ namespace detail {
 
 template <class T> struct __is_extents : ::std::false_type {};
 
-template <class IndexType, size_t... ExtentsPack>
+template <class IndexType, std::size_t... ExtentsPack>
 struct __is_extents<::std::experimental::extents<IndexType, ExtentsPack...>>
     : ::std::true_type {};
 

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -30,29 +30,29 @@ namespace detail {
 
 // Function used to check compatibility of extents in converting constructor
 // can't be a private member function for some reason.
-template <std::size_t... Extents, std::size_t... OtherExtents>
+template <size_t... Extents, size_t... OtherExtents>
 static constexpr std::integral_constant<bool, false> __check_compatible_extents(
     std::integral_constant<bool, false>,
-    std::integer_sequence<std::size_t, Extents...>,
-    std::integer_sequence<std::size_t, OtherExtents...>) noexcept {
+    std::integer_sequence<size_t, Extents...>,
+    std::integer_sequence<size_t, OtherExtents...>) noexcept {
   return {};
 }
 
 // This helper prevents ICE's on MSVC.
-template <std::size_t Lhs, std::size_t Rhs>
+template <size_t Lhs, size_t Rhs>
 struct __compare_extent_compatible : std::integral_constant<bool,
      Lhs == dynamic_extent ||
      Rhs == dynamic_extent ||
      Lhs == Rhs>
 {};
 
-template <std::size_t... Extents, std::size_t... OtherExtents>
+template <size_t... Extents, size_t... OtherExtents>
 static constexpr std::integral_constant<
     bool, _MDSPAN_FOLD_AND(__compare_extent_compatible<Extents, OtherExtents>::value)>
 __check_compatible_extents(
     std::integral_constant<bool, true>,
-    std::integer_sequence<std::size_t, Extents...>,
-    std::integer_sequence<std::size_t, OtherExtents...>) noexcept {
+    std::integer_sequence<size_t, Extents...>,
+    std::integer_sequence<size_t, OtherExtents...>) noexcept {
   return {};
 }
 
@@ -64,18 +64,18 @@ __check_compatible_extents(
 // function and operator [].
 
 // Implementation of Static Array with recursive implementation of get.
-template <std::size_t R, class T, T... Extents> struct static_array_impl;
+template <size_t R, class T, T... Extents> struct static_array_impl;
 
-template <std::size_t R, class T, T FirstExt, T... Extents>
+template <size_t R, class T, T FirstExt, T... Extents>
 struct static_array_impl<R, T, FirstExt, Extents...> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static T get(std::size_t r) {
+  constexpr static T get(size_t r) {
     if (r == R)
       return FirstExt;
     else
       return static_array_impl<R + 1, T, Extents...>::get(r);
   }
-  template <std::size_t r> MDSPAN_INLINE_FUNCTION constexpr static T get() {
+  template <size_t r> MDSPAN_INLINE_FUNCTION constexpr static T get() {
 #if MDSPAN_HAS_CXX_17
     if constexpr (r == R)
       return FirstExt;
@@ -88,11 +88,11 @@ struct static_array_impl<R, T, FirstExt, Extents...> {
 };
 
 // End the recursion
-template <std::size_t R, class T, T FirstExt>
+template <size_t R, class T, T FirstExt>
 struct static_array_impl<R, T, FirstExt> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static T get(std::size_t) { return FirstExt; }
-  template <std::size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
+  constexpr static T get(size_t) { return FirstExt; }
+  template <size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
     return FirstExt;
   }
 };
@@ -100,8 +100,8 @@ struct static_array_impl<R, T, FirstExt> {
 // Don't start recursion if size 0
 template <class T> struct static_array_impl<0, T> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static T get(std::size_t) { return T(); }
-  template <std::size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
+  constexpr static T get(size_t) { return T(); }
+  template <size_t> MDSPAN_INLINE_FUNCTION constexpr static T get() {
     return T();
   }
 };
@@ -114,7 +114,7 @@ public:
   using value_type = T;
 
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t size() { return sizeof...(Values); }
+  constexpr static size_t size() { return sizeof...(Values); }
 };
 
 
@@ -126,12 +126,12 @@ public:
 // and get<r>() which return the sum of the first r-1 values.
 
 // Recursive implementation for get
-template <std::size_t R, std::size_t... Values> struct index_sequence_scan_impl;
+template <size_t R, size_t... Values> struct index_sequence_scan_impl;
 
-template <std::size_t R, std::size_t FirstVal, std::size_t... Values>
+template <size_t R, size_t FirstVal, size_t... Values>
 struct index_sequence_scan_impl<R, FirstVal, Values...> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t get(std::size_t r) {
+  constexpr static size_t get(size_t r) {
     if (r > R)
       return FirstVal + index_sequence_scan_impl<R + 1, Values...>::get(r);
     else
@@ -139,23 +139,23 @@ struct index_sequence_scan_impl<R, FirstVal, Values...> {
   }
 };
 
-template <std::size_t R, std::size_t FirstVal>
+template <size_t R, size_t FirstVal>
 struct index_sequence_scan_impl<R, FirstVal> {
 #if defined(__NVCC__) || defined(__NVCOMPILER)
   // NVCC warns about pointless comparison with 0 for R==0 and r being const
   // evaluatable and also 0.
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t get(std::size_t r) {
+  constexpr static size_t get(size_t r) {
     return static_cast<int64_t>(R) > static_cast<int64_t>(r) ? FirstVal : 0;
   }
 #else
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t get(std::size_t r) { return R > r ? FirstVal : 0; }
+  constexpr static size_t get(size_t r) { return R > r ? FirstVal : 0; }
 #endif
 };
 template <> struct index_sequence_scan_impl<0> {
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t get(std::size_t) { return 0; }
+  constexpr static size_t get(size_t) { return 0; }
 };
 
 // ------------------------------------------------------------------
@@ -167,19 +167,19 @@ template <> struct index_sequence_scan_impl<0> {
 // This is needed to make the maybe_static_array be truly empty, for
 // all static values.
 
-template <class T, std::size_t N> struct possibly_empty_array {
+template <class T, size_t N> struct possibly_empty_array {
   T vals[N];
   MDSPAN_INLINE_FUNCTION
-  constexpr T &operator[](std::size_t r) { return vals[r]; }
+  constexpr T &operator[](size_t r) { return vals[r]; }
   MDSPAN_INLINE_FUNCTION
-  constexpr const T &operator[](std::size_t r) const { return vals[r]; }
+  constexpr const T &operator[](size_t r) const { return vals[r]; }
 };
 
 template <class T> struct possibly_empty_array<T, 0> {
   MDSPAN_INLINE_FUNCTION
-  constexpr T operator[](std::size_t) { return T(); }
+  constexpr T operator[](size_t) { return T(); }
   MDSPAN_INLINE_FUNCTION
-  constexpr const T operator[](std::size_t) const { return T(); }
+  constexpr const T operator[](size_t) const { return T(); }
 };
 
 // ------------------------------------------------------------------
@@ -199,8 +199,8 @@ struct maybe_static_array {
 private:
   // Static values member
   using static_vals_t = static_array<TStatic, Values...>;
-  constexpr static std::size_t m_size = sizeof...(Values);
-  constexpr static std::size_t m_size_dynamic =
+  constexpr static size_t m_size = sizeof...(Values);
+  constexpr static size_t m_size_dynamic =
       _MDSPAN_FOLD_PLUS_RIGHT((Values == dyn_tag), 0);
 
   // Dynamic values member
@@ -208,7 +208,7 @@ private:
       m_dyn_vals;
 
   // static mapping of indices to the position in the dynamic values array
-  using dyn_map_t = index_sequence_scan_impl<0, static_cast<std::size_t>(Values == dyn_tag)...>;
+  using dyn_map_t = index_sequence_scan_impl<0, static_cast<size_t>(Values == dyn_tag)...>;
 public:
 
   // two types for static and dynamic values
@@ -237,25 +237,25 @@ public:
       : m_dyn_vals{static_cast<TDynamic>(vals)...} {}
 
 
-  MDSPAN_TEMPLATE_REQUIRES(class T, std::size_t N,
+  MDSPAN_TEMPLATE_REQUIRES(class T, size_t N,
                            /* requires */ (N == m_size_dynamic && N > 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::array<T, N> &vals) {
-    for (std::size_t r = 0; r < N; r++)
+    for (size_t r = 0; r < N; r++)
       m_dyn_vals[r] = static_cast<TDynamic>(vals[r]);
   }
 
-  MDSPAN_TEMPLATE_REQUIRES(class T, std::size_t N,
+  MDSPAN_TEMPLATE_REQUIRES(class T, size_t N,
                            /* requires */ (N == m_size_dynamic && N == 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::array<T, N> &) : m_dyn_vals{} {}
 
 #ifdef __cpp_lib_span
-  MDSPAN_TEMPLATE_REQUIRES(class T, std::size_t N,
+  MDSPAN_TEMPLATE_REQUIRES(class T, size_t N,
                            /* requires */ (N == m_size_dynamic))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::span<T, N> &vals) {
-    for (std::size_t r = 0; r < N; r++)
+    for (size_t r = 0; r < N; r++)
       m_dyn_vals[r] = static_cast<TDynamic>(vals[r]);
   }
 #endif
@@ -269,7 +269,7 @@ public:
   constexpr maybe_static_array(DynVals... vals) {
     static_assert((sizeof...(DynVals) == m_size), "Invalid number of values.");
     TDynamic values[m_size]{static_cast<TDynamic>(vals)...};
-    for (std::size_t r = 0; r < m_size; r++) {
+    for (size_t r = 0; r < m_size; r++) {
       TStatic static_val = static_vals_t::get(r);
       if (static_val == dyn_tag) {
         m_dyn_vals[dyn_map_t::get(r)] = values[r];
@@ -284,7 +284,7 @@ public:
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-      class T, std::size_t N,
+      class T, size_t N,
       /* requires */ (N != m_size_dynamic && m_size_dynamic > 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::array<T, N> &vals) {
@@ -293,7 +293,7 @@ public:
 #ifdef _MDSPAN_DEBUG
     assert(N == m_size);
 #endif
-    for (std::size_t r = 0; r < m_size; r++) {
+    for (size_t r = 0; r < m_size; r++) {
       TStatic static_val = static_vals_t::get(r);
       if (static_val == dyn_tag) {
         m_dyn_vals[dyn_map_t::get(r)] = static_cast<TDynamic>(vals[r]);
@@ -310,7 +310,7 @@ public:
 
 #ifdef __cpp_lib_span
   MDSPAN_TEMPLATE_REQUIRES(
-      class T, std::size_t N,
+      class T, size_t N,
       /* requires */ (N != m_size_dynamic && m_size_dynamic > 0))
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::span<T, N> &vals) {
@@ -318,7 +318,7 @@ public:
 #ifdef _MDSPAN_DEBUG
     assert(N == m_size);
 #endif
-    for (std::size_t r = 0; r < m_size; r++) {
+    for (size_t r = 0; r < m_size; r++) {
       TStatic static_val = static_vals_t::get(r);
       if (static_val == dyn_tag) {
         m_dyn_vals[dyn_map_t::get(r)] = static_cast<TDynamic>(vals[r]);
@@ -335,23 +335,23 @@ public:
 
   // access functions
   MDSPAN_INLINE_FUNCTION
-  constexpr static TStatic static_value(std::size_t r) { return static_vals_t::get(r); }
+  constexpr static TStatic static_value(size_t r) { return static_vals_t::get(r); }
 
   MDSPAN_INLINE_FUNCTION
-  constexpr TDynamic value(std::size_t r) const {
+  constexpr TDynamic value(size_t r) const {
     TStatic static_val = static_vals_t::get(r);
     return static_val == dyn_tag ? m_dyn_vals[dyn_map_t::get(r)]
                                         : static_cast<TDynamic>(static_val);
   }
   MDSPAN_INLINE_FUNCTION
-  constexpr TDynamic operator[](std::size_t r) const { return value(r); }
+  constexpr TDynamic operator[](size_t r) const { return value(r); }
 
 
   // observers
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t size() { return m_size; }
+  constexpr static size_t size() { return m_size; }
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t size_dynamic() { return m_size_dynamic; }
+  constexpr static size_t size_dynamic() { return m_size_dynamic; }
 };
 
 } // namespace detail
@@ -369,12 +369,12 @@ namespace experimental {
 // Used by mdspan, mdarray and layout mappings.
 // See ISO C++ standard [mdspan.extents]
 
-template <class IndexType, std::size_t... Extents> class extents {
+template <class IndexType, size_t... Extents> class extents {
 public:
   // typedefs for integral types used
   using index_type = IndexType;
   using size_type = std::make_unsigned_t<index_type>;
-  using rank_type = std::size_t;
+  using rank_type = size_t;
 
   static_assert(std::is_integral<index_type>::value && !std::is_same<index_type, bool>::value,
                 "extents::index_type must be a signed or unsigned integer type");
@@ -385,7 +385,7 @@ private:
 
   // internal storage type using maybe_static_array
   using vals_t =
-      detail::maybe_static_array<IndexType, std::size_t, dynamic_extent, Extents...>;
+      detail::maybe_static_array<IndexType, size_t, dynamic_extent, Extents...>;
   _MDSPAN_NO_UNIQUE_ADDRESS vals_t m_vals;
 
 public:
@@ -398,7 +398,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr index_type extent(rank_type r) const noexcept { return m_vals.value(r); }
   MDSPAN_INLINE_FUNCTION
-  constexpr static std::size_t static_extent(rank_type r) noexcept {
+  constexpr static size_t static_extent(rank_type r) noexcept {
     return vals_t::static_value(r);
   }
 
@@ -422,7 +422,7 @@ public:
       : m_vals(static_cast<index_type>(dynvals)...) {}
 
   MDSPAN_TEMPLATE_REQUIRES(
-      class OtherIndexType, std::size_t N,
+      class OtherIndexType, size_t N,
       /* requires */
       (
           _MDSPAN_TRAIT(std::is_convertible, OtherIndexType, index_type) &&
@@ -436,7 +436,7 @@ public:
 
 #ifdef __cpp_lib_span
   MDSPAN_TEMPLATE_REQUIRES(
-      class OtherIndexType, std::size_t N,
+      class OtherIndexType, size_t N,
       /* requires */
       (_MDSPAN_TRAIT(std::is_convertible, OtherIndexType, index_type) &&
        _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, OtherIndexType) &&
@@ -453,38 +453,38 @@ private:
   // in which case you don't need all the requires clauses.
   // in C++ 14 mode that doesn't work due to infinite recursion
   MDSPAN_TEMPLATE_REQUIRES(
-      std::size_t DynCount, std::size_t R, class OtherExtents, class... DynamicValues,
+      size_t DynCount, size_t R, class OtherExtents, class... DynamicValues,
       /* requires */ ((R < m_rank) && (static_extent(R) == dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
-  vals_t __construct_vals_from_extents(std::integral_constant<std::size_t, DynCount>,
-                                       std::integral_constant<std::size_t, R>,
+  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
+                                       std::integral_constant<size_t, R>,
                                        const OtherExtents &exts,
                                        DynamicValues... dynamic_values) noexcept {
     return __construct_vals_from_extents(
-        std::integral_constant<std::size_t, DynCount + 1>(),
-        std::integral_constant<std::size_t, R + 1>(), exts, dynamic_values...,
+        std::integral_constant<size_t, DynCount + 1>(),
+        std::integral_constant<size_t, R + 1>(), exts, dynamic_values...,
         exts.extent(R));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-      std::size_t DynCount, std::size_t R, class OtherExtents, class... DynamicValues,
+      size_t DynCount, size_t R, class OtherExtents, class... DynamicValues,
       /* requires */ ((R < m_rank) && (static_extent(R) != dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
-  vals_t __construct_vals_from_extents(std::integral_constant<std::size_t, DynCount>,
-                                       std::integral_constant<std::size_t, R>,
+  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
+                                       std::integral_constant<size_t, R>,
                                        const OtherExtents &exts,
                                        DynamicValues... dynamic_values) noexcept {
     return __construct_vals_from_extents(
-        std::integral_constant<std::size_t, DynCount>(),
-        std::integral_constant<std::size_t, R + 1>(), exts, dynamic_values...);
+        std::integral_constant<size_t, DynCount>(),
+        std::integral_constant<size_t, R + 1>(), exts, dynamic_values...);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-      std::size_t DynCount, std::size_t R, class OtherExtents, class... DynamicValues,
+      size_t DynCount, size_t R, class OtherExtents, class... DynamicValues,
       /* requires */ ((R == m_rank) && (DynCount == m_rank_dynamic)))
   MDSPAN_INLINE_FUNCTION
-  vals_t __construct_vals_from_extents(std::integral_constant<std::size_t, DynCount>,
-                                       std::integral_constant<std::size_t, R>,
+  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
+                                       std::integral_constant<size_t, R>,
                                        const OtherExtents &,
                                        DynamicValues... dynamic_values) noexcept {
     return vals_t{static_cast<index_type>(dynamic_values)...};
@@ -494,7 +494,7 @@ public:
 
   // Converting constructor from other extents specializations
   MDSPAN_TEMPLATE_REQUIRES(
-      class OtherIndexType, std::size_t... OtherExtents,
+      class OtherIndexType, size_t... OtherExtents,
       /* requires */
       (
           /* multi-stage check to protect from invalid pack expansion when sizes
@@ -502,8 +502,8 @@ public:
           decltype(detail::__check_compatible_extents(
               std::integral_constant<bool, sizeof...(Extents) ==
                                                sizeof...(OtherExtents)>{},
-              std::integer_sequence<std::size_t, Extents...>{},
-              std::integer_sequence<std::size_t, OtherExtents...>{}))::value))
+              std::integer_sequence<size_t, Extents...>{},
+              std::integer_sequence<size_t, OtherExtents...>{}))::value))
   MDSPAN_INLINE_FUNCTION
   MDSPAN_CONDITIONAL_EXPLICIT((((Extents != dynamic_extent) &&
                                 (OtherExtents == dynamic_extent)) ||
@@ -512,11 +512,11 @@ public:
                                std::numeric_limits<OtherIndexType>::max()))
   constexpr extents(const extents<OtherIndexType, OtherExtents...> &other) noexcept
       : m_vals(__construct_vals_from_extents(
-            std::integral_constant<std::size_t, 0>(),
-            std::integral_constant<std::size_t, 0>(), other)) {}
+            std::integral_constant<size_t, 0>(),
+            std::integral_constant<size_t, 0>(), other)) {}
 
   // Comparison operator
-  template <class OtherIndexType, std::size_t... OtherExtents>
+  template <class OtherIndexType, size_t... OtherExtents>
   MDSPAN_INLINE_FUNCTION friend constexpr bool
   operator==(const extents &lhs,
              const extents<OtherIndexType, OtherExtents...> &rhs) noexcept {
@@ -527,7 +527,7 @@ public:
   }
 
 #if !(MDSPAN_HAS_CXX_20)
-  template <class OtherIndexType, std::size_t... OtherExtents>
+  template <class OtherIndexType, size_t... OtherExtents>
   MDSPAN_INLINE_FUNCTION friend constexpr bool
   operator!=(extents const &lhs,
              extents<OtherIndexType, OtherExtents...> const &rhs) noexcept {
@@ -539,11 +539,11 @@ public:
 // Recursive helper classes to implement dextents alias for extents
 namespace detail {
 
-template <class IndexType, std::size_t Rank,
+template <class IndexType, size_t Rank,
           class Extents = ::std::experimental::extents<IndexType>>
 struct __make_dextents;
 
-template <class IndexType, std::size_t Rank, std::size_t... ExtentsPack>
+template <class IndexType, size_t Rank, size_t... ExtentsPack>
 struct __make_dextents<
     IndexType, Rank, ::std::experimental::extents<IndexType, ExtentsPack...>> {
   using type = typename __make_dextents<
@@ -553,7 +553,7 @@ struct __make_dextents<
                                    ExtentsPack...>>::type;
 };
 
-template <class IndexType, std::size_t... ExtentsPack>
+template <class IndexType, size_t... ExtentsPack>
 struct __make_dextents<
     IndexType, 0, ::std::experimental::extents<IndexType, ExtentsPack...>> {
   using type = ::std::experimental::extents<IndexType, ExtentsPack...>;
@@ -562,15 +562,15 @@ struct __make_dextents<
 } // end namespace detail
 
 // [mdspan.extents.dextents], alias template
-template <class IndexType, std::size_t Rank>
+template <class IndexType, size_t Rank>
 using dextents = typename detail::__make_dextents<IndexType, Rank>::type;
 
 // Deduction guide for extents
 #if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 template <class... IndexTypes>
 extents(IndexTypes...)
-    -> extents<std::size_t,
-               std::size_t((IndexTypes(), ::std::experimental::dynamic_extent))...>;
+    -> extents<size_t,
+               size_t((IndexTypes(), ::std::experimental::dynamic_extent))...>;
 #endif
 
 // Helper type traits for identifying a class as extents.
@@ -578,7 +578,7 @@ namespace detail {
 
 template <class T> struct __is_extents : ::std::false_type {};
 
-template <class IndexType, std::size_t... ExtentsPack>
+template <class IndexType, size_t... ExtentsPack>
 struct __is_extents<::std::experimental::extents<IndexType, ExtentsPack...>>
     : ::std::true_type {};
 

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -40,10 +40,10 @@ class layout_left::mapping {
     friend class mapping;
 
     // i0+(i1 + E(1)*(i2 + E(2)*i3))
-    template <size_t r, size_t Rank>
+    template <std::size_t r, std::size_t Rank>
     struct __rank_count {};
 
-    template <size_t r, size_t Rank, class I, class... Indices>
+    template <std::size_t r, std::size_t Rank, class I, class... Indices>
     _MDSPAN_HOST_DEVICE
     constexpr index_type __compute_offset(
       __rank_count<r,Rank>, const I& i, Indices... idx) const {
@@ -76,10 +76,10 @@ class layout_left::mapping {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, extents_type, OtherExtents)
+        _MDSPAN_TRAIT(std::is_constructible, extents_type, OtherExtents)
       )
     )
-    MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
+    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
       :__extents(other.extents())
@@ -93,11 +93,11 @@ class layout_left::mapping {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, extents_type, OtherExtents) &&
+        _MDSPAN_TRAIT(std::is_constructible, extents_type, OtherExtents) &&
         (extents_type::rank() <= 1)
       )
     )
-    MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
+    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(layout_right::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
       :__extents(other.extents())
@@ -111,7 +111,7 @@ class layout_left::mapping {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, extents_type, OtherExtents)
+        _MDSPAN_TRAIT(std::is_constructible, extents_type, OtherExtents)
       )
     )
     MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
@@ -156,8 +156,8 @@ class layout_left::mapping {
       /* requires */ (
         (sizeof...(Indices) == extents_type::rank()) &&
         _MDSPAN_FOLD_AND(
-           (_MDSPAN_TRAIT(is_convertible, Indices, index_type) &&
-            _MDSPAN_TRAIT(is_nothrow_constructible, index_type, Indices))
+           (_MDSPAN_TRAIT(std::is_convertible, Indices, index_type) &&
+            _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, Indices))
         )
       )
     )
@@ -203,13 +203,13 @@ class layout_left::mapping {
 #endif
 
     // Not really public, but currently needed to implement fully constexpr useable submdspan:
-    template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
-    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,integer_sequence<size_t, Idx...>) const {
+    template<std::size_t N, class SizeType, std::size_t ... E, std::size_t ... Idx>
+    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,std::integer_sequence<std::size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT((Idx<N? __extents.template __extent<Idx>():1),1);
     }
-    template<size_t N>
+    template<std::size_t N>
     constexpr index_type __stride() const noexcept {
-      return __get_stride<N>(__extents, make_index_sequence<extents_type::rank()>());
+      return __get_stride<N>(__extents, std::make_index_sequence<extents_type::rank()>());
     }
 
 private:

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -40,10 +40,10 @@ class layout_left::mapping {
     friend class mapping;
 
     // i0+(i1 + E(1)*(i2 + E(2)*i3))
-    template <std::size_t r, std::size_t Rank>
+    template <size_t r, size_t Rank>
     struct __rank_count {};
 
-    template <std::size_t r, std::size_t Rank, class I, class... Indices>
+    template <size_t r, size_t Rank, class I, class... Indices>
     _MDSPAN_HOST_DEVICE
     constexpr index_type __compute_offset(
       __rank_count<r,Rank>, const I& i, Indices... idx) const {
@@ -203,11 +203,11 @@ class layout_left::mapping {
 #endif
 
     // Not really public, but currently needed to implement fully constexpr useable submdspan:
-    template<std::size_t N, class SizeType, std::size_t ... E, std::size_t ... Idx>
-    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,std::integer_sequence<std::size_t, Idx...>) const {
+    template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
+    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT((Idx<N? __extents.template __extent<Idx>():1),1);
     }
-    template<std::size_t N>
+    template<size_t N>
     constexpr index_type __stride() const noexcept {
       return __get_stride<N>(__extents, std::make_index_sequence<extents_type::rank()>());
     }

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -41,10 +41,10 @@ class layout_right::mapping {
     friend class mapping;
 
     // i0+(i1 + E(1)*(i2 + E(2)*i3))
-    template <std::size_t r, std::size_t Rank>
+    template <size_t r, size_t Rank>
     struct __rank_count {};
 
-    template <std::size_t r, std::size_t Rank, class I, class... Indices>
+    template <size_t r, size_t Rank, class I, class... Indices>
     _MDSPAN_HOST_DEVICE
     constexpr index_type __compute_offset(
       index_type offset, __rank_count<r,Rank>, const I& i, Indices... idx) const {
@@ -59,7 +59,7 @@ class layout_right::mapping {
     }
 
     _MDSPAN_HOST_DEVICE
-    constexpr index_type __compute_offset(std::size_t offset, __rank_count<extents_type::rank(), extents_type::rank()>) const {
+    constexpr index_type __compute_offset(size_t offset, __rank_count<extents_type::rank(), extents_type::rank()>) const {
       return static_cast<index_type>(offset);
     }
 
@@ -205,11 +205,11 @@ class layout_right::mapping {
 #endif
 
     // Not really public, but currently needed to implement fully constexpr useable submdspan:
-    template<std::size_t N, class SizeType, std::size_t ... E, std::size_t ... Idx>
-    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,std::integer_sequence<std::size_t, Idx...>) const {
+    template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
+    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT((Idx>N? __extents.template __extent<Idx>():1),1);
     }
-    template<std::size_t N>
+    template<size_t N>
     constexpr index_type __stride() const noexcept {
       return __get_stride<N>(__extents, std::make_index_sequence<extents_type::rank()>());
     }

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -41,10 +41,10 @@ class layout_right::mapping {
     friend class mapping;
 
     // i0+(i1 + E(1)*(i2 + E(2)*i3))
-    template <size_t r, size_t Rank>
+    template <std::size_t r, std::size_t Rank>
     struct __rank_count {};
 
-    template <size_t r, size_t Rank, class I, class... Indices>
+    template <std::size_t r, std::size_t Rank, class I, class... Indices>
     _MDSPAN_HOST_DEVICE
     constexpr index_type __compute_offset(
       index_type offset, __rank_count<r,Rank>, const I& i, Indices... idx) const {
@@ -59,7 +59,7 @@ class layout_right::mapping {
     }
 
     _MDSPAN_HOST_DEVICE
-    constexpr index_type __compute_offset(size_t offset, __rank_count<extents_type::rank(), extents_type::rank()>) const {
+    constexpr index_type __compute_offset(std::size_t offset, __rank_count<extents_type::rank(), extents_type::rank()>) const {
       return static_cast<index_type>(offset);
     }
 
@@ -81,10 +81,10 @@ class layout_right::mapping {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, extents_type, OtherExtents)
+        _MDSPAN_TRAIT(std::is_constructible, extents_type, OtherExtents)
       )
     )
-    MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
+    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
       :__extents(other.extents())
@@ -98,11 +98,11 @@ class layout_right::mapping {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, extents_type, OtherExtents) &&
+        _MDSPAN_TRAIT(std::is_constructible, extents_type, OtherExtents) &&
         (extents_type::rank() <= 1)
       )
     )
-    MDSPAN_CONDITIONAL_EXPLICIT((!is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
+    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(layout_left::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
       :__extents(other.extents())
@@ -116,7 +116,7 @@ class layout_right::mapping {
     MDSPAN_TEMPLATE_REQUIRES(
       class OtherExtents,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, extents_type, OtherExtents)
+        _MDSPAN_TRAIT(std::is_constructible, extents_type, OtherExtents)
       )
     )
     MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
@@ -161,8 +161,8 @@ class layout_right::mapping {
       /* requires */ (
         (sizeof...(Indices) == extents_type::rank()) &&
         _MDSPAN_FOLD_AND(
-           (_MDSPAN_TRAIT(is_convertible, Indices, index_type) &&
-            _MDSPAN_TRAIT(is_nothrow_constructible, index_type, Indices))
+           (_MDSPAN_TRAIT(std::is_convertible, Indices, index_type) &&
+            _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, Indices))
         )
       )
     )
@@ -205,13 +205,13 @@ class layout_right::mapping {
 #endif
 
     // Not really public, but currently needed to implement fully constexpr useable submdspan:
-    template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
-    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,integer_sequence<size_t, Idx...>) const {
+    template<std::size_t N, class SizeType, std::size_t ... E, std::size_t ... Idx>
+    constexpr index_type __get_stride(std::experimental::extents<SizeType, E...>,std::integer_sequence<std::size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT((Idx>N? __extents.template __extent<Idx>():1),1);
     }
-    template<size_t N>
+    template<std::size_t N>
     constexpr index_type __stride() const noexcept {
-      return __get_stride<N>(__extents, make_index_sequence<extents_type::rank()>());
+      return __get_stride<N>(__extents, std::make_index_sequence<extents_type::rank()>());
     }
 
 private:

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -118,9 +118,9 @@ struct layout_stride {
 #endif
     }
 
-    template<class SizeType, ::std::size_t ... Ep, ::std::size_t ... Idx>
+    template<class SizeType, ::size_t ... Ep, ::size_t ... Idx>
     _MDSPAN_HOST_DEVICE
-    constexpr index_type __get_size(::std::experimental::extents<SizeType, Ep...>,std::integer_sequence<::std::size_t, Idx...>) const {
+    constexpr index_type __get_size(::std::experimental::extents<SizeType, Ep...>,std::integer_sequence<::size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT( static_cast<index_type>(extents().extent(Idx)), 1 );
     }
 
@@ -135,7 +135,7 @@ struct layout_stride {
     template <class>
     struct __deduction_workaround;
 
-    template <std::size_t... Idxs>
+    template <size_t... Idxs>
     struct __deduction_workaround<std::index_sequence<Idxs...>>
     {
       template <class OtherExtents>
@@ -153,12 +153,12 @@ struct layout_stride {
 
       template <class... Integral>
       MDSPAN_FORCE_INLINE_FUNCTION
-      static constexpr std::size_t _call_op_impl(mapping const& self, Integral... idxs) noexcept {
+      static constexpr size_t _call_op_impl(mapping const& self, Integral... idxs) noexcept {
         return _MDSPAN_FOLD_PLUS_RIGHT((idxs * self.stride(Idxs)), /* + ... + */ 0);
       }
 
       MDSPAN_INLINE_FUNCTION
-      static constexpr std::size_t _req_span_size_impl(mapping const& self) noexcept {
+      static constexpr size_t _req_span_size_impl(mapping const& self) noexcept {
         // assumes no negative strides; not sure if I'm allowed to assume that or not
         return __impl::_call_op_impl(self, (self.extents().template __extent<Idxs>() - 1)...) + 1;
       }
@@ -188,9 +188,9 @@ struct layout_stride {
       }
 #endif
 
-      template<std::size_t K>
+      template<size_t K>
       MDSPAN_INLINE_FUNCTION
-      static constexpr std::size_t __return_zero() { return 0; }
+      static constexpr size_t __return_zero() { return 0; }
 
       template<class Mapping>
       MDSPAN_INLINE_FUNCTION

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -261,7 +261,7 @@ struct layout_stride {
       class IntegralTypes,
       /* requires */ (
         // MSVC 19.32 does not like using index_type here, requires the typename Extents::index_type
-        // error C2641: cannot deduce template arguments for 'MDSPAN_IMPL_STANDARD_NAMESPACE::layout_stride::mapping'
+        // error C2641: cannot deduce template arguments for 'std::experimental::layout_stride::mapping'
         _MDSPAN_TRAIT(std::is_convertible, const std::remove_const_t<IntegralTypes>&, typename Extents::index_type) &&
         _MDSPAN_TRAIT(std::is_nothrow_constructible, typename Extents::index_type, const std::remove_const_t<IntegralTypes>&)
       )

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -49,18 +49,18 @@ struct layout_right {
 namespace detail {
   template<class Layout, class Mapping>
   constexpr bool __is_mapping_of =
-    is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
+    std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
 
 #if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
   template<class M>
   concept __layout_mapping_alike = requires {
     requires __is_extents<typename M::extents_type>::value;
-    { M::is_always_strided() } -> same_as<bool>;
-    { M::is_always_exhaustive() } -> same_as<bool>;
-    { M::is_always_unique() } -> same_as<bool>;
-    bool_constant<M::is_always_strided()>::value;
-    bool_constant<M::is_always_exhaustive()>::value;
-    bool_constant<M::is_always_unique()>::value;
+    { M::is_always_strided() } -> std::same_as<bool>;
+    { M::is_always_exhaustive() } -> std::same_as<bool>;
+    { M::is_always_unique() } -> std::same_as<bool>;
+    std::bool_constant<M::is_always_strided()>::value;
+    std::bool_constant<M::is_always_exhaustive()>::value;
+    std::bool_constant<M::is_always_unique()>::value;
   };
 #endif
 } // namespace detail
@@ -92,7 +92,7 @@ struct layout_stride {
 
     //----------------------------------------------------------------------------
 
-    using __strides_storage_t = array<index_type, extents_type::rank()>;//::std::experimental::dextents<index_type, extents_type::rank()>;
+    using __strides_storage_t = std::array<index_type, extents_type::rank()>;
     using __member_pair_t = detail::__compressed_pair<extents_type, __strides_storage_t>;
 
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
@@ -120,7 +120,7 @@ struct layout_stride {
 
     template<class SizeType, ::std::size_t ... Ep, ::std::size_t ... Idx>
     _MDSPAN_HOST_DEVICE
-    constexpr index_type __get_size(::std::experimental::extents<SizeType, Ep...>,integer_sequence<::std::size_t, Idx...>) const {
+    constexpr index_type __get_size(::std::experimental::extents<SizeType, Ep...>,std::integer_sequence<::std::size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT( static_cast<index_type>(extents().extent(Idx)), 1 );
     }
 
@@ -135,8 +135,8 @@ struct layout_stride {
     template <class>
     struct __deduction_workaround;
 
-    template <size_t... Idxs>
-    struct __deduction_workaround<index_sequence<Idxs...>>
+    template <std::size_t... Idxs>
+    struct __deduction_workaround<std::index_sequence<Idxs...>>
     {
       template <class OtherExtents>
       MDSPAN_INLINE_FUNCTION
@@ -153,12 +153,12 @@ struct layout_stride {
 
       template <class... Integral>
       MDSPAN_FORCE_INLINE_FUNCTION
-      static constexpr size_t _call_op_impl(mapping const& self, Integral... idxs) noexcept {
+      static constexpr std::size_t _call_op_impl(mapping const& self, Integral... idxs) noexcept {
         return _MDSPAN_FOLD_PLUS_RIGHT((idxs * self.stride(Idxs)), /* + ... + */ 0);
       }
 
       MDSPAN_INLINE_FUNCTION
-      static constexpr size_t _req_span_size_impl(mapping const& self) noexcept {
+      static constexpr std::size_t _req_span_size_impl(mapping const& self) noexcept {
         // assumes no negative strides; not sure if I'm allowed to assume that or not
         return __impl::_call_op_impl(self, (self.extents().template __extent<Idxs>() - 1)...) + 1;
       }
@@ -176,21 +176,21 @@ struct layout_stride {
 
       template<class IntegralType>
       MDSPAN_INLINE_FUNCTION
-      static constexpr const __strides_storage_t fill_strides(const array<IntegralType,extents_type::rank()>& s) {
+      static constexpr const __strides_storage_t fill_strides(const std::array<IntegralType,extents_type::rank()>& s) {
         return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 
 #ifdef __cpp_lib_span
       template<class IntegralType>
       MDSPAN_INLINE_FUNCTION
-      static constexpr const __strides_storage_t fill_strides(const span<IntegralType,extents_type::rank()>& s) {
+      static constexpr const __strides_storage_t fill_strides(const std::span<IntegralType,extents_type::rank()>& s) {
         return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 #endif
 
-      template<size_t K>
+      template<std::size_t K>
       MDSPAN_INLINE_FUNCTION
-      static constexpr size_t __return_zero() { return 0; }
+      static constexpr std::size_t __return_zero() { return 0; }
 
       template<class Mapping>
       MDSPAN_INLINE_FUNCTION
@@ -199,7 +199,7 @@ struct layout_stride {
     };
 
     // Can't use defaulted parameter in the __deduction_workaround template because of a bug in MSVC warning C4348.
-    using __impl = __deduction_workaround<make_index_sequence<Extents::rank()>>;
+    using __impl = __deduction_workaround<std::make_index_sequence<Extents::rank()>>;
 
 
     //----------------------------------------------------------------------------
@@ -224,15 +224,15 @@ struct layout_stride {
       /* requires */ (
         // MSVC 19.32 does not like using index_type here, requires the typename Extents::index_type
         // error C2641: cannot deduce template arguments for 'std::experimental::layout_stride::mapping'
-        _MDSPAN_TRAIT(is_convertible, const remove_const_t<IntegralTypes>&, typename Extents::index_type) &&
-        _MDSPAN_TRAIT(is_nothrow_constructible, typename Extents::index_type, const remove_const_t<IntegralTypes>&)
+        _MDSPAN_TRAIT(std::is_convertible, const std::remove_const_t<IntegralTypes>&, typename Extents::index_type) &&
+        _MDSPAN_TRAIT(std::is_nothrow_constructible, typename Extents::index_type, const std::remove_const_t<IntegralTypes>&)
       )
     )
     MDSPAN_INLINE_FUNCTION
     constexpr
     mapping(
       extents_type const& e,
-      array<IntegralTypes, extents_type::rank()> const& s
+      std::array<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
@@ -261,16 +261,16 @@ struct layout_stride {
       class IntegralTypes,
       /* requires */ (
         // MSVC 19.32 does not like using index_type here, requires the typename Extents::index_type
-        // error C2641: cannot deduce template arguments for 'std::experimental::layout_stride::mapping'
-        _MDSPAN_TRAIT(is_convertible, const remove_const_t<IntegralTypes>&, typename Extents::index_type) &&
-        _MDSPAN_TRAIT(is_nothrow_constructible, typename Extents::index_type, const remove_const_t<IntegralTypes>&)
+        // error C2641: cannot deduce template arguments for 'MDSPAN_IMPL_STANDARD_NAMESPACE::layout_stride::mapping'
+        _MDSPAN_TRAIT(std::is_convertible, const std::remove_const_t<IntegralTypes>&, typename Extents::index_type) &&
+        _MDSPAN_TRAIT(std::is_nothrow_constructible, typename Extents::index_type, const std::remove_const_t<IntegralTypes>&)
       )
     )
     MDSPAN_INLINE_FUNCTION
     constexpr
     mapping(
       extents_type const& e,
-      span<IntegralTypes, extents_type::rank()> const& s
+      std::span<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
@@ -299,7 +299,7 @@ struct layout_stride {
     MDSPAN_TEMPLATE_REQUIRES(
       class StridedLayoutMapping,
       /* requires */ (
-        _MDSPAN_TRAIT(is_constructible, extents_type, typename StridedLayoutMapping::extents_type) &&
+        _MDSPAN_TRAIT(std::is_constructible, extents_type, typename StridedLayoutMapping::extents_type) &&
         detail::__is_mapping_of<typename StridedLayoutMapping::layout_type, StridedLayoutMapping> &&
         StridedLayoutMapping::is_always_unique() &&
         StridedLayoutMapping::is_always_strided()
@@ -309,13 +309,13 @@ struct layout_stride {
     template<class StridedLayoutMapping>
     requires(
          detail::__layout_mapping_alike<StridedLayoutMapping> &&
-         _MDSPAN_TRAIT(is_constructible, extents_type, typename StridedLayoutMapping::extents_type) &&
+         _MDSPAN_TRAIT(std::is_constructible, extents_type, typename StridedLayoutMapping::extents_type) &&
          StridedLayoutMapping::is_always_unique() &&
          StridedLayoutMapping::is_always_strided()
     )
 #endif
     MDSPAN_CONDITIONAL_EXPLICIT(
-      (!is_convertible<typename StridedLayoutMapping::extents_type, extents_type>::value) &&
+      (!std::is_convertible<typename StridedLayoutMapping::extents_type, extents_type>::value) &&
       (detail::__is_mapping_of<layout_left, StridedLayoutMapping> ||
        detail::__is_mapping_of<layout_right, StridedLayoutMapping> ||
        detail::__is_mapping_of<layout_stride, StridedLayoutMapping>)
@@ -356,7 +356,7 @@ struct layout_stride {
     };
 
     MDSPAN_INLINE_FUNCTION
-    constexpr array< index_type, extents_type::rank() > strides() const noexcept {
+    constexpr std::array< index_type, extents_type::rank() > strides() const noexcept {
       return __strides_storage();
     }
 
@@ -376,8 +376,8 @@ struct layout_stride {
       class... Indices,
       /* requires */ (
         sizeof...(Indices) == Extents::rank() &&
-        _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, Indices, index_type) /*&& ...*/ ) &&
-        _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_nothrow_constructible, index_type, Indices) /*&& ...*/)
+        _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, Indices, index_type) /*&& ...*/ ) &&
+        _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, Indices) /*&& ...*/)
       )
     )
     MDSPAN_FORCE_INLINE_FUNCTION
@@ -393,7 +393,7 @@ struct layout_stride {
 
     MDSPAN_INLINE_FUNCTION static constexpr bool is_unique() noexcept { return true; }
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 bool is_exhaustive() const noexcept {
-      return required_span_size() == __get_size(extents(), make_index_sequence<extents_type::rank()>());
+      return required_span_size() == __get_size(extents(), std::make_index_sequence<extents_type::rank()>());
     }
     MDSPAN_INLINE_FUNCTION static constexpr bool is_strided() noexcept { return true; }
 

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -118,9 +118,9 @@ struct layout_stride {
 #endif
     }
 
-    template<class SizeType, ::size_t ... Ep, ::size_t ... Idx>
+    template<class SizeType, size_t ... Ep, size_t ... Idx>
     _MDSPAN_HOST_DEVICE
-    constexpr index_type __get_size(::std::experimental::extents<SizeType, Ep...>,std::integer_sequence<::size_t, Idx...>) const {
+    constexpr index_type __get_size(::std::experimental::extents<SizeType, Ep...>,std::integer_sequence<size_t, Idx...>) const {
       return _MDSPAN_FOLD_TIMES_RIGHT( static_cast<index_type>(extents().extent(Idx)), 1 );
     }
 

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -40,20 +40,20 @@ private:
   template <class>
   struct __deduction_workaround;
 
-  template <size_t... Idxs>
-  struct __deduction_workaround<index_sequence<Idxs...>>
+  template <std::size_t... Idxs>
+  struct __deduction_workaround<std::index_sequence<Idxs...>>
   {
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
-    size_t __size(mdspan const& __self) noexcept {
-      return _MDSPAN_FOLD_TIMES_RIGHT((__self.__mapping_ref().extents().extent(Idxs)), /* * ... * */ size_t(1));
+    std::size_t __size(mdspan const& __self) noexcept {
+      return _MDSPAN_FOLD_TIMES_RIGHT((__self.__mapping_ref().extents().extent(Idxs)), /* * ... * */ std::size_t(1));
     }
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
     bool __empty(mdspan const& __self) noexcept {
       return (__self.rank()>0) && _MDSPAN_FOLD_OR((__self.__mapping_ref().extents().extent(Idxs)==index_type(0)));
     }
-    template <class ReferenceType, class SizeType, size_t N>
+    template <class ReferenceType, class SizeType, std::size_t N>
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
-    ReferenceType __callop(mdspan const& __self, const array<SizeType, N>& indices) noexcept {
+    ReferenceType __callop(mdspan const& __self, const std::array<SizeType, N>& indices) noexcept {
       return __self.__accessor_ref().access(__self.__ptr_ref(), __self.__mapping_ref()(indices[Idxs]...));
     }
   };
@@ -68,22 +68,22 @@ public:
   using accessor_type = AccessorPolicy;
   using mapping_type = typename layout_type::template mapping<extents_type>;
   using element_type = ElementType;
-  using value_type = remove_cv_t<element_type>;
+  using value_type = std::remove_cv_t<element_type>;
   using index_type = typename extents_type::index_type;
   using size_type = typename extents_type::size_type;
   using rank_type = typename extents_type::rank_type;
   using data_handle_type = typename accessor_type::data_handle_type;
   using reference = typename accessor_type::reference;
 
-  MDSPAN_INLINE_FUNCTION static constexpr size_t rank() noexcept { return extents_type::rank(); }
-  MDSPAN_INLINE_FUNCTION static constexpr size_t rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
-  MDSPAN_INLINE_FUNCTION static constexpr size_t static_extent(size_t r) noexcept { return extents_type::static_extent(r); }
-  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return __mapping_ref().extents().extent(r); };
+  MDSPAN_INLINE_FUNCTION static constexpr std::size_t rank() noexcept { return extents_type::rank(); }
+  MDSPAN_INLINE_FUNCTION static constexpr std::size_t rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
+  MDSPAN_INLINE_FUNCTION static constexpr std::size_t static_extent(std::size_t r) noexcept { return extents_type::static_extent(r); }
+  MDSPAN_INLINE_FUNCTION constexpr index_type extent(std::size_t r) const noexcept { return __mapping_ref().extents().extent(r); };
 
 private:
 
   // Can't use defaulted parameter in the __deduction_workaround template because of a bug in MSVC warning C4348.
-  using __impl = __deduction_workaround<make_index_sequence<extents_type::rank()>>;
+  using __impl = __deduction_workaround<std::make_index_sequence<extents_type::rank()>>;
 
   using __map_acc_pair_t = detail::__compressed_pair<mapping_type, accessor_type>;
 
@@ -99,9 +99,9 @@ public:
     requires(
        // nvhpc has a bug where using just rank_dynamic() here doesn't work ...
        (extents_type::rank_dynamic() > 0) &&
-       _MDSPAN_TRAIT(is_default_constructible, data_handle_type) &&
-       _MDSPAN_TRAIT(is_default_constructible, mapping_type) &&
-       _MDSPAN_TRAIT(is_default_constructible, accessor_type)
+       _MDSPAN_TRAIT(std::is_default_constructible, data_handle_type) &&
+       _MDSPAN_TRAIT(std::is_default_constructible, mapping_type) &&
+       _MDSPAN_TRAIT(std::is_default_constructible, accessor_type)
      ) = default;
 #endif
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mdspan(const mdspan&) = default;
@@ -110,11 +110,11 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeTypes) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeTypes) /* && ... */) &&
       ((sizeof...(SizeTypes) == rank()) || (sizeof...(SizeTypes) == rank_dynamic())) &&
-      _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type) &&
-      _MDSPAN_TRAIT(is_default_constructible, accessor_type)
+      _MDSPAN_TRAIT(std::is_constructible, mapping_type, extents_type) &&
+      _MDSPAN_TRAIT(std::is_default_constructible, accessor_type)
     )
   )
   MDSPAN_INLINE_FUNCTION
@@ -124,35 +124,35 @@ public:
   { }
 
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, size_t N,
+    class SizeType, std::size_t N,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
-      _MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeType) &&
+      _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType) &&
       ((N == rank()) || (N == rank_dynamic())) &&
-      _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type) &&
-      _MDSPAN_TRAIT(is_default_constructible, accessor_type)
+      _MDSPAN_TRAIT(std::is_constructible, mapping_type, extents_type) &&
+      _MDSPAN_TRAIT(std::is_default_constructible, accessor_type)
     )
   )
   MDSPAN_CONDITIONAL_EXPLICIT(N != rank_dynamic())
   MDSPAN_INLINE_FUNCTION
-  constexpr mdspan(data_handle_type p, const array<SizeType, N>& dynamic_extents)
+  constexpr mdspan(data_handle_type p, const std::array<SizeType, N>& dynamic_extents)
     : __members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(dynamic_extents)), accessor_type()))
   { }
 
 #ifdef __cpp_lib_span
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, size_t N,
+    class SizeType, std::size_t N,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
-      _MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeType) &&
+      _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType) &&
       ((N == rank()) || (N == rank_dynamic())) &&
-      _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type) &&
-      _MDSPAN_TRAIT(is_default_constructible, accessor_type)
+      _MDSPAN_TRAIT(std::is_constructible, mapping_type, extents_type) &&
+      _MDSPAN_TRAIT(std::is_default_constructible, accessor_type)
     )
   )
   MDSPAN_CONDITIONAL_EXPLICIT(N != rank_dynamic())
   MDSPAN_INLINE_FUNCTION
-  constexpr mdspan(data_handle_type p, span<SizeType, N> dynamic_extents)
+  constexpr mdspan(data_handle_type p, std::span<SizeType, N> dynamic_extents)
     : __members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(as_const(dynamic_extents))), accessor_type()))
   { }
 #endif
@@ -160,15 +160,15 @@ public:
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdspan, (data_handle_type p, const extents_type& exts), ,
-    /* requires */ (_MDSPAN_TRAIT(is_default_constructible, accessor_type) &&
-                    _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type))
+    /* requires */ (_MDSPAN_TRAIT(std::is_default_constructible, accessor_type) &&
+                    _MDSPAN_TRAIT(std::is_constructible, mapping_type, extents_type))
   ) : __members(std::move(p), __map_acc_pair_t(mapping_type(exts), accessor_type()))
   { }
 
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdspan, (data_handle_type p, const mapping_type& m), ,
-    /* requires */ (_MDSPAN_TRAIT(is_default_constructible, accessor_type))
+    /* requires */ (_MDSPAN_TRAIT(std::is_default_constructible, accessor_type))
   ) : __members(std::move(p), __map_acc_pair_t(m, accessor_type()))
   { }
 
@@ -180,16 +180,16 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherAccessor,
     /* requires */ (
-      _MDSPAN_TRAIT(is_constructible, mapping_type, typename OtherLayoutPolicy::template mapping<OtherExtents>) &&
-      _MDSPAN_TRAIT(is_constructible, accessor_type, OtherAccessor)
+      _MDSPAN_TRAIT(std::is_constructible, mapping_type, typename OtherLayoutPolicy::template mapping<OtherExtents>) &&
+      _MDSPAN_TRAIT(std::is_constructible, accessor_type, OtherAccessor)
     )
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other)
     : __members(other.__ptr_ref(), __map_acc_pair_t(other.__mapping_ref(), other.__accessor_ref()))
   {
-      static_assert(_MDSPAN_TRAIT(is_constructible, data_handle_type, typename OtherAccessor::data_handle_type),"Incompatible data_handle_type for mdspan construction");
-      static_assert(_MDSPAN_TRAIT(is_constructible, extents_type, OtherExtents),"Incompatible extents for mdspan construction");
+      static_assert(_MDSPAN_TRAIT(std::is_constructible, data_handle_type, typename OtherAccessor::data_handle_type),"Incompatible data_handle_type for mdspan construction");
+      static_assert(_MDSPAN_TRAIT(std::is_constructible, extents_type, OtherExtents),"Incompatible extents for mdspan construction");
       /*
        * TODO: Check precondition
        * For each rank index r of extents_type, static_extent(r) == dynamic_extent || static_extent(r) == other.extent(r) is true.
@@ -212,8 +212,8 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeTypes) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeTypes) /* && ... */) &&
       (rank() == sizeof...(SizeTypes))
     )
   )
@@ -227,12 +227,12 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class SizeType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
-      _MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeType)
+      _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType)
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator[](const array<SizeType, rank()>& indices) const
+  constexpr reference operator[](const std::array< SizeType, rank()>& indices) const
   {
     return __impl::template __callop<reference>(*this, indices);
   }
@@ -241,12 +241,12 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class SizeType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
-      _MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeType)
+      _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType)
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator[](span<SizeType, rank()> indices) const
+  constexpr reference operator[](std::span<SizeType, rank()> indices) const
   {
     return __impl::template __callop<reference>(*this, indices);
   }
@@ -256,8 +256,8 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class Index,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, Index, index_type) &&
-      _MDSPAN_TRAIT(is_nothrow_constructible, index_type, Index) &&
+      _MDSPAN_TRAIT(std::is_convertible, Index, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, Index) &&
       extents_type::rank() == 1
     )
   )
@@ -272,8 +272,8 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeTypes) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeTypes) /* && ... */) &&
       extents_type::rank() == sizeof...(SizeTypes)
     )
   )
@@ -286,12 +286,12 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class SizeType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
-      _MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeType)
+      _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType)
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator()(const array<SizeType, rank()>& indices) const
+  constexpr reference operator()(const std::array<SizeType, rank()>& indices) const
   {
     return __impl::template __callop<reference>(*this, indices);
   }
@@ -300,19 +300,19 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class SizeType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
-      _MDSPAN_TRAIT(is_nothrow_constructible, index_type, SizeType)
+      _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType)
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator()(span<SizeType, rank()> indices) const
+  constexpr reference operator()(std::span<SizeType, rank()> indices) const
   {
     return __impl::template __callop<reference>(*this, indices);
   }
   #endif // __cpp_lib_span
   #endif // MDSPAN_USE_PAREN_OPERATOR
 
-  MDSPAN_INLINE_FUNCTION constexpr size_t size() const noexcept {
+  MDSPAN_INLINE_FUNCTION constexpr std::size_t size() const noexcept {
     return __impl::__size(*this);
   };
 
@@ -324,6 +324,7 @@ public:
   friend constexpr void swap(mdspan& x, mdspan& y) noexcept {
     // can't call the std::swap inside on HIP
     #if !defined(_MDSPAN_HAS_HIP) && !defined(_MDSPAN_HAS_CUDA)
+    using std::swap;
     swap(x.__ptr_ref(), y.__ptr_ref());
     swap(x.__mapping_ref(), y.__mapping_ref());
     swap(x.__accessor_ref(), y.__accessor_ref());
@@ -353,7 +354,7 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const noexcept { return __mapping_ref().is_unique(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept { return __mapping_ref().is_exhaustive(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const noexcept { return __mapping_ref().is_strided(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return __mapping_ref().stride(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type stride(std::size_t r) const { return __mapping_ref().stride(r); };
 
 private:
 
@@ -374,38 +375,38 @@ private:
 #if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 MDSPAN_TEMPLATE_REQUIRES(
   class ElementType, class... SizeTypes,
-  /* requires */ _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_integral, SizeTypes) /* && ... */) &&
+  /* requires */ _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_integral, SizeTypes) /* && ... */) &&
   (sizeof...(SizeTypes) > 0)
 )
 MDSPAN_DEDUCTION_GUIDE explicit mdspan(ElementType*, SizeTypes...)
-  -> mdspan<ElementType, ::std::experimental::dextents<size_t, sizeof...(SizeTypes)>>;
+  -> mdspan<ElementType, ::std::experimental::dextents<std::size_t, sizeof...(SizeTypes)>>;
 
 MDSPAN_TEMPLATE_REQUIRES(
   class Pointer,
-  (_MDSPAN_TRAIT(is_pointer, std::remove_reference_t<Pointer>))
+  (_MDSPAN_TRAIT(std::is_pointer, std::remove_reference_t<Pointer>))
 )
-MDSPAN_DEDUCTION_GUIDE mdspan(Pointer&&) -> mdspan<std::remove_pointer_t<std::remove_reference_t<Pointer>>, extents<size_t>>;
+MDSPAN_DEDUCTION_GUIDE mdspan(Pointer&&) -> mdspan<std::remove_pointer_t<std::remove_reference_t<Pointer>>, extents<std::size_t>>;
 
 MDSPAN_TEMPLATE_REQUIRES(
   class CArray,
-  (_MDSPAN_TRAIT(is_array, CArray) && (rank_v<CArray> == 1))
+  (_MDSPAN_TRAIT(std::is_array, CArray) && (std::rank_v<CArray> == 1))
 )
-MDSPAN_DEDUCTION_GUIDE mdspan(CArray&) -> mdspan<std::remove_all_extents_t<CArray>, extents<size_t, ::std::extent_v<CArray,0>>>;
+MDSPAN_DEDUCTION_GUIDE mdspan(CArray&) -> mdspan<std::remove_all_extents_t<CArray>, extents<std::size_t, ::std::extent_v<CArray,0>>>;
 
-template <class ElementType, class SizeType, size_t N>
+template <class ElementType, class SizeType, std::size_t N>
 MDSPAN_DEDUCTION_GUIDE mdspan(ElementType*, const ::std::array<SizeType, N>&)
-  -> mdspan<ElementType, ::std::experimental::dextents<size_t, N>>;
+  -> mdspan<ElementType, ::std::experimental::dextents<std::size_t, N>>;
 
 #ifdef __cpp_lib_span
-template <class ElementType, class SizeType, size_t N>
+template <class ElementType, class SizeType, std::size_t N>
 MDSPAN_DEDUCTION_GUIDE mdspan(ElementType*, ::std::span<SizeType, N>)
-  -> mdspan<ElementType, ::std::experimental::dextents<size_t, N>>;
+  -> mdspan<ElementType, ::std::experimental::dextents<std::size_t, N>>;
 #endif
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
-template <class ElementType, class SizeType, size_t... ExtentsPack>
+template <class ElementType, class SizeType, std::size_t... ExtentsPack>
 MDSPAN_DEDUCTION_GUIDE mdspan(ElementType*, const extents<SizeType, ExtentsPack...>&)
   -> mdspan<ElementType, ::std::experimental::extents<SizeType, ExtentsPack...>>;
 

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -40,18 +40,18 @@ private:
   template <class>
   struct __deduction_workaround;
 
-  template <std::size_t... Idxs>
+  template <size_t... Idxs>
   struct __deduction_workaround<std::index_sequence<Idxs...>>
   {
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
-    std::size_t __size(mdspan const& __self) noexcept {
-      return _MDSPAN_FOLD_TIMES_RIGHT((__self.__mapping_ref().extents().extent(Idxs)), /* * ... * */ std::size_t(1));
+    size_t __size(mdspan const& __self) noexcept {
+      return _MDSPAN_FOLD_TIMES_RIGHT((__self.__mapping_ref().extents().extent(Idxs)), /* * ... * */ size_t(1));
     }
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
     bool __empty(mdspan const& __self) noexcept {
       return (__self.rank()>0) && _MDSPAN_FOLD_OR((__self.__mapping_ref().extents().extent(Idxs)==index_type(0)));
     }
-    template <class ReferenceType, class SizeType, std::size_t N>
+    template <class ReferenceType, class SizeType, size_t N>
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
     ReferenceType __callop(mdspan const& __self, const std::array<SizeType, N>& indices) noexcept {
       return __self.__accessor_ref().access(__self.__ptr_ref(), __self.__mapping_ref()(indices[Idxs]...));
@@ -75,10 +75,10 @@ public:
   using data_handle_type = typename accessor_type::data_handle_type;
   using reference = typename accessor_type::reference;
 
-  MDSPAN_INLINE_FUNCTION static constexpr std::size_t rank() noexcept { return extents_type::rank(); }
-  MDSPAN_INLINE_FUNCTION static constexpr std::size_t rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
-  MDSPAN_INLINE_FUNCTION static constexpr std::size_t static_extent(std::size_t r) noexcept { return extents_type::static_extent(r); }
-  MDSPAN_INLINE_FUNCTION constexpr index_type extent(std::size_t r) const noexcept { return __mapping_ref().extents().extent(r); };
+  MDSPAN_INLINE_FUNCTION static constexpr size_t rank() noexcept { return extents_type::rank(); }
+  MDSPAN_INLINE_FUNCTION static constexpr size_t rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
+  MDSPAN_INLINE_FUNCTION static constexpr size_t static_extent(size_t r) noexcept { return extents_type::static_extent(r); }
+  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return __mapping_ref().extents().extent(r); };
 
 private:
 
@@ -124,7 +124,7 @@ public:
   { }
 
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, std::size_t N,
+    class SizeType, size_t N,
     /* requires */ (
       _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
       _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType) &&
@@ -141,7 +141,7 @@ public:
 
 #ifdef __cpp_lib_span
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, std::size_t N,
+    class SizeType, size_t N,
     /* requires */ (
       _MDSPAN_TRAIT(std::is_convertible, SizeType, index_type) &&
       _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeType) &&
@@ -312,7 +312,7 @@ public:
   #endif // __cpp_lib_span
   #endif // MDSPAN_USE_PAREN_OPERATOR
 
-  MDSPAN_INLINE_FUNCTION constexpr std::size_t size() const noexcept {
+  MDSPAN_INLINE_FUNCTION constexpr size_t size() const noexcept {
     return __impl::__size(*this);
   };
 
@@ -354,7 +354,7 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const noexcept { return __mapping_ref().is_unique(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept { return __mapping_ref().is_exhaustive(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const noexcept { return __mapping_ref().is_strided(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type stride(std::size_t r) const { return __mapping_ref().stride(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return __mapping_ref().stride(r); };
 
 private:
 
@@ -379,34 +379,34 @@ MDSPAN_TEMPLATE_REQUIRES(
   (sizeof...(SizeTypes) > 0)
 )
 MDSPAN_DEDUCTION_GUIDE explicit mdspan(ElementType*, SizeTypes...)
-  -> mdspan<ElementType, ::std::experimental::dextents<std::size_t, sizeof...(SizeTypes)>>;
+  -> mdspan<ElementType, ::std::experimental::dextents<size_t, sizeof...(SizeTypes)>>;
 
 MDSPAN_TEMPLATE_REQUIRES(
   class Pointer,
   (_MDSPAN_TRAIT(std::is_pointer, std::remove_reference_t<Pointer>))
 )
-MDSPAN_DEDUCTION_GUIDE mdspan(Pointer&&) -> mdspan<std::remove_pointer_t<std::remove_reference_t<Pointer>>, extents<std::size_t>>;
+MDSPAN_DEDUCTION_GUIDE mdspan(Pointer&&) -> mdspan<std::remove_pointer_t<std::remove_reference_t<Pointer>>, extents<size_t>>;
 
 MDSPAN_TEMPLATE_REQUIRES(
   class CArray,
   (_MDSPAN_TRAIT(std::is_array, CArray) && (std::rank_v<CArray> == 1))
 )
-MDSPAN_DEDUCTION_GUIDE mdspan(CArray&) -> mdspan<std::remove_all_extents_t<CArray>, extents<std::size_t, ::std::extent_v<CArray,0>>>;
+MDSPAN_DEDUCTION_GUIDE mdspan(CArray&) -> mdspan<std::remove_all_extents_t<CArray>, extents<size_t, ::std::extent_v<CArray,0>>>;
 
-template <class ElementType, class SizeType, std::size_t N>
+template <class ElementType, class SizeType, size_t N>
 MDSPAN_DEDUCTION_GUIDE mdspan(ElementType*, const ::std::array<SizeType, N>&)
-  -> mdspan<ElementType, ::std::experimental::dextents<std::size_t, N>>;
+  -> mdspan<ElementType, ::std::experimental::dextents<size_t, N>>;
 
 #ifdef __cpp_lib_span
-template <class ElementType, class SizeType, std::size_t N>
+template <class ElementType, class SizeType, size_t N>
 MDSPAN_DEDUCTION_GUIDE mdspan(ElementType*, ::std::span<SizeType, N>)
-  -> mdspan<ElementType, ::std::experimental::dextents<std::size_t, N>>;
+  -> mdspan<ElementType, ::std::experimental::dextents<size_t, N>>;
 #endif
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
-template <class ElementType, class SizeType, std::size_t... ExtentsPack>
+template <class ElementType, class SizeType, size_t... ExtentsPack>
 MDSPAN_DEDUCTION_GUIDE mdspan(ElementType*, const extents<SizeType, ExtentsPack...>&)
   -> mdspan<ElementType, ::std::experimental::extents<SizeType, ExtentsPack...>>;
 

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -24,7 +24,7 @@ namespace detail {
 
 //==============================================================================
 
-template <class _T, size_t _Disambiguator = 0, class _Enable = void>
+template <class _T, std::size_t _Disambiguator = 0, class _Enable = void>
 struct __no_unique_address_emulation {
   using __stored_type = _T;
   _T __v;
@@ -39,14 +39,14 @@ struct __no_unique_address_emulation {
 // Empty case
 // This doesn't work if _T is final, of course, but we're not using anything
 // like that currently. That kind of thing could be added pretty easily though
-template <class _T, size_t _Disambiguator>
+template <class _T, std::size_t _Disambiguator>
 struct __no_unique_address_emulation<
     _T, _Disambiguator,
-    enable_if_t<_MDSPAN_TRAIT(is_empty, _T) &&
+    std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T) &&
                 // If the type isn't trivially destructible, its destructor
                 // won't be called at the right time, so don't use this
                 // specialization
-                _MDSPAN_TRAIT(is_trivially_destructible, _T)>> : 
+                _MDSPAN_TRAIT(std::is_trivially_destructible, _T)>> :
 #ifdef _MDSPAN_COMPILER_MSVC
     // MSVC doesn't allow you to access public static member functions of a type
     // when you *happen* to privately inherit from that type.

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -24,7 +24,7 @@ namespace detail {
 
 //==============================================================================
 
-template <class _T, std::size_t _Disambiguator = 0, class _Enable = void>
+template <class _T, size_t _Disambiguator = 0, class _Enable = void>
 struct __no_unique_address_emulation {
   using __stored_type = _T;
   _T __v;
@@ -39,7 +39,7 @@ struct __no_unique_address_emulation {
 // Empty case
 // This doesn't work if _T is final, of course, but we're not using anything
 // like that currently. That kind of thing could be added pretty easily though
-template <class _T, std::size_t _Disambiguator>
+template <class _T, size_t _Disambiguator>
 struct __no_unique_address_emulation<
     _T, _Disambiguator,
     std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T) &&
@@ -52,7 +52,7 @@ struct __no_unique_address_emulation<
     // when you *happen* to privately inherit from that type.
     protected
 #else
-    // But we still want this to be private if possible so that we don't accidentally 
+    // But we still want this to be private if possible so that we don't accidentally
     // access members of _T directly rather than calling __ref() first, which wouldn't
     // work if _T happens to be stateful and thus we're using the unspecialized definition
     // of __no_unique_address_emulation above.

--- a/include/experimental/__p0009_bits/trait_backports.hpp
+++ b/include/experimental/__p0009_bits/trait_backports.hpp
@@ -62,12 +62,12 @@ namespace std {
 
 template <class T, T... Vals>
 struct integer_sequence {
-  static constexpr std::size_t size() noexcept { return sizeof...(Vals); }
+  static constexpr size_t size() noexcept { return sizeof...(Vals); }
   using value_type = T;
 };
 
-template <std::size_t... Vals>
-using index_sequence = std::integer_sequence<std::size_t, Vals...>;
+template <size_t... Vals>
+using index_sequence = std::integer_sequence<size_t, Vals...>;
 
 namespace __detail {
 
@@ -91,7 +91,7 @@ struct __make_int_seq_impl<
 template <class T, T N>
 using make_integer_sequence = typename __detail::__make_int_seq_impl<T, N, 0, integer_sequence<T>>::type;
 
-template <std::size_t N>
+template <size_t N>
 using make_index_sequence = typename __detail::__make_int_seq_impl<size_t, N, 0, integer_sequence<size_t>>::type;
 
 template <class... T>

--- a/include/experimental/__p0009_bits/type_list.hpp
+++ b/include/experimental/__p0009_bits/type_list.hpp
@@ -27,10 +27,10 @@ namespace detail {
 template <class... _Ts> struct __type_list { static constexpr auto __size = sizeof...(_Ts); };
 
 // Implementation of type_list at() that's heavily optimized for small typelists
-template <std::size_t, class> struct __type_at;
-template <std::size_t, class _Seq, class=std::make_index_sequence<_Seq::__size>> struct __type_at_large_impl;
+template <size_t, class> struct __type_at;
+template <size_t, class _Seq, class=std::make_index_sequence<_Seq::__size>> struct __type_at_large_impl;
 
-template <std::size_t _I, std::size_t _Idx, class _T>
+template <size_t _I, size_t _Idx, class _T>
 struct __type_at_entry { };
 
 template <class _Result>
@@ -41,20 +41,20 @@ struct __type_at_assign_op_ignore_rest {
 };
 
 struct __type_at_assign_op_impl {
-  template <std::size_t _I, std::size_t _Idx, class _T>
+  template <size_t _I, size_t _Idx, class _T>
   __type_at_assign_op_impl operator=(__type_at_entry<_I, _Idx, _T>&&);
-  template <std::size_t _I, class _T>
+  template <size_t _I, class _T>
   __type_at_assign_op_ignore_rest<_T> operator=(__type_at_entry<_I, _I, _T>&&);
 };
 
-template <std::size_t _I, class... _Ts, std::size_t... _Idxs>
-struct __type_at_large_impl<_I, __type_list<_Ts...>, std::integer_sequence<std::size_t, _Idxs...>>
+template <size_t _I, class... _Ts, size_t... _Idxs>
+struct __type_at_large_impl<_I, __type_list<_Ts...>, std::integer_sequence<size_t, _Idxs...>>
   : decltype(
       _MDSPAN_FOLD_ASSIGN_LEFT(__type_at_assign_op_impl{}, /* = ... = */ __type_at_entry<_I, _Idxs, _Ts>{})
     )
 { };
 
-template <std::size_t _I, class... _Ts>
+template <size_t _I, class... _Ts>
 struct __type_at<_I, __type_list<_Ts...>>
     : __type_at_large_impl<_I, __type_list<_Ts...>>
 { };

--- a/include/experimental/__p0009_bits/type_list.hpp
+++ b/include/experimental/__p0009_bits/type_list.hpp
@@ -27,10 +27,10 @@ namespace detail {
 template <class... _Ts> struct __type_list { static constexpr auto __size = sizeof...(_Ts); };
 
 // Implementation of type_list at() that's heavily optimized for small typelists
-template <size_t, class> struct __type_at;
-template <size_t, class _Seq, class=make_index_sequence<_Seq::__size>> struct __type_at_large_impl;
+template <std::size_t, class> struct __type_at;
+template <std::size_t, class _Seq, class=std::make_index_sequence<_Seq::__size>> struct __type_at_large_impl;
 
-template <size_t _I, size_t _Idx, class _T>
+template <std::size_t _I, std::size_t _Idx, class _T>
 struct __type_at_entry { };
 
 template <class _Result>
@@ -41,20 +41,20 @@ struct __type_at_assign_op_ignore_rest {
 };
 
 struct __type_at_assign_op_impl {
-  template <size_t _I, size_t _Idx, class _T>
+  template <std::size_t _I, std::size_t _Idx, class _T>
   __type_at_assign_op_impl operator=(__type_at_entry<_I, _Idx, _T>&&);
-  template <size_t _I, class _T>
+  template <std::size_t _I, class _T>
   __type_at_assign_op_ignore_rest<_T> operator=(__type_at_entry<_I, _I, _T>&&);
 };
 
-template <size_t _I, class... _Ts, size_t... _Idxs>
-struct __type_at_large_impl<_I, __type_list<_Ts...>, integer_sequence<size_t, _Idxs...>>
+template <std::size_t _I, class... _Ts, std::size_t... _Idxs>
+struct __type_at_large_impl<_I, __type_list<_Ts...>, std::integer_sequence<std::size_t, _Idxs...>>
   : decltype(
       _MDSPAN_FOLD_ASSIGN_LEFT(__type_at_assign_op_impl{}, /* = ... = */ __type_at_entry<_I, _Idxs, _Ts>{})
     )
 { };
 
-template <size_t _I, class... _Ts>
+template <std::size_t _I, class... _Ts>
 struct __type_at<_I, __type_list<_Ts...>>
     : __type_at_large_impl<_I, __type_list<_Ts...>>
 { };

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -27,11 +27,11 @@ namespace {
   template<class Extents>
   struct size_of_extents;
 
-  template<class IndexType, std::size_t ... Extents>
+  template<class IndexType, size_t ... Extents>
   struct size_of_extents<extents<IndexType, Extents...>> {
-    constexpr static std::size_t value() {
-      std::size_t size = 1;
-      for(std::size_t r=0; r<extents<IndexType, Extents...>::rank(); r++)
+    constexpr static size_t value() {
+      size_t size = 1;
+      for(size_t r=0; r<extents<IndexType, Extents...>::rank(); r++)
         size *= extents<IndexType, Extents...>::static_extent(r);
       return size;
     }
@@ -44,7 +44,7 @@ namespace {
     template<class M>
     static constexpr C construct(const M& m) { return C(m.required_span_size()); }
   };
-  template<class T, std::size_t N>
+  template<class T, size_t N>
   struct container_is_array<std::array<T,N>> : std::true_type {
     template<class M>
     static constexpr std::array<T,N> construct(const M&) { return std::array<T,N>(); }
@@ -106,7 +106,7 @@ public:
       _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
       _MDSPAN_TRAIT( std::is_constructible, extents_type, SizeTypes...) &&
       _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type) &&
-      (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t) ||
+      (_MDSPAN_TRAIT( std::is_constructible, container_type, size_t) ||
        container_is_array<container_type>::value) &&
       (extents_type::rank()>0 || extents_type::rank_dynamic()==0)
     )
@@ -119,7 +119,7 @@ public:
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdarray, (const extents_type& exts), ,
-    /* requires */ ((_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t) ||
+    /* requires */ ((_MDSPAN_TRAIT( std::is_constructible, container_type, size_t) ||
                      container_is_array<container_type>::value) &&
                     _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   ) : map_(exts), ctr_(container_is_array<container_type>::construct(map_))
@@ -128,7 +128,7 @@ public:
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdarray, (const mapping_type& m), ,
-    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t) ||
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, size_t) ||
                     container_is_array<container_type>::value)
   ) : map_(m), ctr_(container_is_array<container_type>::construct(map_))
   { }
@@ -145,7 +145,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   explicit constexpr mdarray(const container_type& ctr, SizeTypes... dynamic_extents)
     : map_(extents_type(dynamic_extents...)), ctr_(ctr)
-  { assert(ctr.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr.size() >= static_cast<size_t>(map_.required_span_size())); }
 
 
   MDSPAN_FUNCTION_REQUIRES(
@@ -153,11 +153,11 @@ public:
     mdarray, (const container_type& ctr, const extents_type& exts), ,
     /* requires */ (_MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   ) : map_(exts), ctr_(ctr)
-  { assert(ctr.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr.size() >= static_cast<size_t>(map_.required_span_size())); }
 
   constexpr mdarray(const container_type& ctr, const mapping_type& m)
     : map_(m), ctr_(ctr)
-  { assert(ctr.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr.size() >= static_cast<size_t>(map_.required_span_size())); }
 
 
   // Constructors from container
@@ -172,7 +172,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   explicit constexpr mdarray(container_type&& ctr, SizeTypes... dynamic_extents)
     : map_(extents_type(dynamic_extents...)), ctr_(std::move(ctr))
-  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
 
 
   MDSPAN_FUNCTION_REQUIRES(
@@ -180,11 +180,11 @@ public:
     mdarray, (container_type&& ctr, const extents_type& exts), ,
     /* requires */ (_MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   ) : map_(exts), ctr_(std::move(ctr))
-  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
 
   constexpr mdarray(container_type&& ctr, const mapping_type& m)
     : map_(m), ctr_(std::move(ctr))
-  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
 
 
 
@@ -205,7 +205,7 @@ public:
   // Constructors for container types constructible from a size and allocator
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc) &&
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, size_t, Alloc) &&
                     _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   )
   MDSPAN_INLINE_FUNCTION
@@ -215,7 +215,7 @@ public:
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, size_t, Alloc))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const mapping_type& map, const Alloc& a)
@@ -231,16 +231,16 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const container_type& ctr, const extents_type& exts, const Alloc& a)
     : map_(exts), ctr_(ctr, a)
-  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, size_t, Alloc))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const container_type& ctr, const mapping_type& map, const Alloc& a)
     : map_(map), ctr_(ctr, a)
-  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
@@ -250,11 +250,11 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(container_type&& ctr, const extents_type& exts, const Alloc& a)
     : map_(exts), ctr_(std::move(ctr), a)
-  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, size_t, Alloc))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(container_type&& ctr, const mapping_type& map, const Alloc& a)
@@ -313,7 +313,7 @@ public:
 
 #if 0
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, std::size_t N,
+    class SizeType, size_t N,
     /* requires */ (
       _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
@@ -326,7 +326,7 @@ public:
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, std::size_t N,
+    class SizeType, size_t N,
     /* requires */ (
       _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
@@ -368,7 +368,7 @@ public:
 
 #if 0
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, std::size_t N,
+    class SizeType, size_t N,
     /* requires */ (
       _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
@@ -381,7 +381,7 @@ public:
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, std::size_t N,
+    class SizeType, size_t N,
     /* requires */ (
       _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
@@ -405,10 +405,10 @@ public:
 
   MDSPAN_INLINE_FUNCTION static constexpr rank_type rank() noexcept { return extents_type::rank(); }
   MDSPAN_INLINE_FUNCTION static constexpr rank_type rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
-  MDSPAN_INLINE_FUNCTION static constexpr std::size_t static_extent(std::size_t r) noexcept { return extents_type::static_extent(r); }
+  MDSPAN_INLINE_FUNCTION static constexpr size_t static_extent(size_t r) noexcept { return extents_type::static_extent(r); }
 
   MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return map_.extents(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type extent(std::size_t r) const noexcept { return map_.extents().extent(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return map_.extents().extent(r); };
   MDSPAN_INLINE_FUNCTION constexpr index_type size() const noexcept {
 //    return __impl::__size(*this);
     return ctr_.size();
@@ -426,7 +426,7 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const noexcept { return map_.is_unique(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept { return map_.is_exhaustive(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const noexcept { return map_.is_strided(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type stride(std::size_t r) const { return map_.stride(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return map_.stride(r); };
 
   // Converstion to mdspan
   MDSPAN_TEMPLATE_REQUIRES(

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -27,11 +27,11 @@ namespace {
   template<class Extents>
   struct size_of_extents;
 
-  template<class IndexType, size_t ... Extents>
+  template<class IndexType, std::size_t ... Extents>
   struct size_of_extents<extents<IndexType, Extents...>> {
-    constexpr static size_t value() {
-      size_t size = 1;
-      for(size_t r=0; r<extents<IndexType, Extents...>::rank(); r++)
+    constexpr static std::size_t value() {
+      std::size_t size = 1;
+      for(std::size_t r=0; r<extents<IndexType, Extents...>::rank(); r++)
         size *= extents<IndexType, Extents...>::static_extent(r);
       return size;
     }
@@ -40,14 +40,14 @@ namespace {
 
 namespace {
   template<class C>
-  struct container_is_array : false_type {
+  struct container_is_array :  std::false_type {
     template<class M>
     static constexpr C construct(const M& m) { return C(m.required_span_size()); }
   };
-  template<class T, size_t N>
-  struct container_is_array<array<T,N>> : true_type {
+  template<class T, std::size_t N>
+  struct container_is_array<std::array<T,N>> : std::true_type {
     template<class M>
-    static constexpr array<T,N> construct(const M&) { return array<T,N>(); }
+    static constexpr std::array<T,N> construct(const M&) { return std::array<T,N>(); }
   };
 }
 
@@ -55,7 +55,7 @@ template <
   class ElementType,
   class Extents,
   class LayoutPolicy = layout_right,
-  class Container = vector<ElementType>
+  class Container = std::vector<ElementType>
 >
 class mdarray {
 private:
@@ -74,7 +74,7 @@ public:
   using element_type = ElementType;
   using mdspan_type = mdspan<element_type, extents_type, layout_type>;
   using const_mdspan_type = mdspan<const element_type, extents_type, layout_type>;
-  using value_type = remove_cv_t<element_type>;
+  using value_type = std::remove_cv_t<element_type>;
   using index_type = typename Extents::index_type;
   using size_type = typename Extents::size_type;
   using rank_type = typename Extents::rank_type;
@@ -103,10 +103,10 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
-      _MDSPAN_TRAIT(is_constructible, extents_type, SizeTypes...) &&
-      _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type) &&
-      (_MDSPAN_TRAIT(is_constructible, container_type, size_t) ||
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_TRAIT( std::is_constructible, extents_type, SizeTypes...) &&
+      _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type) &&
+      (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t) ||
        container_is_array<container_type>::value) &&
       (extents_type::rank()>0 || extents_type::rank_dynamic()==0)
     )
@@ -119,16 +119,16 @@ public:
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdarray, (const extents_type& exts), ,
-    /* requires */ ((_MDSPAN_TRAIT(is_constructible, container_type, size_t) ||
+    /* requires */ ((_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t) ||
                      container_is_array<container_type>::value) &&
-                    _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type))
+                    _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   ) : map_(exts), ctr_(container_is_array<container_type>::construct(map_))
   { }
 
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdarray, (const mapping_type& m), ,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, container_type, size_t) ||
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t) ||
                     container_is_array<container_type>::value)
   ) : map_(m), ctr_(container_is_array<container_type>::construct(map_))
   { }
@@ -137,76 +137,76 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
-      _MDSPAN_TRAIT(is_constructible, extents_type, SizeTypes...) &&
-      _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type)
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_TRAIT( std::is_constructible, extents_type, SizeTypes...) &&
+      _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type)
     )
   )
   MDSPAN_INLINE_FUNCTION
   explicit constexpr mdarray(const container_type& ctr, SizeTypes... dynamic_extents)
     : map_(extents_type(dynamic_extents...)), ctr_(ctr)
-  { assert(ctr.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
 
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdarray, (const container_type& ctr, const extents_type& exts), ,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, mapping_type, extents_type))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   ) : map_(exts), ctr_(ctr)
-  { assert(ctr.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
   constexpr mdarray(const container_type& ctr, const mapping_type& m)
     : map_(m), ctr_(ctr)
-  { assert(ctr.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
 
   // Constructors from container
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
-      _MDSPAN_TRAIT(is_constructible, extents_type, SizeTypes...) &&
-      _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type)
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_TRAIT( std::is_constructible, extents_type, SizeTypes...) &&
+      _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type)
     )
   )
   MDSPAN_INLINE_FUNCTION
   explicit constexpr mdarray(container_type&& ctr, SizeTypes... dynamic_extents)
     : map_(extents_type(dynamic_extents...)), ctr_(std::move(ctr))
-  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
 
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdarray, (container_type&& ctr, const extents_type& exts), ,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, mapping_type, extents_type))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   ) : map_(exts), ctr_(std::move(ctr))
-  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
   constexpr mdarray(container_type&& ctr, const mapping_type& m)
     : map_(m), ctr_(std::move(ctr))
-  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
 
 
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherContainer,
     /* requires */ (
-      _MDSPAN_TRAIT(is_constructible, mapping_type, typename OtherLayoutPolicy::template mapping<OtherExtents>) &&
-      _MDSPAN_TRAIT(is_constructible, container_type, OtherContainer)
+      _MDSPAN_TRAIT( std::is_constructible, mapping_type, typename OtherLayoutPolicy::template mapping<OtherExtents>) &&
+      _MDSPAN_TRAIT( std::is_constructible, container_type, OtherContainer)
     )
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const mdarray<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherContainer>& other)
     : map_(other.mapping()), ctr_(other.container())
   {
-    static_assert(is_constructible<extents_type, OtherExtents>::value, "");
+    static_assert( std::is_constructible<extents_type, OtherExtents>::value, "");
   }
 
   // Constructors for container types constructible from a size and allocator
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, container_type, size_t, Alloc) &&
-                    _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc) &&
+                    _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const extents_type& exts, const Alloc& a)
@@ -215,7 +215,7 @@ public:
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, container_type, size_t, Alloc))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const mapping_type& map, const Alloc& a)
@@ -225,36 +225,36 @@ public:
   // Constructors for container types constructible from a container and allocator
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, container_type, container_type, Alloc) &&
-                    _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, container_type, Alloc) &&
+                    _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const container_type& ctr, const extents_type& exts, const Alloc& a)
     : map_(exts), ctr_(ctr, a)
-  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, container_type, size_t, Alloc))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const container_type& ctr, const mapping_type& map, const Alloc& a)
     : map_(map), ctr_(ctr, a)
-  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, container_type, container_type, Alloc) &&
-                    _MDSPAN_TRAIT(is_constructible, mapping_type, extents_type))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, container_type, Alloc) &&
+                    _MDSPAN_TRAIT( std::is_constructible, mapping_type, extents_type))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(container_type&& ctr, const extents_type& exts, const Alloc& a)
     : map_(exts), ctr_(std::move(ctr), a)
-  { assert(ctr_.size() >= static_cast<size_t>(map_.required_span_size())); }
+  { assert(ctr_.size() >= static_cast<std::size_t>(map_.required_span_size())); }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Alloc,
-    /* requires */ (_MDSPAN_TRAIT(is_constructible, container_type, size_t, Alloc))
+    /* requires */ (_MDSPAN_TRAIT( std::is_constructible, container_type, std::size_t, Alloc))
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(container_type&& ctr, const mapping_type& map, const Alloc& a)
@@ -264,15 +264,15 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherElementType, class OtherExtents, class OtherLayoutPolicy, class OtherContainer, class Alloc,
     /* requires */ (
-      _MDSPAN_TRAIT(is_constructible, mapping_type, typename OtherLayoutPolicy::template mapping<OtherExtents>) &&
-      _MDSPAN_TRAIT(is_constructible, container_type, OtherContainer, Alloc)
+      _MDSPAN_TRAIT( std::is_constructible, mapping_type, typename OtherLayoutPolicy::template mapping<OtherExtents>) &&
+      _MDSPAN_TRAIT( std::is_constructible, container_type, OtherContainer, Alloc)
     )
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdarray(const mdarray<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherContainer>& other, const Alloc& a)
     : map_(other.mapping()), ctr_(other.container(), a)
   {
-    static_assert(is_constructible<extents_type, OtherExtents>::value, "");
+    static_assert( std::is_constructible<extents_type, OtherExtents>::value, "");
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mdarray& operator= (const mdarray&) = default;
@@ -287,7 +287,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
       extents_type::rank() == sizeof...(SizeTypes)
     )
   )
@@ -300,7 +300,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
       extents_type::rank() == sizeof...(SizeTypes)
     )
   )
@@ -313,27 +313,27 @@ public:
 
 #if 0
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, size_t N,
+    class SizeType, std::size_t N,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr const_reference operator[](const array<SizeType, N>& indices) const noexcept
+  constexpr const_reference operator[](const std::array<SizeType, N>& indices) const noexcept
   {
     return __impl::template __callop<reference>(*this, indices);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, size_t N,
+    class SizeType, std::size_t N,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator[](const array<SizeType, N>& indices) noexcept
+  constexpr reference operator[](const std::array<SizeType, N>& indices) noexcept
   {
     return __impl::template __callop<reference>(*this, indices);
   }
@@ -344,7 +344,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
       extents_type::rank() == sizeof...(SizeTypes)
     )
   )
@@ -356,7 +356,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
     /* requires */ (
-      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT( std::is_convertible, SizeTypes, index_type) /* && ... */) &&
       extents_type::rank() == sizeof...(SizeTypes)
     )
   )
@@ -368,27 +368,27 @@ public:
 
 #if 0
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, size_t N,
+    class SizeType, std::size_t N,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr const_reference operator()(const array<SizeType, N>& indices) const noexcept
+  constexpr const_reference operator()(const std::array<SizeType, N>& indices) const noexcept
   {
     return __impl::template __callop<reference>(*this, indices);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
-    class SizeType, size_t N,
+    class SizeType, std::size_t N,
     /* requires */ (
-      _MDSPAN_TRAIT(is_convertible, SizeType, index_type) &&
+      _MDSPAN_TRAIT( std::is_convertible, SizeType, index_type) &&
       N == extents_type::rank()
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator()(const array<SizeType, N>& indices) noexcept
+  constexpr reference operator()(const std::array<SizeType, N>& indices) noexcept
   {
     return __impl::template __callop<reference>(*this, indices);
   }
@@ -405,10 +405,10 @@ public:
 
   MDSPAN_INLINE_FUNCTION static constexpr rank_type rank() noexcept { return extents_type::rank(); }
   MDSPAN_INLINE_FUNCTION static constexpr rank_type rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
-  MDSPAN_INLINE_FUNCTION static constexpr size_t static_extent(size_t r) noexcept { return extents_type::static_extent(r); }
+  MDSPAN_INLINE_FUNCTION static constexpr std::size_t static_extent(std::size_t r) noexcept { return extents_type::static_extent(r); }
 
   MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return map_.extents(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return map_.extents().extent(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type extent(std::size_t r) const noexcept { return map_.extents().extent(r); };
   MDSPAN_INLINE_FUNCTION constexpr index_type size() const noexcept {
 //    return __impl::__size(*this);
     return ctr_.size();
@@ -426,14 +426,14 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const noexcept { return map_.is_unique(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept { return map_.is_exhaustive(); };
   MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const noexcept { return map_.is_strided(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return map_.stride(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type stride(std::size_t r) const { return map_.stride(r); };
 
   // Converstion to mdspan
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherElementType, class OtherExtents,
     class OtherLayoutType, class OtherAccessorType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_assignable, mdspan_type,
+      _MDSPAN_TRAIT(std::is_assignable, mdspan_type,
                        mdspan<OtherElementType, OtherExtents, OtherLayoutType, OtherAccessorType>)
     )
   )
@@ -445,7 +445,7 @@ public:
     class OtherElementType, class OtherExtents,
     class OtherLayoutType, class OtherAccessorType,
     /* requires */ (
-      _MDSPAN_TRAIT(is_assignable, const_mdspan_type,
+      _MDSPAN_TRAIT(std::is_assignable, const_mdspan_type,
                       mdspan<OtherElementType, OtherExtents, OtherLayoutType, OtherAccessorType>)
     )
   )
@@ -456,7 +456,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherAccessorType = default_accessor<element_type>,
     /* requires */ (
-      _MDSPAN_TRAIT(is_assignable, mdspan_type,
+      _MDSPAN_TRAIT(std::is_assignable, mdspan_type,
                       mdspan<element_type, extents_type, layout_type, OtherAccessorType>)
     )
   )
@@ -468,7 +468,7 @@ public:
   MDSPAN_TEMPLATE_REQUIRES(
     class OtherAccessorType = default_accessor<const element_type>,
     /* requires */ (
-      _MDSPAN_TRAIT(is_assignable, const_mdspan_type,
+      _MDSPAN_TRAIT(std::is_assignable, const_mdspan_type,
                       mdspan<const element_type, extents_type, layout_type, OtherAccessorType>)
     )
   )

--- a/include/experimental/__p2630_bits/strided_slice.hpp
+++ b/include/experimental/__p2630_bits/strided_slice.hpp
@@ -25,7 +25,7 @@ namespace {
   struct __mdspan_is_integral_constant: std::false_type {};
 
   template<class T, T val>
-  struct __mdspan_is_integral_constant<integral_constant<T,val>>: std::true_type {};
+  struct __mdspan_is_integral_constant<std::integral_constant<T,val>>: std::true_type {};
 }
 // Slice Specifier allowing for strides and compile time extent
 template <class OffsetType, class ExtentType, class StrideType>
@@ -38,9 +38,9 @@ struct strided_slice {
   ExtentType extent;
   StrideType stride;
 
-  static_assert(is_integral_v<OffsetType> || __mdspan_is_integral_constant<OffsetType>::value);
-  static_assert(is_integral_v<ExtentType> || __mdspan_is_integral_constant<ExtentType>::value);
-  static_assert(is_integral_v<StrideType> || __mdspan_is_integral_constant<StrideType>::value);
+  static_assert(std::is_integral_v<OffsetType> || __mdspan_is_integral_constant<OffsetType>::value);
+  static_assert(std::is_integral_v<ExtentType> || __mdspan_is_integral_constant<ExtentType>::value);
+  static_assert(std::is_integral_v<StrideType> || __mdspan_is_integral_constant<StrideType>::value);
 };
 
 } // experimental

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -25,22 +25,22 @@ namespace detail {
 // InvMapRank is an index_sequence, which we build recursively
 // to contain the mapped indices.
 // end of recursion specialization containing the final index_sequence
-template <std::size_t Counter, std::size_t... MapIdxs>
+template <size_t Counter, size_t... MapIdxs>
 MDSPAN_INLINE_FUNCTION
-constexpr auto inv_map_rank(std::integral_constant<std::size_t, Counter>, std::index_sequence<MapIdxs...>) {
+constexpr auto inv_map_rank(std::integral_constant<size_t, Counter>, std::index_sequence<MapIdxs...>) {
   return std::index_sequence<MapIdxs...>();
 }
 
 // specialization reducing rank by one (i.e., integral slice specifier)
-template<std::size_t Counter, class Slice, class... SliceSpecifiers, std::size_t... MapIdxs>
+template<size_t Counter, class Slice, class... SliceSpecifiers, size_t... MapIdxs>
 MDSPAN_INLINE_FUNCTION
-constexpr auto inv_map_rank(std::integral_constant<std::size_t, Counter>, std::index_sequence<MapIdxs...>, Slice,
+constexpr auto inv_map_rank(std::integral_constant<size_t, Counter>, std::index_sequence<MapIdxs...>, Slice,
                   SliceSpecifiers... slices) {
-  using next_idx_seq_t = std::conditional_t<std::is_convertible_v<Slice, std::size_t>,
+  using next_idx_seq_t = std::conditional_t<std::is_convertible_v<Slice, size_t>,
                                        std::index_sequence<MapIdxs...>,
                                        std::index_sequence<MapIdxs..., Counter>>;
 
-  return inv_map_rank(std::integral_constant<std::size_t,Counter + 1>(), next_idx_seq_t(),
+  return inv_map_rank(std::integral_constant<size_t,Counter + 1>(), next_idx_seq_t(),
                                      slices...);
 }
 
@@ -54,7 +54,7 @@ struct is_strided_slice<
 // first_of(slice): getting begin of slice specifier range
 MDSPAN_TEMPLATE_REQUIRES(
   class Integral,
-  /* requires */(std::is_convertible_v<Integral, std::size_t>)
+  /* requires */(std::is_convertible_v<Integral, size_t>)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr Integral first_of(const Integral &i) {
@@ -62,14 +62,14 @@ constexpr Integral first_of(const Integral &i) {
 }
 
 MDSPAN_INLINE_FUNCTION
-constexpr std::integral_constant<std::size_t, 0>
+constexpr std::integral_constant<size_t, 0>
 first_of(const experimental::full_extent_t &) {
-  return std::integral_constant<std::size_t, 0>();
+  return std::integral_constant<size_t, 0>();
 }
 
 MDSPAN_TEMPLATE_REQUIRES(
   class Slice,
-  /* requires */(std::is_convertible_v<Slice, std::tuple<std::size_t, std::size_t>>)
+  /* requires */(std::is_convertible_v<Slice, std::tuple<size_t, size_t>>)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr auto first_of(const Slice &i) {
@@ -88,21 +88,21 @@ first_of(const strided_slice<OffsetType, ExtentType, StrideType> &r) {
 // of the original view and which rank from the extents.
 // This is needed in the case of slice being full_extent_t.
 MDSPAN_TEMPLATE_REQUIRES(
-  std::size_t k, class Extents, class Integral,
-  /* requires */(std::is_convertible_v<Integral, std::size_t>)
+  size_t k, class Extents, class Integral,
+  /* requires */(std::is_convertible_v<Integral, size_t>)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr Integral
-    last_of(std::integral_constant<std::size_t, k>, const Extents &, const Integral &i) {
+    last_of(std::integral_constant<size_t, k>, const Extents &, const Integral &i) {
   return i;
 }
 
 MDSPAN_TEMPLATE_REQUIRES(
-  std::size_t k, class Extents, class Slice,
-  /* requires */(std::is_convertible_v<Slice, std::tuple<std::size_t, std::size_t>>)
+  size_t k, class Extents, class Slice,
+  /* requires */(std::is_convertible_v<Slice, std::tuple<size_t, size_t>>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr auto last_of(std::integral_constant<std::size_t, k>, const Extents &,
+constexpr auto last_of(std::integral_constant<size_t, k>, const Extents &,
                        const Slice &i) {
   return std::get<1>(i);
 }
@@ -126,14 +126,14 @@ constexpr auto last_of(std::integral_constant<std::size_t, k>, const Extents &,
     #pragma    diagnostic push
     #pragma    diag_suppress = implicit_return_from_non_void_function
 #endif
-template <std::size_t k, class Extents>
+template <size_t k, class Extents>
 MDSPAN_INLINE_FUNCTION
-constexpr auto last_of(std::integral_constant<std::size_t, k>, const Extents &ext,
+constexpr auto last_of(std::integral_constant<size_t, k>, const Extents &ext,
                        experimental::full_extent_t) {
   if constexpr (Extents::static_extent(k) == dynamic_extent) {
     return ext.extent(k);
   } else {
-    return std::integral_constant<std::size_t, Extents::static_extent(k)>();
+    return std::integral_constant<size_t, Extents::static_extent(k)>();
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   // Even with CUDA_ARCH protection this thing warns about calling host function
@@ -152,11 +152,11 @@ constexpr auto last_of(std::integral_constant<std::size_t, k>, const Extents &ex
     #pragma    diagnostic pop
 #endif
 
-template <std::size_t k, class Extents, class OffsetType, class ExtentType,
+template <size_t k, class Extents, class OffsetType, class ExtentType,
           class StrideType>
 MDSPAN_INLINE_FUNCTION
 constexpr OffsetType
-last_of(std::integral_constant<std::size_t, k>, const Extents &,
+last_of(std::integral_constant<size_t, k>, const Extents &,
         const strided_slice<OffsetType, ExtentType, StrideType> &r) {
   return r.extent;
 }
@@ -165,7 +165,7 @@ last_of(std::integral_constant<std::size_t, k>, const Extents &,
 template <class T>
 MDSPAN_INLINE_FUNCTION
 constexpr auto stride_of(const T &) {
-  return std::integral_constant<std::size_t, 1>();
+  return std::integral_constant<size_t, 1>();
 }
 
 template <class OffsetType, class ExtentType, class StrideType>
@@ -207,42 +207,42 @@ constexpr auto multiply(const std::integral_constant<T0, v0> &,
 
 // compute new static extent from range, preserving static knowledge
 template <class Arg0, class Arg1> struct StaticExtentFromRange {
-  constexpr static std::size_t value = dynamic_extent;
+  constexpr static size_t value = dynamic_extent;
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromRange<std::integral_constant<Integral0, val0>,
                              std::integral_constant<Integral1, val1>> {
-  constexpr static std::size_t value = val1 - val0;
+  constexpr static size_t value = val1 - val0;
 };
 
 // compute new static extent from strided_slice, preserving static
 // knowledge
 template <class Arg0, class Arg1> struct StaticExtentFromStridedRange {
-  constexpr static std::size_t value = dynamic_extent;
+  constexpr static size_t value = dynamic_extent;
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromStridedRange<std::integral_constant<Integral0, val0>,
                                     std::integral_constant<Integral1, val1>> {
-  constexpr static std::size_t value = val0 > 0 ? 1 + (val0 - 1) / val1 : 0;
+  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / val1 : 0;
 };
 
 // creates new extents through recursive calls to next_extent member function
 // next_extent has different overloads for different types of stride specifiers
-template <std::size_t K, class Extents, std::size_t... NewExtents>
+template <size_t K, class Extents, size_t... NewExtents>
 struct extents_constructor {
   MDSPAN_TEMPLATE_REQUIRES(
     class Slice, class... SlicesAndExtents,
-    /* requires */(!std::is_convertible_v<Slice, std::size_t> &&
+    /* requires */(!std::is_convertible_v<Slice, size_t> &&
                    !is_strided_slice<Slice>::value)
   )
   MDSPAN_INLINE_FUNCTION
   constexpr static auto next_extent(const Extents &ext, const Slice &sl,
                                     SlicesAndExtents... slices_and_extents) {
-    constexpr std::size_t new_static_extent = StaticExtentFromRange<
+    constexpr size_t new_static_extent = StaticExtentFromRange<
         decltype(first_of(std::declval<Slice>())),
-        decltype(last_of(std::integral_constant<std::size_t, Extents::rank() - K>(),
+        decltype(last_of(std::integral_constant<size_t, Extents::rank() - K>(),
                          std::declval<Extents>(),
                          std::declval<Slice>()))>::value;
 
@@ -251,14 +251,14 @@ struct extents_constructor {
     using index_t = typename Extents::index_type;
     return next_t::next_extent(
         ext, slices_and_extents...,
-        index_t(last_of(std::integral_constant<std::size_t, Extents::rank() - K>(), ext,
+        index_t(last_of(std::integral_constant<size_t, Extents::rank() - K>(), ext,
                         sl)) -
             index_t(first_of(sl)));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Slice, class... SlicesAndExtents,
-    /* requires */ (std::is_convertible_v<Slice, std::size_t>)
+    /* requires */ (std::is_convertible_v<Slice, size_t>)
   )
   MDSPAN_INLINE_FUNCTION
   constexpr static auto next_extent(const Extents &ext, const Slice &,
@@ -284,7 +284,7 @@ struct extents_constructor {
           ext, slices_and_extents...,
           r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, r.stride) : 0);
     } else {
-      constexpr std::size_t new_static_extent = new_static_extent_t::value;
+      constexpr size_t new_static_extent = new_static_extent_t::value;
       using next_t =
           extents_constructor<K - 1, Extents, NewExtents..., new_static_extent>;
       return next_t::next_extent(
@@ -293,7 +293,7 @@ struct extents_constructor {
   }
 };
 
-template <class Extents, std::size_t... NewStaticExtents>
+template <class Extents, size_t... NewStaticExtents>
 struct extents_constructor<0, Extents, NewStaticExtents...> {
 
   template <class... NewExtents>
@@ -308,7 +308,7 @@ struct extents_constructor<0, Extents, NewStaticExtents...> {
 
 // submdspan_extents creates new extents given src extents and submdspan slice
 // specifiers
-template <class IndexType, std::size_t... Extents, class... SliceSpecifiers>
+template <class IndexType, size_t... Extents, class... SliceSpecifiers>
 MDSPAN_INLINE_FUNCTION
 constexpr auto submdspan_extents(const extents<IndexType, Extents...> &src_exts,
                                  SliceSpecifiers... slices) {

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -14,6 +14,8 @@
 //
 //@HEADER
 
+#include <tuple>
+
 #include "strided_slice.hpp"
 namespace std {
 namespace experimental {

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -23,36 +23,36 @@ namespace detail {
 // InvMapRank is an index_sequence, which we build recursively
 // to contain the mapped indices.
 // end of recursion specialization containing the final index_sequence
-template <size_t Counter, size_t... MapIdxs>
+template <std::size_t Counter, std::size_t... MapIdxs>
 MDSPAN_INLINE_FUNCTION
-constexpr auto inv_map_rank(integral_constant<size_t, Counter>, index_sequence<MapIdxs...>) {
-  return index_sequence<MapIdxs...>();
+constexpr auto inv_map_rank(std::integral_constant<std::size_t, Counter>, std::index_sequence<MapIdxs...>) {
+  return std::index_sequence<MapIdxs...>();
 }
 
 // specialization reducing rank by one (i.e., integral slice specifier)
-template<size_t Counter, class Slice, class... SliceSpecifiers, size_t... MapIdxs>
+template<std::size_t Counter, class Slice, class... SliceSpecifiers, std::size_t... MapIdxs>
 MDSPAN_INLINE_FUNCTION
-constexpr auto inv_map_rank(integral_constant<size_t, Counter>, index_sequence<MapIdxs...>, Slice,
+constexpr auto inv_map_rank(std::integral_constant<std::size_t, Counter>, std::index_sequence<MapIdxs...>, Slice,
                   SliceSpecifiers... slices) {
-  using next_idx_seq_t = conditional_t<is_convertible_v<Slice, size_t>,
-                                       index_sequence<MapIdxs...>,
-                                       index_sequence<MapIdxs..., Counter>>;
+  using next_idx_seq_t = std::conditional_t<std::is_convertible_v<Slice, std::size_t>,
+                                       std::index_sequence<MapIdxs...>,
+                                       std::index_sequence<MapIdxs..., Counter>>;
 
-  return inv_map_rank(integral_constant<size_t,Counter + 1>(), next_idx_seq_t(),
+  return inv_map_rank(std::integral_constant<std::size_t,Counter + 1>(), next_idx_seq_t(),
                                      slices...);
 }
 
 // Helper for identifying strided_slice
-template <class T> struct is_strided_slice : false_type {};
+template <class T> struct is_strided_slice : std::false_type {};
 
 template <class OffsetType, class ExtentType, class StrideType>
 struct is_strided_slice<
-    strided_slice<OffsetType, ExtentType, StrideType>> : true_type {};
+    strided_slice<OffsetType, ExtentType, StrideType>> : std::true_type {};
 
 // first_of(slice): getting begin of slice specifier range
 MDSPAN_TEMPLATE_REQUIRES(
   class Integral,
-  /* requires */(is_convertible_v<Integral, size_t>)
+  /* requires */(std::is_convertible_v<Integral, std::size_t>)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr Integral first_of(const Integral &i) {
@@ -60,18 +60,18 @@ constexpr Integral first_of(const Integral &i) {
 }
 
 MDSPAN_INLINE_FUNCTION
-constexpr integral_constant<size_t, 0>
+constexpr std::integral_constant<std::size_t, 0>
 first_of(const experimental::full_extent_t &) {
-  return integral_constant<size_t, 0>();
+  return std::integral_constant<std::size_t, 0>();
 }
 
 MDSPAN_TEMPLATE_REQUIRES(
   class Slice,
-  /* requires */(is_convertible_v<Slice, tuple<size_t, size_t>>)
+  /* requires */(std::is_convertible_v<Slice, std::tuple<std::size_t, std::size_t>>)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr auto first_of(const Slice &i) {
-  return get<0>(i);
+  return std::get<0>(i);
 }
 
 template <class OffsetType, class ExtentType, class StrideType>
@@ -86,23 +86,23 @@ first_of(const strided_slice<OffsetType, ExtentType, StrideType> &r) {
 // of the original view and which rank from the extents.
 // This is needed in the case of slice being full_extent_t.
 MDSPAN_TEMPLATE_REQUIRES(
-  size_t k, class Extents, class Integral,
-  /* requires */(is_convertible_v<Integral, size_t>)
+  std::size_t k, class Extents, class Integral,
+  /* requires */(std::is_convertible_v<Integral, std::size_t>)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr Integral
-    last_of(integral_constant<size_t, k>, const Extents &, const Integral &i) {
+    last_of(std::integral_constant<std::size_t, k>, const Extents &, const Integral &i) {
   return i;
 }
 
 MDSPAN_TEMPLATE_REQUIRES(
-  size_t k, class Extents, class Slice,
-  /* requires */(is_convertible_v<Slice, tuple<size_t, size_t>>)
+  std::size_t k, class Extents, class Slice,
+  /* requires */(std::is_convertible_v<Slice, std::tuple<std::size_t, std::size_t>>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr auto last_of(integral_constant<size_t, k>, const Extents &,
+constexpr auto last_of(std::integral_constant<std::size_t, k>, const Extents &,
                        const Slice &i) {
-  return get<1>(i);
+  return std::get<1>(i);
 }
 
 // Suppress spurious warning with NVCC about no return statement.
@@ -124,14 +124,14 @@ constexpr auto last_of(integral_constant<size_t, k>, const Extents &,
     #pragma    diagnostic push
     #pragma    diag_suppress = implicit_return_from_non_void_function
 #endif
-template <size_t k, class Extents>
+template <std::size_t k, class Extents>
 MDSPAN_INLINE_FUNCTION
-constexpr auto last_of(integral_constant<size_t, k>, const Extents &ext,
+constexpr auto last_of(std::integral_constant<std::size_t, k>, const Extents &ext,
                        experimental::full_extent_t) {
   if constexpr (Extents::static_extent(k) == dynamic_extent) {
     return ext.extent(k);
   } else {
-    return integral_constant<size_t, Extents::static_extent(k)>();
+    return std::integral_constant<std::size_t, Extents::static_extent(k)>();
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   // Even with CUDA_ARCH protection this thing warns about calling host function
@@ -150,11 +150,11 @@ constexpr auto last_of(integral_constant<size_t, k>, const Extents &ext,
     #pragma    diagnostic pop
 #endif
 
-template <size_t k, class Extents, class OffsetType, class ExtentType,
+template <std::size_t k, class Extents, class OffsetType, class ExtentType,
           class StrideType>
 MDSPAN_INLINE_FUNCTION
 constexpr OffsetType
-last_of(integral_constant<size_t, k>, const Extents &,
+last_of(std::integral_constant<std::size_t, k>, const Extents &,
         const strided_slice<OffsetType, ExtentType, StrideType> &r) {
   return r.extent;
 }
@@ -163,7 +163,7 @@ last_of(integral_constant<size_t, k>, const Extents &,
 template <class T>
 MDSPAN_INLINE_FUNCTION
 constexpr auto stride_of(const T &) {
-  return integral_constant<size_t, 1>();
+  return std::integral_constant<std::size_t, 1>();
 }
 
 template <class OffsetType, class ExtentType, class StrideType>
@@ -182,11 +182,11 @@ constexpr auto divide(const T0 &v0, const T1 &v1) {
 
 template <class IndexT, class T0, T0 v0, class T1, T1 v1>
 MDSPAN_INLINE_FUNCTION
-constexpr auto divide(const integral_constant<T0, v0> &,
-                      const integral_constant<T1, v1> &) {
+constexpr auto divide(const std::integral_constant<T0, v0> &,
+                      const std::integral_constant<T1, v1> &) {
   // cutting short division by zero
   // this is used for strided_slice with zero extent/stride
-  return integral_constant<IndexT, v0 == 0 ? 0 : v0 / v1>();
+  return std::integral_constant<IndexT, v0 == 0 ? 0 : v0 / v1>();
 }
 
 // multiply which can deal with integral constant preservation
@@ -198,49 +198,49 @@ constexpr auto multiply(const T0 &v0, const T1 &v1) {
 
 template <class IndexT, class T0, T0 v0, class T1, T1 v1>
 MDSPAN_INLINE_FUNCTION
-constexpr auto multiply(const integral_constant<T0, v0> &,
-                        const integral_constant<T1, v1> &) {
-  return integral_constant<IndexT, v0 * v1>();
+constexpr auto multiply(const std::integral_constant<T0, v0> &,
+                        const std::integral_constant<T1, v1> &) {
+  return std::integral_constant<IndexT, v0 * v1>();
 }
 
 // compute new static extent from range, preserving static knowledge
 template <class Arg0, class Arg1> struct StaticExtentFromRange {
-  constexpr static size_t value = dynamic_extent;
+  constexpr static std::size_t value = dynamic_extent;
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromRange<std::integral_constant<Integral0, val0>,
                              std::integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val1 - val0;
+  constexpr static std::size_t value = val1 - val0;
 };
 
 // compute new static extent from strided_slice, preserving static
 // knowledge
 template <class Arg0, class Arg1> struct StaticExtentFromStridedRange {
-  constexpr static size_t value = dynamic_extent;
+  constexpr static std::size_t value = dynamic_extent;
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromStridedRange<std::integral_constant<Integral0, val0>,
                                     std::integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / val1 : 0;
+  constexpr static std::size_t value = val0 > 0 ? 1 + (val0 - 1) / val1 : 0;
 };
 
 // creates new extents through recursive calls to next_extent member function
 // next_extent has different overloads for different types of stride specifiers
-template <size_t K, class Extents, size_t... NewExtents>
+template <std::size_t K, class Extents, std::size_t... NewExtents>
 struct extents_constructor {
   MDSPAN_TEMPLATE_REQUIRES(
     class Slice, class... SlicesAndExtents,
-    /* requires */(!is_convertible_v<Slice, size_t> &&
+    /* requires */(!std::is_convertible_v<Slice, std::size_t> &&
                    !is_strided_slice<Slice>::value)
   )
   MDSPAN_INLINE_FUNCTION
   constexpr static auto next_extent(const Extents &ext, const Slice &sl,
                                     SlicesAndExtents... slices_and_extents) {
-    constexpr size_t new_static_extent = StaticExtentFromRange<
+    constexpr std::size_t new_static_extent = StaticExtentFromRange<
         decltype(first_of(std::declval<Slice>())),
-        decltype(last_of(integral_constant<size_t, Extents::rank() - K>(),
+        decltype(last_of(std::integral_constant<std::size_t, Extents::rank() - K>(),
                          std::declval<Extents>(),
                          std::declval<Slice>()))>::value;
 
@@ -249,14 +249,14 @@ struct extents_constructor {
     using index_t = typename Extents::index_type;
     return next_t::next_extent(
         ext, slices_and_extents...,
-        index_t(last_of(integral_constant<size_t, Extents::rank() - K>(), ext,
+        index_t(last_of(std::integral_constant<std::size_t, Extents::rank() - K>(), ext,
                         sl)) -
             index_t(first_of(sl)));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
     class Slice, class... SlicesAndExtents,
-    /* requires */ (is_convertible_v<Slice, size_t>)
+    /* requires */ (std::is_convertible_v<Slice, std::size_t>)
   )
   MDSPAN_INLINE_FUNCTION
   constexpr static auto next_extent(const Extents &ext, const Slice &,
@@ -282,7 +282,7 @@ struct extents_constructor {
           ext, slices_and_extents...,
           r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, r.stride) : 0);
     } else {
-      constexpr size_t new_static_extent = new_static_extent_t::value;
+      constexpr std::size_t new_static_extent = new_static_extent_t::value;
       using next_t =
           extents_constructor<K - 1, Extents, NewExtents..., new_static_extent>;
       return next_t::next_extent(
@@ -291,7 +291,7 @@ struct extents_constructor {
   }
 };
 
-template <class Extents, size_t... NewStaticExtents>
+template <class Extents, std::size_t... NewStaticExtents>
 struct extents_constructor<0, Extents, NewStaticExtents...> {
 
   template <class... NewExtents>
@@ -306,7 +306,7 @@ struct extents_constructor<0, Extents, NewStaticExtents...> {
 
 // submdspan_extents creates new extents given src extents and submdspan slice
 // specifiers
-template <class IndexType, size_t... Extents, class... SliceSpecifiers>
+template <class IndexType, std::size_t... Extents, class... SliceSpecifiers>
 MDSPAN_INLINE_FUNCTION
 constexpr auto submdspan_extents(const extents<IndexType, Extents...> &src_exts,
                                  SliceSpecifiers... slices) {

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -27,12 +27,12 @@ namespace experimental {
 //******************************************
 template <class Mapping> struct mapping_offset {
   Mapping mapping;
-  std::size_t offset;
+  size_t offset;
 };
 
 namespace detail {
 // constructs sub strides
-template <class SrcMapping, class... slice_strides, std::size_t... InvMapIdxs>
+template <class SrcMapping, class... slice_strides, size_t... InvMapIdxs>
 MDSPAN_INLINE_FUNCTION
 constexpr auto
 construct_sub_strides(const SrcMapping &src_mapping,
@@ -51,10 +51,10 @@ construct_sub_strides(const SrcMapping &src_mapping,
 namespace detail {
 
 // Figure out whether to preserve layout_left
-template <class IndexSequence, std::size_t SubRank, class... SliceSpecifiers>
+template <class IndexSequence, size_t SubRank, class... SliceSpecifiers>
 struct preserve_layout_left_mapping;
 
-template <class... SliceSpecifiers, std::size_t... Idx, std::size_t SubRank>
+template <class... SliceSpecifiers, size_t... Idx, size_t SubRank>
 struct preserve_layout_left_mapping<std::index_sequence<Idx...>, SubRank,
                                     SliceSpecifiers...> {
   constexpr static bool value =
@@ -67,7 +67,7 @@ struct preserve_layout_left_mapping<std::index_sequence<Idx...>, SubRank,
           ((Idx > SubRank - 1) || // these are only integral slice specifiers
            (std::is_same_v<SliceSpecifiers, full_extent_t>) ||
            ((Idx == SubRank - 1) &&
-            std::is_convertible_v<SliceSpecifiers, std::tuple<std::size_t, std::size_t>>)) &&
+            std::is_convertible_v<SliceSpecifiers, std::tuple<size_t, size_t>>)) &&
           ...);
 };
 } // namespace detail
@@ -115,11 +115,11 @@ submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
     // layout_left case
     return mapping_offset<dst_mapping_t>{
         dst_mapping_t(dst_ext),
-        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
-      std::integral_constant<std::size_t,0>(),
+      std::integral_constant<size_t,0>(),
       std::index_sequence<>(),
       slices...);
     return mapping_offset<dst_mapping_t>{
@@ -131,7 +131,7 @@ submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
     #else
                                    std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -155,13 +155,13 @@ submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
 namespace detail {
 
 // Figure out whether to preserve layout_right
-template <class IndexSequence, std::size_t SubRank, class... SliceSpecifiers>
+template <class IndexSequence, size_t SubRank, class... SliceSpecifiers>
 struct preserve_layout_right_mapping;
 
-template <class... SliceSpecifiers, std::size_t... Idx, std::size_t SubRank>
+template <class... SliceSpecifiers, size_t... Idx, size_t SubRank>
 struct preserve_layout_right_mapping<std::index_sequence<Idx...>, SubRank,
                                      SliceSpecifiers...> {
-  constexpr static std::size_t SrcRank = sizeof...(SliceSpecifiers);
+  constexpr static size_t SrcRank = sizeof...(SliceSpecifiers);
   constexpr static bool value =
       // Preserve layout for rank 0
       (SubRank == 0) ||
@@ -174,7 +174,7 @@ struct preserve_layout_right_mapping<std::index_sequence<Idx...>, SubRank,
             SrcRank - SubRank) || // these are only integral slice specifiers
            (std::is_same_v<SliceSpecifiers, full_extent_t>) ||
            ((Idx == SrcRank - SubRank) &&
-            std::is_convertible_v<SliceSpecifiers, std::tuple<std::size_t, std::size_t>>)) &&
+            std::is_convertible_v<SliceSpecifiers, std::tuple<size_t, size_t>>)) &&
           ...);
 };
 } // namespace detail
@@ -221,11 +221,11 @@ submdspan_mapping(const layout_right::mapping<Extents> &src_mapping,
     // layout_right case
     return mapping_offset<dst_mapping_t>{
         dst_mapping_t(dst_ext),
-        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
-      std::integral_constant<std::size_t,0>(),
+      std::integral_constant<size_t,0>(),
       std::index_sequence<>(),
       slices...);
     return mapping_offset<dst_mapping_t>{
@@ -237,7 +237,7 @@ submdspan_mapping(const layout_right::mapping<Extents> &src_mapping,
     #else
                                    std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -266,7 +266,7 @@ submdspan_mapping(const layout_stride::mapping<Extents> &src_mapping,
   auto dst_ext = submdspan_extents(src_mapping.extents(), slices...);
   using dst_ext_t = decltype(dst_ext);
   auto inv_map = detail::inv_map_rank(
-      std::integral_constant<std::size_t,0>(),
+      std::integral_constant<size_t,0>(),
       std::index_sequence<>(),
       slices...);
   using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
@@ -274,7 +274,7 @@ submdspan_mapping(const layout_stride::mapping<Extents> &src_mapping,
       dst_mapping_t(dst_ext, detail::construct_sub_strides(
                                  src_mapping, inv_map,
                                  std::tuple{detail::stride_of(slices)...})),
-      static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
+      static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
 }
 } // namespace experimental
 } // namespace std

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -27,21 +27,21 @@ namespace experimental {
 //******************************************
 template <class Mapping> struct mapping_offset {
   Mapping mapping;
-  size_t offset;
+  std::size_t offset;
 };
 
 namespace detail {
 // constructs sub strides
-template <class SrcMapping, class... slice_strides, size_t... InvMapIdxs>
+template <class SrcMapping, class... slice_strides, std::size_t... InvMapIdxs>
 MDSPAN_INLINE_FUNCTION
 constexpr auto
 construct_sub_strides(const SrcMapping &src_mapping,
-                      index_sequence<InvMapIdxs...>,
-                      const tuple<slice_strides...> &slices_stride_factor) {
+                      std::index_sequence<InvMapIdxs...>,
+                      const std::tuple<slice_strides...> &slices_stride_factor) {
   using index_type = typename SrcMapping::index_type;
-  return array<typename SrcMapping::index_type, sizeof...(InvMapIdxs)>{
+  return std::array<typename SrcMapping::index_type, sizeof...(InvMapIdxs)>{
       (static_cast<index_type>(src_mapping.stride(InvMapIdxs)) *
-       static_cast<index_type>(get<InvMapIdxs>(slices_stride_factor)))...};
+       static_cast<index_type>(std::get<InvMapIdxs>(slices_stride_factor)))...};
 }
 } // namespace detail
 
@@ -51,11 +51,11 @@ construct_sub_strides(const SrcMapping &src_mapping,
 namespace detail {
 
 // Figure out whether to preserve layout_left
-template <class IndexSequence, size_t SubRank, class... SliceSpecifiers>
+template <class IndexSequence, std::size_t SubRank, class... SliceSpecifiers>
 struct preserve_layout_left_mapping;
 
-template <class... SliceSpecifiers, size_t... Idx, size_t SubRank>
-struct preserve_layout_left_mapping<index_sequence<Idx...>, SubRank,
+template <class... SliceSpecifiers, std::size_t... Idx, std::size_t SubRank>
+struct preserve_layout_left_mapping<std::index_sequence<Idx...>, SubRank,
                                     SliceSpecifiers...> {
   constexpr static bool value =
       // Preserve layout for rank 0
@@ -65,9 +65,9 @@ struct preserve_layout_left_mapping<index_sequence<Idx...>, SubRank,
           // for the last one which could also be tuple but not a strided index
           // range slice specifiers after subrank are integrals
           ((Idx > SubRank - 1) || // these are only integral slice specifiers
-           (is_same_v<SliceSpecifiers, full_extent_t>) ||
+           (std::is_same_v<SliceSpecifiers, full_extent_t>) ||
            ((Idx == SubRank - 1) &&
-            is_convertible_v<SliceSpecifiers, tuple<size_t, size_t>>)) &&
+            std::is_convertible_v<SliceSpecifiers, std::tuple<std::size_t, std::size_t>>)) &&
           ...);
 };
 } // namespace detail
@@ -105,33 +105,33 @@ submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
 
   // figure out sub layout type
   constexpr bool preserve_layout = detail::preserve_layout_left_mapping<
-      decltype(make_index_sequence<src_ext_t::rank()>()), dst_ext_t::rank(),
+      decltype(std::make_index_sequence<src_ext_t::rank()>()), dst_ext_t::rank(),
       SliceSpecifiers...>::value;
   using dst_layout_t =
-      conditional_t<preserve_layout, layout_left, layout_stride>;
+      std::conditional_t<preserve_layout, layout_left, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
-  if constexpr (is_same_v<dst_layout_t, layout_left>) {
+  if constexpr (std::is_same_v<dst_layout_t, layout_left>) {
     // layout_left case
     return mapping_offset<dst_mapping_t>{
         dst_mapping_t(dst_ext),
-        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
-      integral_constant<size_t,0>(),
-      index_sequence<>(),
+      std::integral_constant<std::size_t,0>(),
+      std::index_sequence<>(),
       slices...);
     return mapping_offset<dst_mapping_t>{
         dst_mapping_t(dst_ext, detail::construct_sub_strides(
                                    src_mapping, inv_map,
     // HIP needs deduction guides to have markups so we need to be explicit
     #ifdef _MDSPAN_HAS_HIP
-                                   tuple<decltype(detail::stride_of(slices))...>{detail::stride_of(slices)...})),
+                                   std::tuple<decltype(detail::stride_of(slices))...>{detail::stride_of(slices)...})),
     #else
-                                   tuple{detail::stride_of(slices)...})),
+                                   std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -155,13 +155,13 @@ submdspan_mapping(const layout_left::mapping<Extents> &src_mapping,
 namespace detail {
 
 // Figure out whether to preserve layout_right
-template <class IndexSequence, size_t SubRank, class... SliceSpecifiers>
+template <class IndexSequence, std::size_t SubRank, class... SliceSpecifiers>
 struct preserve_layout_right_mapping;
 
-template <class... SliceSpecifiers, size_t... Idx, size_t SubRank>
-struct preserve_layout_right_mapping<index_sequence<Idx...>, SubRank,
+template <class... SliceSpecifiers, std::size_t... Idx, std::size_t SubRank>
+struct preserve_layout_right_mapping<std::index_sequence<Idx...>, SubRank,
                                      SliceSpecifiers...> {
-  constexpr static size_t SrcRank = sizeof...(SliceSpecifiers);
+  constexpr static std::size_t SrcRank = sizeof...(SliceSpecifiers);
   constexpr static bool value =
       // Preserve layout for rank 0
       (SubRank == 0) ||
@@ -172,9 +172,9 @@ struct preserve_layout_right_mapping<index_sequence<Idx...>, SubRank,
           // integrals
           ((Idx <
             SrcRank - SubRank) || // these are only integral slice specifiers
-           (is_same_v<SliceSpecifiers, full_extent_t>) ||
+           (std::is_same_v<SliceSpecifiers, full_extent_t>) ||
            ((Idx == SrcRank - SubRank) &&
-            is_convertible_v<SliceSpecifiers, tuple<size_t, size_t>>)) &&
+            std::is_convertible_v<SliceSpecifiers, std::tuple<std::size_t, std::size_t>>)) &&
           ...);
 };
 } // namespace detail
@@ -211,33 +211,33 @@ submdspan_mapping(const layout_right::mapping<Extents> &src_mapping,
 
   // determine new layout type
   constexpr bool preserve_layout = detail::preserve_layout_right_mapping<
-      decltype(make_index_sequence<src_ext_t::rank()>()), dst_ext_t::rank(),
+      decltype(std::make_index_sequence<src_ext_t::rank()>()), dst_ext_t::rank(),
       SliceSpecifiers...>::value;
   using dst_layout_t =
-      conditional_t<preserve_layout, layout_right, layout_stride>;
+      std::conditional_t<preserve_layout, layout_right, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
-  if constexpr (is_same_v<dst_layout_t, layout_right>) {
+  if constexpr (std::is_same_v<dst_layout_t, layout_right>) {
     // layout_right case
     return mapping_offset<dst_mapping_t>{
         dst_mapping_t(dst_ext),
-        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
-      integral_constant<size_t,0>(),
-      index_sequence<>(),
+      std::integral_constant<std::size_t,0>(),
+      std::index_sequence<>(),
       slices...);
     return mapping_offset<dst_mapping_t>{
         dst_mapping_t(dst_ext, detail::construct_sub_strides(
                                    src_mapping, inv_map,
     // HIP needs deduction guides to have markups so we need to be explicit
     #ifdef _MDSPAN_HAS_HIP
-                                   tuple<decltype(detail::stride_of(slices))...>{detail::stride_of(slices)...})),
+                                   std::tuple<decltype(detail::stride_of(slices))...>{detail::stride_of(slices)...})),
     #else
-                                   tuple{detail::stride_of(slices)...})),
+                                   std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+        static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -266,15 +266,15 @@ submdspan_mapping(const layout_stride::mapping<Extents> &src_mapping,
   auto dst_ext = submdspan_extents(src_mapping.extents(), slices...);
   using dst_ext_t = decltype(dst_ext);
   auto inv_map = detail::inv_map_rank(
-      integral_constant<size_t,0>(),
-      index_sequence<>(),
+      std::integral_constant<std::size_t,0>(),
+      std::index_sequence<>(),
       slices...);
   using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
   return mapping_offset<dst_mapping_t>{
       dst_mapping_t(dst_ext, detail::construct_sub_strides(
                                  src_mapping, inv_map,
-                                 tuple{detail::stride_of(slices)...})),
-      static_cast<size_t>(src_mapping(detail::first_of(slices)...))};
+                                 std::tuple{detail::stride_of(slices)...})),
+      static_cast<std::size_t>(src_mapping(detail::first_of(slices)...))};
 }
 } // namespace experimental
 } // namespace std


### PR DESCRIPTION
Closes #254

I honestly think I caught all of it. This builds if I change the mdspan namespace on gcc12 in C++14, 17, 20, and 23 modes. If I missed anything I'll catch it in the PR for changing the namespace...