### PR TITLE
Fix LWG Issue 4060 (fix submdspan to prevent invalid pointer creation)

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -656,7 +656,7 @@ check_one_index(InputIndex user_index,
                 ExtentsIndexType current_extent)
 {
   check_lower_bound(user_index, current_extent,
-    std::bool_constant<std::is_signed_v<ExtentsIndexType>>{});
+    std::integral_constant<bool, std::is_signed_v<ExtentsIndexType>>{});
   check_upper_bound(user_index, current_extent);
 }
  

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -615,50 +615,58 @@ static
 #endif
 constexpr bool __is_extents_v = __is_extents<T>::value;
 
-template<class UserIndexType, class IndexType>
-constexpr void check_lower_bound(const UserIndexType& user_index,
-                                 const IndexType& /* current_extent */,
-                                 std::true_type) /* is_signed */
+template<class InputIndexType, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
+constexpr void
+check_lower_bound(InputIndexType user_index,
+                  ExtentsIndexType /* current_extent */,
+                  std::true_type /* is_signed */)
 {
   (void) user_index; // prevent unused variable warning
 #ifdef _MDSPAN_DEBUG
-  assert(static_cast<IndexType>(user_index) >= 0);
+  assert(static_cast<ExtentsIndexType>(user_index) >= 0);
 #endif
 }
 
-template<class UserIndexType, class IndexType>
+template<class InputIndexType, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
 constexpr void
-check_lower_bound(const UserIndexType& /* user_index */,
-                  const IndexType& /* current_extent */,
-                  std::false_type) /* is_signed */
+check_lower_bound(InputIndexType /* user_index */,
+                  ExtentsIndexType /* current_extent */,
+                  std::false_type /* is_signed */)
 {}
 
-template<class UserIndexType, class IndexType>
+template<class InputIndexType, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
 constexpr void
-check_upper_bound(const UserIndexType& user_index,
-                  const IndexType& current_extent)
+check_upper_bound(InputIndexType user_index,
+                  ExtentsIndexType current_extent)
 {
   (void) user_index; // prevent unused variable warnings
   (void) current_extent;
 #ifdef _MDSPAN_DEBUG
-  assert(static_cast<IndexType>(user_index) < current_extent);
+  assert(static_cast<ExtentsIndexType>(user_index) < current_extent);
 #endif
 }
 
-template<class InputIndex, class IndexType>
+template<class InputIndex, class ExtentsIndexType>
+MDSPAN_INLINE_FUNCTION
 constexpr void
-check_one_index(const InputIndex& user_index,
-                const IndexType& current_extent)
+check_one_index(InputIndex user_index,
+                ExtentsIndexType current_extent)
 {
   check_lower_bound(user_index, current_extent,
-                    std::bool_constant<std::is_signed_v<IndexType>>{});
+    std::bool_constant<std::is_signed_v<ExtentsIndexType>>{});
   check_upper_bound(user_index, current_extent);
 }
  
