### PR TITLE
Fix #316: replace `throw` with `std::abort` in `layout_right.hpp`

### DIFF
--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -160,11 +160,10 @@ class layout_right::mapping {
        #if !defined(_MDSPAN_HAS_CUDA) && !defined(_MDSPAN_HAS_HIP) && !defined(NDEBUG)
        if constexpr (extents_type::rank() > 0) {
          index_type stride = 1;
+         using common_t = std::common_type_t<index_type, typename OtherExtents::index_type>;
          for(rank_type r=__extents.rank(); r>0; r--) {
-           if(stride != static_cast<index_type>(other.stride(r-1))) {
-             // Note this throw will lead to a terminate if triggered since this function is marked noexcept
-             throw std::runtime_error("Assigning layout_stride to layout_right with invalid strides.");
-           }
+           if(static_cast<common_t>(stride) != static_cast<common_t>(other.stride(r-1)))
+             std::abort(); // ("Assigning layout_stride to layout_right with invalid strides.");
            stride *= __extents.extent(r-1);
          }
        }


### PR DESCRIPTION
See #316.