### PR TITLE
googletest: bump minimum CMake version to 3.5

### DIFF
--- a/cmake/googletest/CMakeLists.txt.in
+++ b/cmake/googletest/CMakeLists.txt.in
@@ -1,5 +1,5 @@
 # from https://github.com/google/googletest/blob/master/googletest/README.md
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Modern CMake versions give the following warning when building tests:

```
CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Bumping it to 3.5 fixes this. Not an issue since the rest requires a higher CMake version anyway.