-template<class ... Indices, class Extents, size_t ... RankIndices>
+template<size_t ... RankIndices,
+         class ExtentsIndexType, size_t ... Exts,
+         class ... Indices>
+MDSPAN_INLINE_FUNCTION
 constexpr void
 check_all_indices_helper(std::index_sequence<RankIndices...>,
-                         const Extents& exts,
+                         const extents<ExtentsIndexType, Exts...>& exts,
                          Indices... indices)
 {
   _MDSPAN_FOLD_COMMA(
@@ -666,9 +674,12 @@ check_all_indices_helper(std::index_sequence<RankIndices...>,
   );
 }
 
-template<class Extents, class ... Indices>
-constexpr void check_all_indices(const Extents& exts,
-                                 Indices... indices)
+template<class ExtentsIndexType, size_t ... Exts,
+         class ... Indices>
+MDSPAN_INLINE_FUNCTION
+constexpr void
+check_all_indices(const extents<ExtentsIndexType, Exts...>& exts,
+                  Indices... indices)
 {
   check_all_indices_helper(std::make_index_sequence<sizeof...(Indices)>(),
                            exts, indices...);

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -22,6 +22,7 @@
 #endif
 #include <array>
 
+#include <cassert>
 #include <cinttypes>
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
@@ -614,5 +615,65 @@ static
 #endif
 constexpr bool __is_extents_v = __is_extents<T>::value;
 
+template<class UserIndexType, class IndexType>
+constexpr void check_lower_bound(const UserIndexType& user_index,
+                                 const IndexType& /* current_extent */,
+                                 std::true_type) /* is_signed */
+{
+#if defined(NDEBUG)
+  (void) user_index;
+#else
+  assert(static_cast<IndexType>(user_index) >= 0);
+#endif
+}
+
+template<class UserIndexType, class IndexType>
+constexpr void
+check_lower_bound(const UserIndexType& /* user_index */,
+                  const IndexType& /* current_extent */,
+                  std::false_type) /* is_signed */
+{}
+
+template<class UserIndexType, class IndexType>
+constexpr void
+check_upper_bound(const UserIndexType& user_index,
+                  const IndexType& current_extent)
+{
+#if defined(NDEBUG)
+  (void) user_index;
+  (void) current_extent;
+#else
+  assert(static_cast<IndexType>(user_index) < current_extent);
+#endif
+}
+
+template<class InputIndex, class IndexType>
+constexpr void
+check_one_index(const InputIndex& user_index,
+                const IndexType& current_extent)
+{
+  check_lower_bound(user_index, current_extent,
+                    std::bool_constant<std::is_signed_v<IndexType>>{});
+  check_upper_bound(user_index, current_extent);
+}
+ 
+template<class ... Indices, class Extents, size_t ... RankIndices>
+constexpr void
+check_all_indices_helper(std::index_sequence<RankIndices...>,
+                         const Extents& exts,
+                         Indices... indices)
+{
+  _MDSPAN_FOLD_COMMA(
+    (check_one_index(indices, exts.extent(RankIndices)))
+  );
+}
+
+template<class Extents, class ... Indices>
+constexpr void check_all_indices(const Extents& exts,
+                                 Indices... indices)
+{
+  check_all_indices_helper(std::make_index_sequence<sizeof...(Indices)>(), exts, indices...);
+}
+  
 } // namespace detail
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -620,9 +620,8 @@ constexpr void check_lower_bound(const UserIndexType& user_index,
                                  const IndexType& /* current_extent */,
                                  std::true_type) /* is_signed */
 {
-#if defined(NDEBUG)
-  (void) user_index;
-#else
+  (void) user_index; // prevent unused variable warning
+#ifdef _MDSPAN_DEBUG
   assert(static_cast<IndexType>(user_index) >= 0);
 #endif
 }
@@ -639,10 +638,9 @@ constexpr void
 check_upper_bound(const UserIndexType& user_index,
                   const IndexType& current_extent)
 {
-#if defined(NDEBUG)
-  (void) user_index;
+  (void) user_index; // prevent unused variable warnings
   (void) current_extent;
-#else
+#ifdef _MDSPAN_DEBUG
   assert(static_cast<IndexType>(user_index) < current_extent);
 #endif
 }
@@ -672,7 +670,8 @@ template<class Extents, class ... Indices>
 constexpr void check_all_indices(const Extents& exts,
                                  Indices... indices)
 {
-  check_all_indices_helper(std::make_index_sequence<sizeof...(Indices)>(), exts, indices...);
+  check_all_indices_helper(std::make_index_sequence<sizeof...(Indices)>(),
+                           exts, indices...);
 }
   
 } // namespace detail

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -194,6 +194,9 @@ class layout_left::mapping {
     )
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
+#if ! defined(NDEBUG)
+      detail::check_all_indices(this->extents(), idxs...);
+#endif // ! NDEBUG
       return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -24,7 +24,7 @@
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
-namespace impl {
+namespace detail {
   template<class UserIndexType, class IndexType>
   constexpr void check_lower_bound(const UserIndexType& user_index,
                                    const IndexType& /* current_extent */,
@@ -256,7 +256,7 @@ class layout_right::mapping {
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
 #if ! defined(NDEBUG)
-      impl::check_all_indices(std::tuple<Indices...>{idxs...}, this->extents());
+      detail::check_all_indices(std::tuple<Indices...>{idxs...}, this->extents());
 #endif // ! NDEBUG
       return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -73,7 +73,9 @@ namespace detail {
                            const Extents& exts,
                            Indices... indices)
   {
-    ((check_one_index(indices, exts.extent(RankIndices))), ...);
+    _MDSPAN_FOLD_COMMA(
+      (check_one_index(indices, exts.extent(RankIndices)))
+    );
   }
 
   template<class Extents, class ... Indices>

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -195,6 +195,31 @@ class layout_right::mapping {
     )
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
+#if ! defined(NDEBUG)
+#if defined(__cpp_if_constexpr) && defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas > 201707L)
+      std::tuple<Indices...> indices{idxs...};
+      auto check_one = [] <class InputIndex, rank_type RankIndex>
+        (const InputIndex& input_index,
+         index_type current_extent,
+         std::integral_constant<size_t, RankIndex> rank_index) {
+        if constexpr (std::is_signed_v<InputIndex>) {
+          assert(index >= 0);
+        }
+        assert(static_cast<index_type>(index) < current_extent);
+      };
+
+      [&] <size_t ... RankIndices> (std::index_sequence<RankIndices...>) {
+        ((check_one(std::get<RankIndices>(indices),
+                    this->extents().extent(RankIndices),
+                    std::integral_constant<size_t, RankIndices>{})), ...);
+      } (std::make_index_sequence<extents_type::rank()>());
+#else
+      std::array<index_type, extents_type::rank()> indices{static_cast<index_type>(idxs)...};
+      for (rank_type r = 0; r < extents_type::rank(); ++r) {
+        assert(indices[r] < this->extents().extent(r));
+      }
+#endif // if constexpr, and explicit template parameter list for generic lambdas
+#endif // ! NDEBUG
       return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -24,68 +24,6 @@
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
-namespace detail {
-  template<class UserIndexType, class IndexType>
-  constexpr void check_lower_bound(const UserIndexType& user_index,
-                                   const IndexType& /* current_extent */,
-                                   std::true_type) /* is_signed */
-  {
-#if defined(NDEBUG)
-    (void) user_index;
-#else
-    assert(static_cast<IndexType>(user_index) >= 0);
-#endif
-  }
-
-  template<class UserIndexType, class IndexType>
-  constexpr void
-  check_lower_bound(const UserIndexType& /* user_index */,
-                    const IndexType& /* current_extent */,
-                    std::false_type) /* is_signed */
-  {}
-
-  template<class UserIndexType, class IndexType>
-  constexpr void
-  check_upper_bound(const UserIndexType& user_index,
-                    const IndexType& current_extent)
-  {
-#if defined(NDEBUG)
-    (void) user_index;
-    (void) current_extent;
-#else
-    assert(static_cast<IndexType>(user_index) < current_extent);
-#endif
-  }
-
-  template<class InputIndex, class IndexType>
-  constexpr void
-  check_one_index(const InputIndex& user_index,
-                  const IndexType& current_extent)
-  {
-    check_lower_bound(user_index, current_extent,
-                      std::bool_constant<std::is_signed_v<IndexType>>{});
-    check_upper_bound(user_index, current_extent);
-  }
-  
-  template<class ... Indices, class Extents, size_t ... RankIndices>
-  constexpr void
-  check_all_indices_helper(std::index_sequence<RankIndices...>,
-                           const Extents& exts,
-                           Indices... indices)
-  {
-    _MDSPAN_FOLD_COMMA(
-      (check_one_index(indices, exts.extent(RankIndices)))
-    );
-  }
-
-  template<class Extents, class ... Indices>
-  constexpr void check_all_indices(const Extents& exts,
-                                   Indices... indices)
-  {
-    check_all_indices_helper(std::make_index_sequence<sizeof...(Indices)>(), exts, indices...);
-  }
-}
-
 //==============================================================================
 template <class Extents>
 class layout_right::mapping {

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -24,6 +24,66 @@
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
+namespace impl {
+  template<class UserIndexType, class IndexType>
+  constexpr void check_lower_bound(const UserIndexType& user_index,
+                                   const IndexType& /* current_extent */,
+                                   std::true_type) /* is_signed */
+  {
+#if defined(NDEBUG)
+    (void) user_index;
+#else
+    assert(static_cast<IndexType>(user_index) >= 0);
+#endif
+  }
+
+  template<class UserIndexType, class IndexType>
+  constexpr void
+  check_lower_bound(const UserIndexType& /* user_index */,
+                    const IndexType& /* current_extent */,
+                    std::false_type) /* is_signed */
+  {}
+
+  template<class UserIndexType, class IndexType>
+  constexpr void
+  check_upper_bound(const UserIndexType& user_index,
+                    const IndexType& current_extent)
+  {
+#if defined(NDEBUG)
+    (void) user_index;
+    (void) current_extent;
+#else
+    assert(static_cast<IndexType>(user_index) < current_extent);
+#endif
+  }
+
+  template<class InputIndex, class IndexType>
+  constexpr void
+  check_one_index(const InputIndex& user_index,
+                  const IndexType& current_extent)
+  {
+    check_lower_bound(user_index, current_extent,
+                      std::bool_constant<std::is_signed_v<IndexType>>{});
+    check_upper_bound(user_index, current_extent);
+  }
+  
+  template<class ... Indices, class Extents, size_t ... RankIndices>
+  constexpr void
+  check_all_indices_helper(const std::tuple<Indices...> indices,
+                           const Extents& exts,
+                           std::index_sequence<RankIndices...>)
+  {
+    ((check_one_index(std::get<RankIndices>(indices), exts.extent(RankIndices))), ...);
+  }
+
+  template<class ... Indices, class Extents>
+  constexpr void check_all_indices(const std::tuple<Indices...>& indices,
+                         const Extents& exts)
+  {
+    check_all_indices_helper(indices, exts, std::make_index_sequence<sizeof...(Indices)>());
+  }
+}
+
 //==============================================================================
 template <class Extents>
 class layout_right::mapping {
@@ -196,29 +256,7 @@ class layout_right::mapping {
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
 #if ! defined(NDEBUG)
-#if defined(__cpp_if_constexpr) && defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas > 201707L)
-      std::tuple<Indices...> indices{idxs...};
-      auto check_one = [] <class InputIndex, rank_type RankIndex>
-        (const InputIndex& input_index,
-         index_type current_extent,
-         std::integral_constant<size_t, RankIndex> rank_index) {
-        if constexpr (std::is_signed_v<InputIndex>) {
-          assert(index >= 0);
-        }
-        assert(static_cast<index_type>(index) < current_extent);
-      };
-
-      [&] <size_t ... RankIndices> (std::index_sequence<RankIndices...>) {
-        ((check_one(std::get<RankIndices>(indices),
-                    this->extents().extent(RankIndices),
-                    std::integral_constant<size_t, RankIndices>{})), ...);
-      } (std::make_index_sequence<extents_type::rank()>());
-#else
-      std::array<index_type, extents_type::rank()> indices{static_cast<index_type>(idxs)...};
-      for (rank_type r = 0; r < extents_type::rank(); ++r) {
-        assert(indices[r] < this->extents().extent(r));
-      }
-#endif // if constexpr, and explicit template parameter list for generic lambdas
+      impl::check_all_indices(std::tuple<Indices...>{idxs...}, this->extents());
 #endif // ! NDEBUG
       return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -69,18 +69,18 @@ namespace detail {
   
   template<class ... Indices, class Extents, size_t ... RankIndices>
   constexpr void
-  check_all_indices_helper(const std::tuple<Indices...> indices,
+  check_all_indices_helper(std::index_sequence<RankIndices...>,
                            const Extents& exts,
-                           std::index_sequence<RankIndices...>)
+                           Indices... indices)
   {
-    ((check_one_index(std::get<RankIndices>(indices), exts.extent(RankIndices))), ...);
+    ((check_one_index(indices, exts.extent(RankIndices))), ...);
   }
 
-  template<class ... Indices, class Extents>
-  constexpr void check_all_indices(const std::tuple<Indices...>& indices,
-                         const Extents& exts)
+  template<class Extents, class ... Indices>
+  constexpr void check_all_indices(const Extents& exts,
+                                   Indices... indices)
   {
-    check_all_indices_helper(indices, exts, std::make_index_sequence<sizeof...(Indices)>());
+    check_all_indices_helper(std::make_index_sequence<sizeof...(Indices)>(), exts, indices...);
   }
 }
 
@@ -256,7 +256,7 @@ class layout_right::mapping {
     _MDSPAN_HOST_DEVICE
     constexpr index_type operator()(Indices... idxs) const noexcept {
 #if ! defined(NDEBUG)
-      detail::check_all_indices(std::tuple<Indices...>{idxs...}, this->extents());
+      detail::check_all_indices(this->extents(), idxs...);
 #endif // ! NDEBUG
       return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -434,6 +434,9 @@ struct layout_stride {
     )
     MDSPAN_FORCE_INLINE_FUNCTION
     constexpr index_type operator()(Indices... idxs) const noexcept {
+#if ! defined(NDEBUG)
+      detail::check_all_indices(this->extents(), idxs...);
+#endif // ! NDEBUG
       return static_cast<index_type>(__impl::_call_op_impl(*this, static_cast<index_type>(idxs)...));
     }
 

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -32,31 +32,44 @@ template <class LayoutMapping> struct submdspan_mapping_result {
 
 namespace detail {
 
-template<class IndexType, class Slice>
+// We use const Slice& and not Slice&& because the various
+// submdspan_mapping_impl overloads use their slices arguments
+// multiple times.  This makes perfect forwarding not useful, but we
+// still don't want to pass those (possibly of size 64 x 3 bits)
+// objects by value.
+template<class IndexType,
+         class Slice>
+MDSPAN_INLINE_FUNCTION
 constexpr bool
-one_slice_out_of_bounds(const IndexType& extent, Slice&& slice)
+one_slice_out_of_bounds(const IndexType& extent, const Slice& slice)
 {
-  return detail::first_of(std::forward<Slice>(slice)) == extent;
+  return detail::first_of(slice) == extent;
 }
 
-template<size_t ... RankIndices, class Extents, class ... Slices>
+template<size_t ... RankIndices,
+         class IndexType, size_t ... Exts,
+         class ... Slices>
+MDSPAN_INLINE_FUNCTION
 constexpr bool
 any_slice_out_of_bounds_helper(std::index_sequence<RankIndices...>,
-                               const Extents& exts,
-                               Slices&& ... slices)
+                               const extents<IndexType, Exts...>& exts,
+                               const Slices& ... slices)
 {
   return _MDSPAN_FOLD_OR(
-    (one_slice_out_of_bounds(exts.extent(RankIndices), std::forward<Slices>(slices)))
+    (one_slice_out_of_bounds(exts.extent(RankIndices), slices))
   );
 }
 
-template<class Extents, class ... Slices>
+template<class IndexType, size_t ... Exts,
+         class ... Slices>
+MDSPAN_INLINE_FUNCTION
 constexpr bool
-any_slice_out_of_bounds(const Extents& exts,
-                        Slices&& ... slices)
+any_slice_out_of_bounds(const extents<IndexType, Exts...>& exts,
+                        const Slices& ... slices)
 {
-  return any_slice_out_of_bounds_helper(std::make_index_sequence<sizeof...(Slices)>(),
-                                        exts, std::forward<Slices>(slices)...);
+  return any_slice_out_of_bounds_helper(
+    std::make_index_sequence<sizeof...(Slices)>(),
+    exts, slices...);
 }
   
 // constructs sub strides
@@ -142,8 +155,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
-    detail::any_slice_out_of_bounds(this->extents(),
-      std::forward<SliceSpecifiers>(slices)...);
+    detail::any_slice_out_of_bounds(this->extents(), slices...);
   auto offset = static_cast<size_t>(
     out_of_bounds ?
     this->required_span_size() :
@@ -258,8 +270,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
-    detail::any_slice_out_of_bounds(this->extents(),
-      std::forward<SliceSpecifiers>(slices)...);
+    detail::any_slice_out_of_bounds(this->extents(), slices...);
   auto offset = static_cast<size_t>(
     out_of_bounds ?
     this->required_span_size() :
@@ -323,8 +334,7 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
-    detail::any_slice_out_of_bounds(this->extents(),
-      std::forward<SliceSpecifiers>(slices)...);
+    detail::any_slice_out_of_bounds(this->extents(), slices...);
   auto offset = static_cast<size_t>(
     out_of_bounds ?
     this->required_span_size() :

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -139,7 +139,6 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
       std::conditional_t<preserve_layout, layout_left, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
-#if defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas >= 201707L)
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
@@ -150,7 +149,6 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
     this->required_span_size() :
     this->operator()(detail::first_of(slices)...)
   );
-#endif // explicit template parameter list for generic lambdas
 
   if constexpr (std::is_same_v<dst_layout_t, layout_left>) {
     // layout_left case
@@ -257,7 +255,6 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
       std::conditional_t<preserve_layout, layout_right, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
-#if defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas >= 201707L)
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
@@ -268,7 +265,6 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
     this->required_span_size() :
     this->operator()(detail::first_of(slices)...)
   );
-#endif // explicit template parameter list for generic lambdas
   
   if constexpr (std::is_same_v<dst_layout_t, layout_right>) {
     // layout_right case
@@ -324,7 +320,6 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
       slices...);
   using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
 
-#if defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas >= 201707L)
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
@@ -335,7 +330,6 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
     this->required_span_size() :
     this->operator()(detail::first_of(slices)...)
   );
-#endif // explicit template parameter list for generic lambdas
 
   return submdspan_mapping_result<dst_mapping_t>{
       dst_mapping_t(dst_ext, detail::construct_sub_strides(

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -32,31 +32,31 @@ template <class LayoutMapping> struct submdspan_mapping_result {
 
 namespace detail {
 
-  template<class IndexType, class Slice>
-  constexpr bool
-  one_slice_out_of_bounds(const IndexType& extent, Slice&& slice)
-  {
-    return detail::first_of(std::forward<Slice>(slice)) == extent;
-  }
+template<class IndexType, class Slice>
+constexpr bool
+one_slice_out_of_bounds(const IndexType& extent, Slice&& slice)
+{
+  return detail::first_of(std::forward<Slice>(slice)) == extent;
+}
 
-  template<size_t ... RankIndices, class Extents, class ... Slices>
-  constexpr bool
-  any_slice_out_of_bounds_helper(std::index_sequence<RankIndices...>,
-                                 const Extents& exts,
-                                 Slices&& ... slices)
-  {
-    return (one_slice_out_of_bounds(exts.extent(RankIndices),
-                                    std::forward<Slices>(slices)) || ...);
-  }
+template<size_t ... RankIndices, class Extents, class ... Slices>
+constexpr bool
+any_slice_out_of_bounds_helper(std::index_sequence<RankIndices...>,
+                               const Extents& exts,
+                               Slices&& ... slices)
+{
+  return (one_slice_out_of_bounds(exts.extent(RankIndices),
+                                  std::forward<Slices>(slices)) || ...);
+}
 
-  template<class Extents, class ... Slices>
-  constexpr bool
-  any_slice_out_of_bounds(const Extents& exts,
-                          Slices&& ... slices)
-  {
-    return any_slice_out_of_bounds_helper(std::make_index_sequence<sizeof...(Slices)>(),
-                                          exts, std::forward<Slices>(slices)...);
-  }
+template<class Extents, class ... Slices>
+constexpr bool
+any_slice_out_of_bounds(const Extents& exts,
+                        Slices&& ... slices)
+{
+  return any_slice_out_of_bounds_helper(std::make_index_sequence<sizeof...(Slices)>(),
+                                        exts, std::forward<Slices>(slices)...);
+}
   
 // constructs sub strides
 template <class SrcMapping, class... slice_strides, size_t... InvMapIdxs>

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -111,11 +111,23 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
       std::conditional_t<preserve_layout, layout_left, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
+#if defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas >= 201707L)
+  // Figure out if any slice's lower bound equals the corresponding extent.
+  // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+  const bool out_of_bounds =
+    [&] <size_t ... RankIndices> (const extents_type& exts, std::index_sequence<RankIndices...>) {
+      return ((detail::first_of(slices) == exts.extent(RankIndices)) && ...);
+    } (this->extents(), std::make_index_sequence<sizeof...(slices)>());
+  auto offset = static_cast<size_t>(
+    out_of_bounds ?
+    this->required_span_size() :
+    this->operator()(detail::first_of(slices)...)
+  );
+#endif // explicit template parameter list for generic lambdas
+
   if constexpr (std::is_same_v<dst_layout_t, layout_left>) {
     // layout_left case
-    return submdspan_mapping_result<dst_mapping_t>{
-        dst_mapping_t(dst_ext),
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+    return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext), offset};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
@@ -132,7 +144,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
     #else
                                    std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+        offset};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -218,11 +230,23 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
       std::conditional_t<preserve_layout, layout_right, layout_stride>;
   using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
 
+#if defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas >= 201707L)
+  // Figure out if any slice's lower bound equals the corresponding extent.
+  // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+  const bool out_of_bounds =
+    [&] <size_t ... RankIndices> (const extents_type& exts, std::index_sequence<RankIndices...>) {
+      return ((detail::first_of(slices) == exts.extent(RankIndices)) && ...);
+    } (this->extents(), std::make_index_sequence<sizeof...(slices)>());
+  auto offset = static_cast<size_t>(
+    out_of_bounds ?
+    this->required_span_size() :
+    this->operator()(detail::first_of(slices)...)
+  );
+#endif // explicit template parameter list for generic lambdas
+  
   if constexpr (std::is_same_v<dst_layout_t, layout_right>) {
     // layout_right case
-    return submdspan_mapping_result<dst_mapping_t>{
-        dst_mapping_t(dst_ext),
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+    return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext), offset};
   } else {
     // layout_stride case
     auto inv_map = detail::inv_map_rank(
@@ -239,7 +263,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
     #else
                                    std::tuple{detail::stride_of(slices)...})),
     #endif
-        static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+        offset};
   }
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
@@ -273,6 +297,21 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
       std::index_sequence<>(),
       slices...);
   using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
+
+#if defined(__cpp_generic_lambdas) && (__cpp_generic_lambdas >= 201707L)
+  // Figure out if any slice's lower bound equals the corresponding extent.
+  // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+  const bool out_of_bounds =
+    [&] <size_t ... RankIndices> (const extents_type& exts, std::index_sequence<RankIndices...>) {
+      return ((detail::first_of(slices) == exts.extent(RankIndices)) && ...);
+    } (this->extents(), std::make_index_sequence<sizeof...(slices)>());
+  auto offset = static_cast<size_t>(
+    out_of_bounds ?
+    this->required_span_size() :
+    this->operator()(detail::first_of(slices)...)
+  );
+#endif // explicit template parameter list for generic lambdas
+
   return submdspan_mapping_result<dst_mapping_t>{
       dst_mapping_t(dst_ext, detail::construct_sub_strides(
                                  *this, inv_map,
@@ -283,7 +322,7 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
 #else
                                  std::tuple(detail::stride_of(slices)...))),
 #endif
-      static_cast<size_t>(this->operator()(detail::first_of(slices)...))};
+      offset};
 }
 
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -45,8 +45,9 @@ any_slice_out_of_bounds_helper(std::index_sequence<RankIndices...>,
                                const Extents& exts,
                                Slices&& ... slices)
 {
-  return (one_slice_out_of_bounds(exts.extent(RankIndices),
-                                  std::forward<Slices>(slices)) || ...);
+  return _MDSPAN_FOLD_OR(
+    (one_slice_out_of_bounds(exts.extent(RankIndices), std::forward<Slices>(slices)))
+  );
 }
 
 template<class Extents, class ... Slices>

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -31,6 +31,33 @@ template <class LayoutMapping> struct submdspan_mapping_result {
 };
 
 namespace detail {
+
+  template<class IndexType, class Slice>
+  constexpr bool
+  one_slice_out_of_bounds(const IndexType& extent, Slice&& slice)
+  {
+    return detail::first_of(std::forward<Slice>(slice)) == extent;
+  }
+
+  template<size_t ... RankIndices, class Extents, class ... Slices>
+  constexpr bool
+  any_slice_out_of_bounds_helper(std::index_sequence<RankIndices...>,
+                                 const Extents& exts,
+                                 Slices&& ... slices)
+  {
+    return (one_slice_out_of_bounds(exts.extent(RankIndices),
+                                    std::forward<Slices>(slices)) || ...);
+  }
+
+  template<class Extents, class ... Slices>
+  constexpr bool
+  any_slice_out_of_bounds(const Extents& exts,
+                          Slices&& ... slices)
+  {
+    return any_slice_out_of_bounds_helper(std::make_index_sequence<sizeof...(Slices)>(),
+                                          exts, std::forward<Slices>(slices)...);
+  }
+  
 // constructs sub strides
 template <class SrcMapping, class... slice_strides, size_t... InvMapIdxs>
 MDSPAN_INLINE_FUNCTION
@@ -115,9 +142,8 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(SliceSpecifiers... slices)
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
-    [&] <size_t ... RankIndices> (const extents_type& exts, std::index_sequence<RankIndices...>) {
-      return ((detail::first_of(slices) == exts.extent(RankIndices)) && ...);
-    } (this->extents(), std::make_index_sequence<sizeof...(slices)>());
+    detail::any_slice_out_of_bounds(this->extents(),
+      std::forward<SliceSpecifiers>(slices)...);
   auto offset = static_cast<size_t>(
     out_of_bounds ?
     this->required_span_size() :
@@ -234,9 +260,8 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
-    [&] <size_t ... RankIndices> (const extents_type& exts, std::index_sequence<RankIndices...>) {
-      return ((detail::first_of(slices) == exts.extent(RankIndices)) && ...);
-    } (this->extents(), std::make_index_sequence<sizeof...(slices)>());
+    detail::any_slice_out_of_bounds(this->extents(),
+      std::forward<SliceSpecifiers>(slices)...);
   auto offset = static_cast<size_t>(
     out_of_bounds ?
     this->required_span_size() :
@@ -302,9 +327,8 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
-    [&] <size_t ... RankIndices> (const extents_type& exts, std::index_sequence<RankIndices...>) {
-      return ((detail::first_of(slices) == exts.extent(RankIndices)) && ...);
-    } (this->extents(), std::make_index_sequence<sizeof...(slices)>());
+    detail::any_slice_out_of_bounds(this->extents(),
+      std::forward<SliceSpecifiers>(slices)...);
   auto offset = static_cast<size_t>(
     out_of_bounds ?
     this->required_span_size() :

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -382,6 +382,9 @@ public:
   )
   constexpr size_t operator()(_Indices... idxs) const noexcept
   {
+#if ! defined(NDEBUG)
+    ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::check_all_indices(this->extents(), idxs...);
+#endif // ! NDEBUG
     return compute_offset(std::index_sequence_for<_Indices...>{}, idxs...);
   }
 

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -286,20 +286,41 @@ TEST(TestSubmdspanIssue4060, Rank1) {
   EXPECT_EQ(B.data_handle(), x.data() + 3);
 }
 
-TEST(TestSubmdspanIssue4060, Rank2_all) {
+template<class MappingType>
+void test_submdspan_issue4060_rank2_all(const MappingType& mapping)
+{
   auto y = std::array<int, 9>{};
-  auto C = Kokkos::mdspan{y.data(), Kokkos::extents{3, 3}}; 
-  auto D = Kokkos::submdspan(C, std::tuple{3, 3}, std::tuple{3, 3});
+  ASSERT_EQ(mapping.extents().rank(), 2u);
+  ASSERT_EQ(mapping.required_span_size(), y.size());
+  auto C = Kokkos::mdspan{y.data(), mapping};
+  auto D = Kokkos::submdspan(C, std::tuple{3u, 3u}, std::tuple{3u, 3u});
 
   ASSERT_EQ(D.rank(), 2u);
   EXPECT_EQ(D.extent(0), 0);
   EXPECT_EQ(D.extent(1), 0);
-  EXPECT_EQ(D.data_handle(), y.data() + 9);
+  EXPECT_EQ(D.data_handle(), y.data() + mapping.required_span_size());
+}
+
+TEST(TestSubmdspanIssue4060, Rank2_all) {
+  Kokkos::dextents<size_t, 2> exts{3u, 3u};
+  {
+    using mapping_type = Kokkos::layout_left::mapping<Kokkos::dextents<size_t, 2>>;
+    test_submdspan_issue4060_rank2_all(mapping_type{exts});
+  }
+  {
+    using mapping_type = Kokkos::layout_right::mapping<Kokkos::dextents<size_t, 2>>;
+    test_submdspan_issue4060_rank2_all(mapping_type{exts});
+  }
+  {
+    using mapping_type = Kokkos::layout_stride::mapping<Kokkos::dextents<size_t, 2>>;
+    std::array<size_t, 2> strides{1u, 3u};
+    test_submdspan_issue4060_rank2_all(mapping_type{exts, strides});
+  }
 }
 
 TEST(TestSubmdspanIssue4060, Rank2_one) {
   auto y = std::array<int, 9>{};
-  auto C = Kokkos::mdspan{y.data(), Kokkos::extents{3, 3}}; 
+  auto C = Kokkos::mdspan{y.data(), Kokkos::extents{3, 3}};
   auto D = Kokkos::submdspan(C, std::tuple{0, 3}, std::tuple{3, 3});
 
   ASSERT_EQ(D.rank(), 2u);

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -286,7 +286,7 @@ TEST(TestSubmdspanIssue4060, Rank1) {
   EXPECT_EQ(B.data_handle(), x.data() + 3);
 }
 
-TEST(TestSubmdspanIssue4060, Rank2) {
+TEST(TestSubmdspanIssue4060, Rank2_all) {
   auto y = std::array<int, 9>{};
   auto C = Kokkos::mdspan{y.data(), Kokkos::extents{3, 3}}; 
   auto D = Kokkos::submdspan(C, std::tuple{3, 3}, std::tuple{3, 3});
@@ -295,4 +295,16 @@ TEST(TestSubmdspanIssue4060, Rank2) {
   EXPECT_EQ(D.extent(0), 0);
   EXPECT_EQ(D.extent(1), 0);
   EXPECT_EQ(D.data_handle(), y.data() + 9);
+}
+
+TEST(TestSubmdspanIssue4060, Rank2_one) {
+  auto y = std::array<int, 9>{};
+  auto C = Kokkos::mdspan{y.data(), Kokkos::extents{3, 3}}; 
+  auto D = Kokkos::submdspan(C, std::tuple{0, 3}, std::tuple{3, 3});
+
+  ASSERT_EQ(D.rank(), 2u);
+  EXPECT_EQ(D.extent(0), 3);
+  EXPECT_EQ(D.extent(1), 0);
+  EXPECT_EQ(C.mapping().required_span_size(), 9);
+  EXPECT_EQ(D.data_handle(), y.data() + C.mapping().required_span_size());
 }

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -318,14 +318,34 @@ TEST(TestSubmdspanIssue4060, Rank2_all) {
   }
 }
 
-TEST(TestSubmdspanIssue4060, Rank2_one) {
+template<class MappingType>
+void test_submdspan_issue4060_rank2_one(const MappingType& mapping)
+{
   auto y = std::array<int, 9>{};
-  auto C = Kokkos::mdspan{y.data(), Kokkos::extents{3, 3}};
-  auto D = Kokkos::submdspan(C, std::tuple{0, 3}, std::tuple{3, 3});
+  ASSERT_EQ(mapping.extents().rank(), 2u);
+  ASSERT_EQ(mapping.required_span_size(), y.size());
+  auto C = Kokkos::mdspan{y.data(), mapping};
+  auto D = Kokkos::submdspan(C, std::tuple{0u, 3u}, std::tuple{3u, 3u});
 
   ASSERT_EQ(D.rank(), 2u);
-  EXPECT_EQ(D.extent(0), 3);
+  EXPECT_EQ(D.extent(0), 3u);
   EXPECT_EQ(D.extent(1), 0);
-  EXPECT_EQ(C.mapping().required_span_size(), 9);
-  EXPECT_EQ(D.data_handle(), y.data() + C.mapping().required_span_size());
+  EXPECT_EQ(D.data_handle(), y.data() + mapping.required_span_size());
+}
+
+TEST(TestSubmdspanIssue4060, Rank2_one) {
+  Kokkos::dextents<size_t, 2> exts{3u, 3u};
+  {
+    using mapping_type = Kokkos::layout_left::mapping<Kokkos::dextents<size_t, 2>>;
+    test_submdspan_issue4060_rank2_one(mapping_type{exts});
+  }
+  {
+    using mapping_type = Kokkos::layout_right::mapping<Kokkos::dextents<size_t, 2>>;
+    test_submdspan_issue4060_rank2_one(mapping_type{exts});
+  }
+  {
+    using mapping_type = Kokkos::layout_stride::mapping<Kokkos::dextents<size_t, 2>>;
+    std::array<size_t, 2> strides{1u, 3u};
+    test_submdspan_issue4060_rank2_one(mapping_type{exts, strides});
+  }
 }

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -279,11 +279,12 @@ TYPED_TEST(TestSubMDSpan, submdspan_return_type) {
 TEST(TestSubmdspanIssue4060, Rank1) {
   auto x = std::array<int, 3>{};
   auto A = Kokkos::mdspan{x.data(), Kokkos::extents{3}};
+  ASSERT_EQ(A.mapping().required_span_size(), 3);
   auto B = Kokkos::submdspan(A, std::tuple{3, 3});
 
   ASSERT_EQ(B.rank(), 1u);
   EXPECT_EQ(B.extent(0), 0);
-  EXPECT_EQ(B.data_handle(), x.data() + 3);
+  EXPECT_EQ(B.data_handle(), x.data() + A.mapping().required_span_size());
 }
 
 template<class MappingType>

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -275,3 +275,24 @@ TYPED_TEST(TestSubMDSpan, submdspan_return_type) {
                 "SubMDSpan: wrong return type");
   __MDSPAN_TESTS_RUN_TEST(TestFixture::run());
 }
+
+TEST(TestSubmdspanIssue4060, Rank1) {
+  auto x = std::array<int, 3>{};
+  auto A = Kokkos::mdspan{x.data(), Kokkos::extents{3}};
+  auto B = Kokkos::submdspan(A, std::tuple{3, 3});
+
+  ASSERT_EQ(B.rank(), 1u);
+  EXPECT_EQ(B.extent(0), 0);
+  EXPECT_EQ(B.data_handle(), x.data() + 3);
+}
+
+TEST(TestSubmdspanIssue4060, Rank2) {
+  auto y = std::array<int, 9>{};
+  auto C = Kokkos::mdspan{y.data(), Kokkos::extents{3, 3}}; 
+  auto D = Kokkos::submdspan(C, std::tuple{3, 3}, std::tuple{3, 3});
+
+  ASSERT_EQ(D.rank(), 2u);
+  EXPECT_EQ(D.extent(0), 0);
+  EXPECT_EQ(D.extent(1), 0);
+  EXPECT_EQ(D.data_handle(), y.data() + 9);
+}


### PR DESCRIPTION
Link to issue: https://cplusplus.github.io/LWG/issue4060

1. Fix submdspan to prevent invalid pointer creation
2. Implement bounds checking for the various layouts, so we can actually detect the issue

I aimed for C++14 backwards compatibility.  Item (2) above is not strictly necessary to fix the issue, but it does help with finding the issue in the first place.

Bounds checking is only enabled in a debug build (if `NDEBUG` is not defined).  It involves some fold expressions over `assert` expressions.  I'm not attached to the use of `assert` for reporting errors.