### PR TITLE
Update workflow to clang++ instead of clang++12

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,7 +16,7 @@ jobs:
           compiler_prefix: /usr/bin
         - compiler_driver: g++-10
           compiler_prefix: /usr/bin
-        - compiler_driver: clang++-12
+        - compiler_driver: clang++
           compiler_prefix: /usr/bin
         - compiler_driver: icpx
           compiler_prefix: /opt/intel/oneapi/compiler/latest/linux/bin


### PR DESCRIPTION
Ubuntu test failed because clang++12 did not exist ..