### PR TITLE
add option for stdmode install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(MDSPAN_ENABLE_SYCL "Enable SYCL tests/benchmarks/examples if tests/benchm
 option(MDSPAN_ENABLE_HIP "Enable HIP tests/benchmarks/examples if tests/benchmarks/examples are enabled." Off)
 option(MDSPAN_ENABLE_OPENMP "Enable OpenMP benchmarks if benchmarks are enabled." On)
 option(MDSPAN_USE_SYSTEM_GTEST "Use system-installed GoogleTest library for tests." Off)
+option(MDSPAN_INSTALL_STDMODE_HEADERS "Whether to install headers to emulate standard library headers and namespaces" Off)
 
 # Option to override which C++ standard to use
 set(MDSPAN_CXX_STANDARD DETECT CACHE STRING "Override the default CXX_STANDARD to compile with.")
@@ -165,7 +166,13 @@ export(TARGETS mdspan
     FILE mdspanTargets.cmake
 )
 
-install(DIRECTORY include/experimental include/mdspan DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY include/mdspan DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+if (MDSPAN_INSTALL_STDMODE_HEADERS)
+  install(DIRECTORY include/experimental DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+else()
+  install(DIRECTORY include/experimental DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+          REGEX "/mdspan$|/mdarray$" EXCLUDE)
+endif()
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(cmake/mdspanConfig.cmake.in


### PR DESCRIPTION
Anyway, this PR adds a new CMake option, `MDSPAN_INSTALL_STDMODE_HEADERS` that will disable installing the std-like headers `<experimental/mdspan>` and `<experimental/mdarray>`. This will hopefully avoid conflicts with any standard library that actually ships mdspan if the user is not intending to use these headers (including ones that ship this library :P). I've defaulted this to `OFF` which is technically a breaking change so I can switch that around. However, in general I think it shouldn't be on by default.

Also, I realized that `<mdspan/mdspan.hpp>` and `<mdspan/mdarray.hpp>` were not installed, so this fixes that too.