### PR TITLE
Workaround for missing <concepts> but __cpp_concepts is defined

### DIFF
--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -30,8 +30,8 @@
 #ifdef __cpp_lib_span
 #include <span>
 #endif
-#if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
-#include <type_traits>  // for std::is_same_v
+#if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20 && defined(__cpp_lib_concepts)
+#  include <concepts>
 #endif
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
@@ -51,6 +51,7 @@ namespace detail {
     std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
 
 #if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+#  if !defined(__cpp_lib_concepts)
   namespace internal {
   namespace detail {
   template <typename _Tp, typename _Up>
@@ -59,13 +60,20 @@ namespace detail {
   template <class T, class U>
   concept __same_as = detail::__same_as<T, U> && detail::__same_as<U, T>;
   } // namespace internal
+#  endif
 
   template<class M>
   concept __layout_mapping_alike = requires {
     requires __is_extents<typename M::extents_type>::value;
+#if defined(__cpp_lib_concepts)
+    { M::is_always_strided() } -> std::same_as<bool>;
+    { M::is_always_exhaustive() } -> std::same_as<bool>;
+    { M::is_always_unique() } -> std::same_as<bool>;
+#else
     { M::is_always_strided() } -> internal::__same_as<bool>;
     { M::is_always_exhaustive() } -> internal::__same_as<bool>;
     { M::is_always_unique() } -> internal::__same_as<bool>;
+#endif
     std::bool_constant<M::is_always_strided()>::value;
     std::bool_constant<M::is_always_exhaustive()>::value;
     std::bool_constant<M::is_always_unique()>::value;

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -31,7 +31,7 @@
 #include <span>
 #endif
 #if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
-#include<concepts>
+#include <type_traits>  // for std::is_same_v
 #endif
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
@@ -51,12 +51,21 @@ namespace detail {
     std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
 
 #if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+  namespace internal {
+  namespace detail {
+  template <typename _Tp, typename _Up>
+  concept __same_as = std::is_same_v<_Tp, _Up>;
+  } // namespace detail
+  template <class T, class U>
+  concept __same_as = detail::__same_as<T, U> && detail::__same_as<U, T>;
+  } // namespace internal
+
   template<class M>
   concept __layout_mapping_alike = requires {
     requires __is_extents<typename M::extents_type>::value;
-    { M::is_always_strided() } -> std::same_as<bool>;
-    { M::is_always_exhaustive() } -> std::same_as<bool>;
-    { M::is_always_unique() } -> std::same_as<bool>;
+    { M::is_always_strided() } -> internal::__same_as<bool>;
+    { M::is_always_exhaustive() } -> internal::__same_as<bool>;
+    { M::is_always_unique() } -> internal::__same_as<bool>;
     std::bool_constant<M::is_always_strided()>::value;
     std::bool_constant<M::is_always_exhaustive()>::value;
     std::bool_constant<M::is_always_unique()>::value;


### PR DESCRIPTION
Fixes issue #273 

This approach to fixing the issue avoids the include of \<concepts\> entirely because the only thing needed from it was a very simple concept that could be recreated (same_as)

I put the new concept which is a duplicate of the standard one in the namespace `internal` rather than `detail` to avoid collisions with the standard library version which uses `detail` internally for its helper function `__same_as`