### PR TITLE
Add element access via `at()` to `std::mdspan`

### DIFF
--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -176,6 +176,13 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #  endif
 #endif
 
+#ifndef _MDSPAN_USE_IF_CONSTEXPR_17
+#  if (defined(__cpp_if_constexpr) && __cpp_if_constexpr >= 201606) \
+        || (!defined(__cpp_constexpr) && MDSPAN_HAS_CXX_17)
+#    define _MDSPAN_USE_IF_CONSTEXPR_17 1
+#  endif
+#endif
+
 #ifndef _MDSPAN_USE_INTEGER_SEQUENCE
 #  if defined(_MDSPAN_COMPILER_MSVC)
 #    if (defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence >= 201304)

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -697,3 +697,9 @@ struct __bools;
 
 // </editor-fold> end Pre-C++14 constexpr }}}1
 //==============================================================================
+
+#if _MDSPAN_USE_IF_CONSTEXPR_17
+#  define _MDSPAN_IF_CONSTEXPR_17 constexpr
+#else
+#  define _MDSPAN_IF_CONSTEXPR_17
+#endif

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -18,6 +18,7 @@
 
 #include "default_accessor.hpp"
 #include "layout_right.hpp"
+#include "macros.hpp"
 #include "extents.hpp"
 #include "trait_backports.hpp"
 #include "compressed_pair.hpp"
@@ -442,7 +443,7 @@ private:
   MDSPAN_FORCE_INLINE_FUNCTION constexpr mapping_type const& __mapping_ref() const noexcept { return __members.__second().__first(); }
   MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 accessor_type& __accessor_ref() noexcept { return __members.__second().__second(); }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr accessor_type const& __accessor_ref() const noexcept { return __members.__second().__second(); }
-  
+
   MDSPAN_TEMPLATE_REQUIRES(
     class SizeType,
     /* requires */ (
@@ -452,7 +453,7 @@ private:
   )
   MDSPAN_FORCE_INLINE_FUNCTION constexpr bool __is_index_oor(SizeType index, index_type extent) const noexcept {
     // Check for negative indices
-    if constexpr(std::is_signed_v<SizeType>) {
+    if _MDSPAN_IF_CONSTEXPR_17 (_MDSPAN_TRAIT(std::is_signed, SizeType)) {
       if(index < 0) {
         return true;
       }

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -22,6 +22,9 @@
 #include "trait_backports.hpp"
 #include "compressed_pair.hpp"
 
+#include <stdexcept>
+#include <string>
+
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 template <
   class ElementType,
@@ -219,6 +222,68 @@ public:
   //--------------------------------------------------------------------------------
   // [mdspan.basic.mapping], mdspan mapping domain multidimensional index to access codomain element
 
+  MDSPAN_TEMPLATE_REQUIRES(
+    class... SizeTypes,
+    /* requires */ (
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, SizeTypes, index_type) /* && ... */) &&
+      _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, SizeTypes) /* && ... */) &&
+      (rank() == sizeof...(SizeTypes))
+    )
+  )
+  constexpr reference at(SizeTypes... indices) const
+  {
+    size_t r = 0;
+    for (const auto& index : {indices...}) {
+      if (index >= __mapping_ref().extents().extent(r)) {
+        throw std::out_of_range(
+          "mdspan::at(...," + std::to_string(index) + ",...) out-of-range at rank index " + std::to_string(r) +
+          " for mdspan with extent {...," + std::to_string(__mapping_ref().extents().extent(r)) + ",...}");
+      }
+      ++r;
+    }
+    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(static_cast<index_type>(std::move(indices))...));
+  }
+
+  MDSPAN_TEMPLATE_REQUIRES(
+    class SizeType,
+    /* requires */ (
+      _MDSPAN_TRAIT(std::is_convertible, const SizeType&, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, const SizeType&)
+    )
+  )
+  constexpr reference at(const std::array<SizeType, rank()>& indices) const
+  {
+    for (size_t r = 0; r < indices.size(); ++r) {
+      if (indices[r] >= __mapping_ref().extents().extent(r)) {
+        throw std::out_of_range(
+          "mdspan::at({...," + std::to_string(indices[r]) + ",...}) out-of-range at rank index " + std::to_string(r) +
+          " for mdspan with extent {...," + std::to_string(__mapping_ref().extents().extent(r)) + ",...}");
+      }
+    }
+    return __impl::template __callop<reference>(*this, indices);
+  }
+
+  #ifdef __cpp_lib_span
+  MDSPAN_TEMPLATE_REQUIRES(
+    class SizeType,
+    /* requires */ (
+      _MDSPAN_TRAIT(std::is_convertible, const SizeType&, index_type) &&
+      _MDSPAN_TRAIT(std::is_nothrow_constructible, index_type, const SizeType&)
+    )
+  )
+  constexpr reference at(std::span<SizeType, rank()> indices) const
+  {
+    for (size_t r = 0; r < indices.size(); ++r) {
+      if (indices[r] >= __mapping_ref().extents().extent(r)) {
+        throw std::out_of_range(
+          "mdspan::at({...," + std::to_string(indices[r]) + ",...}) out-of-range at rank index " + std::to_string(r) +
+          " for mdspan with extent {...," + std::to_string(__mapping_ref().extents().extent(r)) + ",...}");
+      }
+    }
+    return __impl::template __callop<reference>(*this, indices);
+  }
+  #endif // __cpp_lib_span
+
   #if MDSPAN_USE_BRACKET_OPERATOR
   MDSPAN_TEMPLATE_REQUIRES(
     class... SizeTypes,
@@ -243,7 +308,7 @@ public:
     )
   )
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference operator[](const std::array< SizeType, rank()>& indices) const
+  constexpr reference operator[](const std::array<SizeType, rank()>& indices) const
   {
     return __impl::template __callop<reference>(*this, indices);
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ mdspan_add_test(test_layout_preconditions ENABLE_PRECONDITIONS)
 
 mdspan_add_test(test_dims)
 mdspan_add_test(test_extents)
+mdspan_add_test(test_mdspan_at)
 mdspan_add_test(test_mdspan_ctors)
 mdspan_add_test(test_mdspan_swap)
 mdspan_add_test(test_mdspan_conversion)

--- a/tests/test_mdspan_at.cpp
+++ b/tests/test_mdspan_at.cpp
@@ -1,0 +1,34 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+
+#include <array>
+#include <mdspan/mdspan.hpp>
+
+#include <gtest/gtest.h>
+
+
+TEST(TestMdspanAt, test_mdspan_at) {
+    std::array<double, 6> a{};
+    Kokkos::mdspan<double, Kokkos::extents<size_t, 2, 3>> s(a.data());
+
+    s.at(0, 0) = 3.14;
+    s.at(std::array<int, 2>{1, 2}) = 2.72;
+    ASSERT_EQ(s.at(0, 0), 3.14);
+    ASSERT_EQ(s.at(std::array<int, 2>{1, 2}), 2.72);
+
+    EXPECT_THROW(s.at(2, 3), std::out_of_range);
+    EXPECT_THROW(s.at(std::array<int, 2>{3, 1}), std::out_of_range);
+}


### PR DESCRIPTION
Closes #300

Possible implementation for ::at element access to mdspan with boundary checks. The boundary check is implemented with a for loop, as I did not see any other way to achieve this. The error message is inspired by the `std::span::at` error message from libstdc++ (https://github.com/gcc-mirror/gcc/commit/1fa85dcf656e2f2c7e483c9ed3c2680bf7db6858).

Note that this does not implement ::at element access to mdarray.