### PR TITLE
#265: fix extents constructor not usable in constant expressions

### DIFF
--- a/compilation_tests/ctest_extents_ctors.cpp
+++ b/compilation_tests/ctest_extents_ctors.cpp
@@ -283,3 +283,13 @@ MDSPAN_STATIC_TEST(
   >::value
 );
 
+MDSPAN_STATIC_TEST(
+  std::is_constructible<
+    Kokkos::extents<size_t, Kokkos::dynamic_extent, 4>,
+    int, int
+  >::value
+);
+
+MDSPAN_STATIC_TEST(
+  Kokkos::extents<size_t, Kokkos::dynamic_extent, 4>{ 7, 4 }.extent( 0 ) == 7
+);

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -265,7 +265,8 @@ public:
                                                m_size_dynamic &&
                                            m_size_dynamic > 0))
   MDSPAN_INLINE_FUNCTION
-  constexpr maybe_static_array(DynVals... vals) {
+  constexpr maybe_static_array(DynVals... vals)
+    : m_dyn_vals{} {
     static_assert((sizeof...(DynVals) == m_size), "Invalid number of values.");
     TDynamic values[m_size]{static_cast<TDynamic>(vals)...};
     for (size_t r = 0; r < m_size; r++) {


### PR DESCRIPTION
Fixes #265