### PR TITLE
remove use of `_v` variable template type traits

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -59,8 +59,8 @@ template<class IndexType, class ... Arguments>
 MDSPAN_INLINE_FUNCTION
 static constexpr bool are_valid_indices() {
     return 
-      (std::is_convertible_v<Arguments, IndexType> && ... && true) &&
-      (std::is_nothrow_constructible_v<IndexType, Arguments> && ... && true);
+      (std::is_convertible<Arguments, IndexType>::value && ... && true) &&
+      (std::is_nothrow_constructible<IndexType, Arguments>::value && ... && true);
 }
 
 // ------------------------------------------------------------------

--- a/include/experimental/__p2642_bits/layout_padded_fwd.hpp
+++ b/include/experimental/__p2642_bits/layout_padded_fwd.hpp
@@ -65,7 +65,7 @@ struct is_layout_left_padded_mapping : std::false_type {};
 
 template <class _Mapping>
 struct is_layout_left_padded_mapping<_Mapping,
-  std::enable_if_t<std::is_same_v<_Mapping, typename layout_left_padded<_Mapping::padding_value>::template mapping<typename _Mapping::extents_type>>>>
+  std::enable_if_t<std::is_same<_Mapping, typename layout_left_padded<_Mapping::padding_value>::template mapping<typename _Mapping::extents_type>>::value>>
     : std::true_type {};
 
 template <class _Layout>
@@ -79,7 +79,7 @@ struct is_layout_right_padded_mapping : std::false_type {};
 
 template <class _Mapping>
 struct is_layout_right_padded_mapping<_Mapping,
-  std::enable_if_t<std::is_same_v<_Mapping, typename layout_right_padded<_Mapping::padding_value>::template mapping<typename _Mapping::extents_type>>>>
+  std::enable_if_t<std::is_same<_Mapping, typename layout_right_padded<_Mapping::padding_value>::template mapping<typename _Mapping::extents_type>>::value>>
     : std::true_type {};
 
 template <class _LayoutExtentsType, class _PaddedLayoutMappingType>


### PR DESCRIPTION
`_v` variable templates (e.g. `std::is_same_v`) are not available when building for C++14.

I assume C++14 is still supported given https://github.com/kokkos/mdspan/issues/272.

`are_valid_indices` uses C++17 fold expressions but that only emits a warning when I tested with recent Clang + GCC.