### PR TITLE
Avoid reserved identifier collisions with newlib

### DIFF
--- a/include/experimental/__p0009_bits/compressed_pair.hpp
+++ b/include/experimental/__p0009_bits/compressed_pair.hpp
@@ -27,16 +27,16 @@ namespace detail {
 
 // For no unique address emulation, this is the case taken when neither are empty.
 // For real `[[no_unique_address]]`, this case is always taken.
-template <class _T, class _U, class _Enable = void> struct __compressed_pair {
-  _MDSPAN_NO_UNIQUE_ADDRESS _T __t_val;
-  _MDSPAN_NO_UNIQUE_ADDRESS _U __u_val;
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T &__first() noexcept { return __t_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T const &__first() const noexcept {
-    return __t_val;
+template <class _T1, class _T2, class _Enable = void> struct __compressed_pair {
+  _MDSPAN_NO_UNIQUE_ADDRESS _T1 __t1_val;
+  _MDSPAN_NO_UNIQUE_ADDRESS _T2 __t2_val;
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T1 &__first() noexcept { return __t1_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
+    return __t1_val;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _U &__second() noexcept { return __u_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _U const &__second() const noexcept {
-    return __u_val;
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T2 &__second() noexcept { return __t2_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
+    return __t2_val;
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
@@ -53,29 +53,29 @@ template <class _T, class _U, class _Enable = void> struct __compressed_pair {
   operator=(__compressed_pair &&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~__compressed_pair() noexcept = default;
-  template <class _TLike, class _ULike>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_TLike &&__t, _ULike &&__u)
-      : __t_val((_TLike &&) __t), __u_val((_ULike &&) __u) {}
+  template <class _T1Like, class _T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
+      : __t1_val((_T1Like &&) __t1), __t2_val((_T2Like &&) __t2) {}
 };
 
 #if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 
 // First empty.
-template <class _T, class _U>
+template <class _T1, class _T2>
 struct __compressed_pair<
-    _T, _U,
-    std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T) && !_MDSPAN_TRAIT(std::is_empty, _U)>>
-    : private _T {
-  _U __u_val;
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T &__first() noexcept {
-    return *static_cast<_T *>(this);
+    _T1, _T2,
+    std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T1) && !_MDSPAN_TRAIT(std::is_empty, _T2)>>
+    : private _T1 {
+  _T2 __t2_val;
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T1 &__first() noexcept {
+    return *static_cast<_T1 *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T const &__first() const noexcept {
-    return *static_cast<_T const *>(this);
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
+    return *static_cast<_T1 const *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _U &__second() noexcept { return __u_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _U const &__second() const noexcept {
-    return __u_val;
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T2 &__second() noexcept { return __t2_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
+    return __t2_val;
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
@@ -92,27 +92,27 @@ struct __compressed_pair<
   operator=(__compressed_pair &&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~__compressed_pair() noexcept = default;
-  template <class _TLike, class _ULike>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_TLike &&__t, _ULike &&__u)
-      : _T((_TLike &&) __t), __u_val((_ULike &&) __u) {}
+  template <class _T1Like, class _T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
+      : _T1((_T1Like &&) __t1), __t2_val((_T2Like &&) __t2) {}
 };
 
 // Second empty.
-template <class _T, class _U>
+template <class _T1, class _T2>
 struct __compressed_pair<
-    _T, _U,
-    std::enable_if_t<!_MDSPAN_TRAIT(std::is_empty, _T) && _MDSPAN_TRAIT(std::is_empty, _U)>>
-    : private _U {
-  _T __t_val;
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T &__first() noexcept { return __t_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T const &__first() const noexcept {
-    return __t_val;
+    _T1, _T2,
+    std::enable_if_t<!_MDSPAN_TRAIT(std::is_empty, _T1) && _MDSPAN_TRAIT(std::is_empty, _T2)>>
+    : private _T2 {
+  _T1 __t1_val;
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T1 &__first() noexcept { return __t1_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
+    return __t1_val;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _U &__second() noexcept {
-    return *static_cast<_U *>(this);
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T2 &__second() noexcept {
+    return *static_cast<_T2 *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _U const &__second() const noexcept {
-    return *static_cast<_U const *>(this);
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
+    return *static_cast<_T2 const *>(this);
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
@@ -130,41 +130,41 @@ struct __compressed_pair<
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~__compressed_pair() noexcept = default;
 
-  template <class _TLike, class _ULike>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_TLike &&__t, _ULike &&__u)
-      : _U((_ULike &&) __u), __t_val((_TLike &&) __t) {}
+  template <class _T1Like, class _T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
+      : _T2((_T2Like &&) __t2), __t1_val((_T1Like &&) __t1) {}
 };
 
 // Both empty.
-template <class _T, class _U>
+template <class _T1, class _T2>
 struct __compressed_pair<
-    _T, _U,
-    std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T) && _MDSPAN_TRAIT(std::is_empty, _U)>>
+    _T1, _T2,
+    std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T1) && _MDSPAN_TRAIT(std::is_empty, _T2)>>
     // We need to use the __no_unique_address_emulation wrapper here to avoid
     // base class ambiguities.
 #ifdef _MDSPAN_COMPILER_MSVC
 // MSVC doesn't allow you to access public static member functions of a type
 // when you *happen* to privately inherit from that type.
-    : protected __no_unique_address_emulation<_T, 0>,
-      protected __no_unique_address_emulation<_U, 1>
+    : protected __no_unique_address_emulation<_T1, 0>,
+      protected __no_unique_address_emulation<_T2, 1>
 #else
-    : private __no_unique_address_emulation<_T, 0>,
-      private __no_unique_address_emulation<_U, 1>
+    : private __no_unique_address_emulation<_T1, 0>,
+      private __no_unique_address_emulation<_T2, 1>
 #endif
 {
-  using __first_base_t = __no_unique_address_emulation<_T, 0>;
-  using __second_base_t = __no_unique_address_emulation<_U, 1>;
+  using __first_base_t = __no_unique_address_emulation<_T1, 0>;
+  using __second_base_t = __no_unique_address_emulation<_T2, 1>;
 
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T &__first() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T1 &__first() noexcept {
     return this->__first_base_t::__ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T const &__first() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
     return this->__first_base_t::__ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _U &__second() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T2 &__second() noexcept {
     return this->__second_base_t::__ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _U const &__second() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
     return this->__second_base_t::__ref();
   }
 
@@ -182,10 +182,10 @@ struct __compressed_pair<
   operator=(__compressed_pair &&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~__compressed_pair() noexcept = default;
-  template <class _TLike, class _ULike>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_TLike &&__t, _ULike &&__u) noexcept
-    : __first_base_t(_T((_TLike &&) __t)),
-      __second_base_t(_U((_ULike &&) __u))
+  template <class _T1Like, class _T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2) noexcept
+    : __first_base_t(_T1((_T1Like &&) __t1)),
+      __second_base_t(_T2((_T2Like &&) __t2))
   { }
 };
 


### PR DESCRIPTION
Newlib defines a macro _U in ctype.h (https://github.com/bminor/newlib/blob/048031501043e61ca31713b92ce2190213c7fb21/newlib/libc/include/ctype.h#L60-L67), resulting in a collision with the existing template names for __compressed_pair. Use _T1 and _T2 instead of _T and _U to avoid this collision. _T1 and _T2 are already used elsewhere, for example in type_list.hpp (https://github.com/kokkos/mdspan/blob/9d0a451e11177cbdeaef035c7914b0aa73ddd1e2/include/experimental/__p0009_bits/type_list.hpp#L76), so their use here should hopefully not introduce any new collisions with other environments.

Fixes #187.

Readme example compiler explorer demonstrating the original issue:
https://godbolt.org/z/s6qzafWP4

And a successful build made with this patch:
https://godbolt.org/z/zbMf4hddj