### PR TITLE
fix padded layout annotations and add tagged raw array constructor to `layout_stride`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Features in Addition To C++ Standard
 - C++14 backport (e.g., fold expressions not required)
   - Compile times of this backport will be substantially slower than the C++17 version
 - Macros to enable, e.g., `__device__` marking of all functions for CUDA compatibility
+* Non-standard extensions for device code compatibility
+  * These extension methods can be invoked by passing `Kokkos::mdspan_non_standard` as the first argument.
 
 Building and Installation
 -------------------------

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -202,6 +202,12 @@ struct layout_stride {
         return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 
+      template<class IntegralType>
+      MDSPAN_INLINE_FUNCTION
+      static constexpr const __strides_storage_t fill_strides(mdspan_non_standard_tag, const IntegralType (&s)[extents_type::rank()]) {
+        return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
+      }
+
 #ifdef __cpp_lib_span
       template<class IntegralType>
       MDSPAN_INLINE_FUNCTION
@@ -297,6 +303,44 @@ struct layout_stride {
       : __base_t(__base_t{__member_pair_t(
 #endif
           e, __strides_storage_t(__impl::fill_strides(s))
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+        }
+#else
+        )})
+#endif
+    {
+      /*
+       * TODO: check preconditions
+       * - s[i] > 0 is true for all i in the range [0, rank_ ).
+       * - REQUIRED-SPAN-SIZE(e, s) is a representable value of type index_type ([basic.fundamental]).
+       * - If rank_ is greater than 0, then there exists a permutation P of the integers in the
+       *   range [0, rank_), such that s[ pi ] >= s[ pi − 1 ] * e.extent( pi − 1 ) is true for
+       *   all i in the range [1, rank_ ), where pi is the ith element of P.
+       */
+    }
+
+    MDSPAN_TEMPLATE_REQUIRES(
+      class IntegralTypes,
+      /* requires */ (
+        // MSVC 19.32 does not like using index_type here, requires the typename Extents::index_type
+        // error C2641: cannot deduce template arguments for 'MDSPAN_IMPL_STANDARD_NAMESPACE::layout_stride::mapping'
+        _MDSPAN_TRAIT(std::is_convertible, const std::remove_const_t<IntegralTypes>&, typename Extents::index_type) &&
+        _MDSPAN_TRAIT(std::is_nothrow_constructible, typename Extents::index_type, const std::remove_const_t<IntegralTypes>&)
+      )
+    )
+    MDSPAN_INLINE_FUNCTION
+    constexpr
+    mapping(
+      mdspan_non_standard_tag,
+      extents_type const& e,
+      IntegralTypes (&s)[extents_type::rank()]
+    ) noexcept
+#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+      : __members{
+#else
+      : __base_t(__base_t{__member_pair_t(
+#endif
+          e, __strides_storage_t(__impl::fill_strides(mdspan_non_standard, s))
 #if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -697,8 +697,3 @@ struct __bools;
 
 // </editor-fold> end Pre-C++14 constexpr }}}1
 //==============================================================================
-
-namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
-constexpr struct mdspan_non_standard_tag {
-} mdspan_non_standard;
-} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -697,3 +697,8 @@ struct __bools;
 
 // </editor-fold> end Pre-C++14 constexpr }}}1
 //==============================================================================
+
+namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
+constexpr struct mdspan_non_standard_tag {
+} mdspan_non_standard;
+} // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -59,4 +59,8 @@ constexpr struct
 } stride;
 
 } // namespace detail
+
+constexpr struct mdspan_non_standard_tag {
+} mdspan_non_standard;
+
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -174,19 +174,21 @@ private:
   typename padded_stride_type::static_array_type padded_stride = {};
   extents_type exts = {};
 
-  constexpr index_type compute_offset(std::index_sequence<>) const {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  compute_offset(std::index_sequence<>) const {
     return 0;
   }
 
   template <size_t Rank, class IndexOffset>
-  constexpr index_type compute_offset(std::index_sequence<Rank>,
-                                        IndexOffset index_offset) const {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  compute_offset(std::index_sequence<Rank>, IndexOffset index_offset) const {
     return index_offset;
   }
 
   template <size_t... Ranks, class... IndexOffsets>
-  constexpr index_type compute_offset(std::index_sequence<Ranks...>,
-                                        IndexOffsets... index_offsets) const {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  compute_offset(std::index_sequence<Ranks...>,
+                 IndexOffsets... index_offsets) const {
     index_type indices[] = {static_cast<index_type>(index_offsets)...};
     // self-recursive fold trick from
     // https://github.com/llvm/llvm-project/blob/96e1914aa2e6d8966acbfbe2f4d184201f1aa318/libcxx/include/mdspan/layout_left.h#L144
@@ -257,62 +259,71 @@ public:
   /**
    * Converting constructor from `layout_left::mapping`.
    *
-   * This overload participates in overload resolution only if `is_constructible_v<extents_type, OtherExtents>` is true.
-   * If `OtherExtents::rank() > 1` then one of `padding_value`, `static_extent(0)`, or `OtherExtents::static_extent(0)` must be `dynamic_extent`;
-   * otherwise, `OtherExtents::static_extent(0)` must be equal to the least multiple of `padding_value` greater than or equal to `extents_type::static_extent(0)`
+   * This overload participates in overload resolution only if
+   * `is_constructible_v<extents_type, OtherExtents>` is true. If
+   * `OtherExtents::rank() > 1` then one of `padding_value`, `static_extent(0)`,
+   * or `OtherExtents::static_extent(0)` must be `dynamic_extent`; otherwise,
+   * `OtherExtents::static_extent(0)` must be equal to the least multiple of
+   * `padding_value` greater than or equal to `extents_type::static_extent(0)`
    */
   MDSPAN_TEMPLATE_REQUIRES(
-    class _OtherExtents,
-    /* requires */ (
-      std::is_constructible_v<extents_type, _OtherExtents>
-    )
-  )
-  MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<_OtherExtents, extents_type>))
+      class _OtherExtents,
+      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
+  MDSPAN_CONDITIONAL_EXPLICIT(
+      (!std::is_convertible_v<_OtherExtents, extents_type>))
+  MDSPAN_INLINE_FUNCTION
   constexpr mapping(const layout_left::mapping<_OtherExtents> &other_mapping)
-      : padded_stride(padded_stride_type::init_padding(other_mapping, std::integral_constant<size_t, padded_stride_idx>{})),
-        exts(other_mapping.extents())
-  {
-    static_assert((_OtherExtents::rank() > 1) || (static_padding_stride != dynamic_extent) || (_OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent)
-                  || (static_padding_stride == _OtherExtents::static_extent(extent_to_pad_idx)));
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping,
+            std::integral_constant<size_t, padded_stride_idx>{})),
+        exts(other_mapping.extents()) {
+    static_assert(
+        (_OtherExtents::rank() > 1) ||
+        (static_padding_stride != dynamic_extent) ||
+        (_OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent) ||
+        (static_padding_stride ==
+         _OtherExtents::static_extent(extent_to_pad_idx)));
   }
 
   /**
    * Converting constructor from `layout_stride::mapping`.
    *
-   * This overload participates in overload resolution only if `is_constructible_v<extents_type, OtherExtents>` is true
+   * This overload participates in overload resolution only if
+   * `is_constructible_v<extents_type, OtherExtents>` is true
    */
   MDSPAN_TEMPLATE_REQUIRES(
-    class _OtherExtents,
-    /* requires */ (
-      std::is_constructible_v<extents_type, _OtherExtents>
-    )
-  )
+      class _OtherExtents,
+      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
   MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
+  MDSPAN_INLINE_FUNCTION
   constexpr mapping(const layout_stride::mapping<_OtherExtents> &other_mapping)
-      : padded_stride(padded_stride_type::init_padding(other_mapping, std::integral_constant<size_t, padded_stride_idx>{})),
-        exts(other_mapping.extents())
-  {
-  }
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping,
+            std::integral_constant<size_t, padded_stride_idx>{})),
+        exts(other_mapping.extents()) {}
 
   /**
    * Converting constructor from `layout_left_padded::mapping`.
    *
-   * This overload participates in overload resolution only if `is_constructible_v<extents_type, OtherExtents>` is true.
-   * Either `padding_value` or `OtherPaddingStride` must be `std::dynamic_extent`, or `padding_value == OtherPaddingStride`.
+   * This overload participates in overload resolution only if
+   * `is_constructible_v<extents_type, OtherExtents>` is true. Either
+   * `padding_value` or `OtherPaddingStride` must be `std::dynamic_extent`, or
+   * `padding_value == OtherPaddingStride`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-    class _Mapping,
-    /* requires */ (
-      detail::is_layout_left_padded_mapping<_Mapping>::value
-      && std::is_constructible_v<extents_type, typename _Mapping::extents_type>
-    )
-  )
-  MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 1 && (padding_value == dynamic_extent || _Mapping::padding_value == dynamic_extent)))
-  constexpr
-  mapping(const _Mapping &other_mapping)
-      : padded_stride(padded_stride_type::init_padding(other_mapping, std::integral_constant<size_t, padded_stride_idx>{})),
-        exts(other_mapping.extents())
-  {
+      class _Mapping,
+      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value
+                          &&std::is_constructible_v<
+                              extents_type, typename _Mapping::extents_type>))
+  MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 1 &&
+                               (padding_value == dynamic_extent ||
+                                _Mapping::padding_value == dynamic_extent)))
+  MDSPAN_INLINE_FUNCTION
+  constexpr mapping(const _Mapping &other_mapping)
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping,
+            std::integral_constant<size_t, padded_stride_idx>{})),
+        exts(other_mapping.extents()) {
     static_assert(padding_value == dynamic_extent ||
                   _Mapping::padding_value == dynamic_extent ||
                   padding_value == _Mapping::padding_value);
@@ -321,42 +332,43 @@ public:
   /**
    * Converting constructor from `layout_right_padded::mapping`.
    *
-   * This overload participates in overload resolution only if `extents_type::rank()` is 0 or 1 and `is_constructible_v<extents_type, OtherExtents>` is `true`.
+   * This overload participates in overload resolution only if
+   * `extents_type::rank()` is 0 or 1 and `is_constructible_v<extents_type,
+   * OtherExtents>` is `true`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-    class _Mapping,
-    /* requires */ (
-      detail::is_layout_right_padded_mapping<_Mapping>::value
-      && extents_type::rank() <= 1
-      && std::is_constructible_v<extents_type, typename _Mapping::extents_type>
-    )
-  )
-  MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
-  constexpr
-  mapping(const _Mapping &other_mapping) noexcept
-      : padded_stride(padded_stride_type::init_padding(other_mapping.extents(), other_mapping.extents().extent(extent_to_pad_idx))),
-        exts(other_mapping.extents())
-  {}
+      class _Mapping,
+      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value
+                              &&extents_type::rank() <= 1 &&
+                      std::is_constructible_v<extents_type,
+                                              typename _Mapping::extents_type>))
+  MDSPAN_CONDITIONAL_EXPLICIT(
+      (!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+  MDSPAN_INLINE_FUNCTION
+  constexpr mapping(const _Mapping &other_mapping) noexcept
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping.extents(),
+            other_mapping.extents().extent(extent_to_pad_idx))),
+        exts(other_mapping.extents()) {}
 
-  constexpr const extents_type &extents() const noexcept
-  {
+  MDSPAN_INLINE_FUNCTION constexpr const extents_type &
+  extents() const noexcept {
     return exts;
   }
 
-  constexpr std::array<index_type, extents_type::rank()>
-  strides() const noexcept
-  {
-    if constexpr ( extents_type::rank() == 0 ) {
+  MDSPAN_INLINE_FUNCTION constexpr std::array<index_type, extents_type::rank()>
+  strides() const noexcept {
+    if constexpr (extents_type::rank() == 0) {
       return {};
-    } else if constexpr ( extents_type::rank() == 1 ) {
+    } else if constexpr (extents_type::rank() == 1) {
       return {1};
     } else {
       index_type value = 1;
       std::array<index_type, extents_type::rank()> s{};
       s[extent_to_pad_idx] = value;
       value *= padded_stride.value(0);
-      for (rank_type r = extent_to_pad_idx + 1; r < extents_type::rank() - 1; ++r)
-      {
+      for (rank_type r = extent_to_pad_idx + 1; r < extents_type::rank() - 1;
+           ++r) {
         s[r] = value;
         value *= exts.extent(r);
       }
@@ -365,12 +377,11 @@ public:
     }
   }
 
-  constexpr index_type
-  required_span_size() const noexcept
-  {
-    if constexpr ( extents_type::rank() == 0 ) {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  required_span_size() const noexcept {
+    if constexpr (extents_type::rank() == 0) {
       return 1;
-    } else if constexpr ( extents_type::rank() == 1 ) {
+    } else if constexpr (extents_type::rank() == 1) {
       return exts.extent(0);
     } else {
       index_type value = padded_stride.value(0);
@@ -391,43 +402,51 @@ public:
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class... _Indices,
-      /* requires */ (
-          sizeof...(_Indices) == extents_type::rank() &&
-          (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::are_valid_indices<index_type, _Indices...>())
-    )
-  )
-  constexpr size_t operator()(_Indices... idxs) const noexcept
-  {
-#if ! defined(NDEBUG)
-    ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::check_all_indices(this->extents(), idxs...);
+      /* requires */ (sizeof...(_Indices) == extents_type::rank() &&
+                      (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::
+                           are_valid_indices<index_type, _Indices...>())))
+  MDSPAN_INLINE_FUNCTION constexpr size_t
+  operator()(_Indices... idxs) const noexcept {
+#if !defined(NDEBUG)
+    ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::check_all_indices(this->extents(),
+                                                                idxs...);
 #endif // ! NDEBUG
     return compute_offset(std::index_sequence_for<_Indices...>{}, idxs...);
   }
 
-  static constexpr bool is_always_unique() noexcept { return true; }
-  static constexpr bool is_always_exhaustive() noexcept
-  {
-    return (extents_type::rank() <= rank_type(1))
-      || (extents_type::static_extent(extent_to_pad_idx) != dynamic_extent
-          && extents_type::static_extent(extent_to_pad_idx) == padded_stride_type::static_value());
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept {
+    return true;
   }
-  static constexpr bool is_always_strided() noexcept { return true; }
-
-  static constexpr bool is_unique() noexcept { return true; }
-  constexpr bool is_exhaustive() const noexcept
-  {
-    return (extents_type::rank() < 2)
-           || (exts.extent(extent_to_pad_idx) == padded_stride.value(0));
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_exhaustive() noexcept {
+    return (extents_type::rank() <= rank_type(1)) ||
+           (extents_type::static_extent(extent_to_pad_idx) != dynamic_extent &&
+            extents_type::static_extent(extent_to_pad_idx) ==
+                padded_stride_type::static_value());
   }
-  static constexpr bool is_strided() noexcept { return true; }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() noexcept {
+    return true;
+  }
 
-  constexpr index_type stride(rank_type r) const noexcept
-  {
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_unique() noexcept {
+    return true;
+  }
+  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept {
+    return (extents_type::rank() < 2) ||
+           (exts.extent(extent_to_pad_idx) == padded_stride.value(0));
+  }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_strided() noexcept {
+    return true;
+  }
+
+  MDSPAN_INLINE_FUNCTION
+  constexpr index_type stride(rank_type r) const noexcept {
     assert(r < extents_type::rank());
-    if(r == 0) return index_type(1);
+    if (r == 0)
+      return index_type(1);
 
     index_type value = padded_stride.value(0);
-    for (rank_type k = 1; k < r; k++) value *= exts.extent(k);
+    for (rank_type k = 1; k < r; k++)
+      value *= exts.extent(k);
 
     return value;
   }
@@ -435,26 +454,26 @@ public:
   /**
    * Equality operator between `layout_left_padded`s
    *
-   * This overload only participates in overload resolution if `OtherExtents::rank() == extents_type::rank()`.
+   * This overload only participates in overload resolution if
+   * `OtherExtents::rank() == extents_type::rank()`.
    *
-   * \note There is currently a difference from p2642r2, where this function is specified as taking
-   * `layout_left_padded< padding_value >::mapping< Extents>`. However, this makes `padding_value` non-deducible.
+   * \note There is currently a difference from p2642r2, where this function is
+   * specified as taking `layout_left_padded< padding_value >::mapping<
+   * Extents>`. However, this makes `padding_value` non-deducible.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-    class _Mapping,
-    /* requires */ (
-      detail::is_layout_left_padded_mapping<_Mapping>::value
-      && (_Mapping::extents_type::rank() == extents_type::rank())
-    )
-  )
-  friend constexpr bool operator==(const mapping &left, const _Mapping &right) noexcept
-  {
-    // Workaround for some compilers not short-circuiting properly with compile-time checks
-    // i.e. we can't access stride(_padding_stride_idx) of a rank 0 mapping
+      class _Mapping,
+      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value &&
+                      (_Mapping::extents_type::rank() == extents_type::rank())))
+  MDSPAN_INLINE_FUNCTION friend constexpr bool
+  operator==(const mapping &left, const _Mapping &right) noexcept {
+    // Workaround for some compilers not short-circuiting properly with
+    // compile-time checks i.e. we can't access stride(_padding_stride_idx) of a
+    // rank 0 mapping
     bool strides_equal = true;
-    if constexpr (extents_type::rank() > rank_type(1))
-    {
-      strides_equal = left.stride(padded_stride_idx) == right.stride(padded_stride_idx);
+    if constexpr (extents_type::rank() > rank_type(1)) {
+      strides_equal =
+          left.stride(padded_stride_idx) == right.stride(padded_stride_idx);
     }
     return (left.extents() == right.extents()) && strides_equal;
   }
@@ -463,17 +482,15 @@ public:
   /**
    * Inequality operator between `layout_left_padded`s
    *
-   * This overload only participates in overload resolution if `OtherExtents::rank() == extents_type::rank()`.
+   * This overload only participates in overload resolution if
+   * `OtherExtents::rank() == extents_type::rank()`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-    class _Mapping,
-    /* requires */ (
-      detail::is_layout_left_padded_mapping<_Mapping>::value
-      && (_Mapping::extents_type::rank() == extents_type::rank())
-    )
-  )
-  friend constexpr bool operator!=(const mapping &left, const _Mapping &right) noexcept
-  {
+      class _Mapping,
+      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value &&
+                      (_Mapping::extents_type::rank() == extents_type::rank())))
+  MDSPAN_INLINE_FUNCTION friend constexpr bool
+  operator!=(const mapping &left, const _Mapping &right) noexcept {
     return !(left == right);
   }
 #endif
@@ -509,25 +526,27 @@ public:
   typename padded_stride_type::static_array_type padded_stride = {};
   extents_type exts = {};
 
-  constexpr index_type compute_offset(std::index_sequence<>) const {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  compute_offset(std::index_sequence<>) const {
     return 0;
   }
 
   template <size_t Rank, class IndexOffset>
-  constexpr index_type compute_offset(std::index_sequence<Rank>,
-                                        IndexOffset index_offset) const {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  compute_offset(std::index_sequence<Rank>, IndexOffset index_offset) const {
     return index_offset;
   }
 
   template <size_t... Ranks, class... IndexOffsets>
-  constexpr index_type compute_offset(std::index_sequence<Ranks...>,
-                                        IndexOffsets... index_offsets) const {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  compute_offset(std::index_sequence<Ranks...>,
+                 IndexOffsets... index_offsets) const {
     // self-recursive fold trick from
     // https://github.com/llvm/llvm-project/blob/4d9771741d40cc9cfcccb6b033f43689d36b705a/libcxx/include/mdspan/layout_right.h#L141
     index_type res = 0;
     ((res = static_cast<index_type>(index_offsets) +
             (Ranks == extent_to_pad_idx ? padded_stride.value(0)
-                                          : exts.extent(Ranks)) *
+                                        : exts.extent(Ranks)) *
                 res),
      ...);
     return res;
@@ -596,56 +615,62 @@ public:
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class _OtherExtents,
-      /* requires */ (
-          std::is_constructible_v<extents_type, _OtherExtents>
-          )
-      )
-  MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<_OtherExtents, extents_type>))
+      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
+  MDSPAN_CONDITIONAL_EXPLICIT(
+      (!std::is_convertible_v<_OtherExtents, extents_type>))
+  MDSPAN_INLINE_FUNCTION
   constexpr mapping(const layout_right::mapping<_OtherExtents> &other_mapping)
-      : padded_stride(padded_stride_type::init_padding(other_mapping, std::integral_constant<size_t, padded_stride_idx>{})),
-        exts(other_mapping.extents())
-  {
-    static_assert((_OtherExtents::rank() > 1) || (padded_stride_type::static_value() != dynamic_extent) || (_OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent)
-                  || (padded_stride_type::static_value() == _OtherExtents::static_extent(extent_to_pad_idx)));
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping,
+            std::integral_constant<size_t, padded_stride_idx>{})),
+        exts(other_mapping.extents()) {
+    static_assert(
+        (_OtherExtents::rank() > 1) ||
+        (padded_stride_type::static_value() != dynamic_extent) ||
+        (_OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent) ||
+        (padded_stride_type::static_value() ==
+         _OtherExtents::static_extent(extent_to_pad_idx)));
   }
 
   /**
    * Converting constructor from `layout_stride::mapping`.
    *
-   * This overload participates in overload resolution only if `is_constructible_v<extents_type, OtherExtents>` is true
+   * This overload participates in overload resolution only if
+   * `is_constructible_v<extents_type, OtherExtents>` is true
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class _OtherExtents,
-      /* requires */ (
-          std::is_constructible_v<extents_type, _OtherExtents>
-          )
-      )
+      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
   MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
+  MDSPAN_INLINE_FUNCTION
   constexpr mapping(const layout_stride::mapping<_OtherExtents> &other_mapping)
-      : padded_stride(padded_stride_type::init_padding(other_mapping, std::integral_constant<size_t, padded_stride_idx>{})),
-        exts(other_mapping.extents())
-  {}
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping,
+            std::integral_constant<size_t, padded_stride_idx>{})),
+        exts(other_mapping.extents()) {}
 
   /**
    * Converting constructor from `layout_right_padded::mapping`.
    *
-   * This overload participates in overload resolution only if `is_constructible_v<extents_type, OtherExtents>` is true.
-   * Either `padding_value` or `OtherPaddingStride` must be `std::dynamic_extent`, or `padding_value == OtherPaddingStride`.
+   * This overload participates in overload resolution only if
+   * `is_constructible_v<extents_type, OtherExtents>` is true. Either
+   * `padding_value` or `OtherPaddingStride` must be `std::dynamic_extent`, or
+   * `padding_value == OtherPaddingStride`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class _Mapping,
-      /* requires */ (
-          detail::is_layout_right_padded_mapping<_Mapping>::value
-              && std::is_constructible_v<extents_type, typename _Mapping::extents_type>
-          )
-      )
+      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value
+                          &&std::is_constructible_v<
+                              extents_type, typename _Mapping::extents_type>))
   MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 1 &&
                                (padding_value == dynamic_extent ||
                                 _Mapping::padding_value == dynamic_extent)))
+  MDSPAN_INLINE_FUNCTION
   constexpr mapping(const _Mapping &other_mapping)
-      : padded_stride(padded_stride_type::init_padding(other_mapping, std::integral_constant<size_t, padded_stride_idx>{})),
-        exts(other_mapping.extents())
-  {
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping,
+            std::integral_constant<size_t, padded_stride_idx>{})),
+        exts(other_mapping.extents()) {
     static_assert(padding_value == dynamic_extent ||
                   _Mapping::padding_value == dynamic_extent ||
                   padding_value == _Mapping::padding_value);
@@ -654,41 +679,42 @@ public:
   /**
    * Converting constructor from `layout_left_padded::mapping`.
    *
-   * This overload participates in overload resolution only if `extents_type::rank()` is 0 or 1 and `is_constructible_v<extents_type, OtherExtents>` is `true`.
+   * This overload participates in overload resolution only if
+   * `extents_type::rank()` is 0 or 1 and `is_constructible_v<extents_type,
+   * OtherExtents>` is `true`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class _Mapping,
-      /* requires */ (
-          detail::is_layout_left_padded_mapping<_Mapping>::value
-                  && extents_type::rank() <= 1
-          && std::is_constructible_v<extents_type, typename _Mapping::extents_type>
-          )
-      )
-  MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value
+                              &&extents_type::rank() <= 1 &&
+                      std::is_constructible_v<extents_type,
+                                              typename _Mapping::extents_type>))
+  MDSPAN_CONDITIONAL_EXPLICIT(
+      (!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+  MDSPAN_INLINE_FUNCTION
   constexpr mapping(const _Mapping &other_mapping) noexcept
-      : padded_stride(padded_stride_type::init_padding(other_mapping.extents(), other_mapping.extents().extent(extent_to_pad_idx))),
-        exts(other_mapping.extents())
-  {}
+      : padded_stride(padded_stride_type::init_padding(
+            other_mapping.extents(),
+            other_mapping.extents().extent(extent_to_pad_idx))),
+        exts(other_mapping.extents()) {}
 
-  constexpr const extents_type &extents() const noexcept
-  {
+  MDSPAN_INLINE_FUNCTION constexpr const extents_type &
+  extents() const noexcept {
     return exts;
   }
 
-  constexpr std::array<index_type, extents_type::rank()>
-  strides() const noexcept
-  {
-    if constexpr ( extents_type::rank() == 0 ) {
+  MDSPAN_INLINE_FUNCTION constexpr std::array<index_type, extents_type::rank()>
+  strides() const noexcept {
+    if constexpr (extents_type::rank() == 0) {
       return {};
-    } else if constexpr ( extents_type::rank() == 1 ) {
+    } else if constexpr (extents_type::rank() == 1) {
       return {1};
     } else {
       index_type value = 1;
       std::array<index_type, extents_type::rank()> s{};
       s[extent_to_pad_idx] = value;
       value *= padded_stride.value(0);
-      for (rank_type r = extent_to_pad_idx - 1; r > 0; --r)
-      {
+      for (rank_type r = extent_to_pad_idx - 1; r > 0; --r) {
         s[r] = value;
         value *= exts.extent(r);
       }
@@ -697,17 +723,15 @@ public:
     }
   }
 
-  constexpr index_type
-  required_span_size() const noexcept
-  {
-    if constexpr ( extents_type::rank() == 0 ) {
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  required_span_size() const noexcept {
+    if constexpr (extents_type::rank() == 0) {
       return 1;
-    } else if constexpr ( extents_type::rank() == 1 ) {
+    } else if constexpr (extents_type::rank() == 1) {
       return exts.extent(0);
     } else {
       index_type value = 1;
-      for (rank_type r = 0; r < extent_to_pad_idx; ++r)
-      {
+      for (rank_type r = 0; r < extent_to_pad_idx; ++r) {
         value *= exts.extent(r);
       }
       return value * padded_stride.value(0);
@@ -724,40 +748,47 @@ public:
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class... _Indices,
-      /* requires */ (
-          sizeof...(_Indices) == extents_type::rank() &&
-          (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::are_valid_indices<index_type, _Indices...>())
-          )
-      )
-  constexpr size_t operator()(_Indices... idxs) const noexcept
-  {
+      /* requires */ (sizeof...(_Indices) == extents_type::rank() &&
+                      (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::
+                           are_valid_indices<index_type, _Indices...>())))
+  MDSPAN_INLINE_FUNCTION constexpr size_t
+  operator()(_Indices... idxs) const noexcept {
     return compute_offset(std::index_sequence_for<_Indices...>{}, idxs...);
   }
 
-  static constexpr bool is_always_unique() noexcept { return true; }
-  static constexpr bool is_always_exhaustive() noexcept
-  {
-    return (extents_type::rank() <= rank_type(1))
-           || (extents_type::static_extent(extent_to_pad_idx) != dynamic_extent
-               && extents_type::static_extent(extent_to_pad_idx) == padded_stride_type::static_value());
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept {
+    return true;
   }
-  static constexpr bool is_always_strided() noexcept { return true; }
-
-  static constexpr bool is_unique() noexcept { return true; }
-  constexpr bool is_exhaustive() const noexcept
-  {
-    return (extents_type::rank() < 2)
-           || (exts.extent(extent_to_pad_idx) == padded_stride.value(0));
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_exhaustive() noexcept {
+    return (extents_type::rank() <= rank_type(1)) ||
+           (extents_type::static_extent(extent_to_pad_idx) != dynamic_extent &&
+            extents_type::static_extent(extent_to_pad_idx) ==
+                padded_stride_type::static_value());
   }
-  static constexpr bool is_strided() noexcept { return true; }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() noexcept {
+    return true;
+  }
 
-  constexpr index_type stride(rank_type r) const noexcept
-  {
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_unique() noexcept {
+    return true;
+  }
+  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept {
+    return (extents_type::rank() < 2) ||
+           (exts.extent(extent_to_pad_idx) == padded_stride.value(0));
+  }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_strided() noexcept {
+    return true;
+  }
+
+  MDSPAN_INLINE_FUNCTION constexpr index_type
+  stride(rank_type r) const noexcept {
     assert(r < extents_type::rank());
-    if(r == extents_type::rank() - 1) return index_type(1);
+    if (r == extents_type::rank() - 1)
+      return index_type(1);
 
     index_type value = padded_stride.value(0);
-    for (rank_type k = extents_type::rank() - 2; k > r; k--) value *= exts.extent(k);
+    for (rank_type k = extents_type::rank() - 2; k > r; k--)
+      value *= exts.extent(k);
 
     return value;
   }
@@ -765,26 +796,26 @@ public:
   /**
    * Equality operator between `layout_right_padded`s
    *
-   * This overload only participates in overload resolution if `OtherExtents::rank() == extents_type::rank()`.
+   * This overload only participates in overload resolution if
+   * `OtherExtents::rank() == extents_type::rank()`.
    *
-   * \note There is currently a difference from p2642r2, where this function is specified as taking
-   * `layout_right_padded< padding_value >::mapping< Extents>`. However, this makes `padding_value` non-deducible.
+   * \note There is currently a difference from p2642r2, where this function is
+   * specified as taking `layout_right_padded< padding_value >::mapping<
+   * Extents>`. However, this makes `padding_value` non-deducible.
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class _Mapping,
-      /* requires */ (
-          detail::is_layout_right_padded_mapping<_Mapping>::value
-          && (_Mapping::extents_type::rank() == extents_type::rank())
-          )
-      )
-  friend constexpr bool operator==(const mapping &left, const _Mapping &right) noexcept
-  {
-    // Workaround for some compilers not short-circuiting properly with compile-time checks
-    // i.e. we can't access stride(_padding_stride_idx) of a rank 0 mapping
+      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value &&
+                      (_Mapping::extents_type::rank() == extents_type::rank())))
+  MDSPAN_INLINE_FUNCTION friend constexpr bool
+  operator==(const mapping &left, const _Mapping &right) noexcept {
+    // Workaround for some compilers not short-circuiting properly with
+    // compile-time checks i.e. we can't access stride(_padding_stride_idx) of a
+    // rank 0 mapping
     bool strides_equal = true;
-    if constexpr (extents_type::rank() > rank_type(1))
-    {
-      strides_equal = left.stride(padded_stride_idx) == right.stride(padded_stride_idx);
+    if constexpr (extents_type::rank() > rank_type(1)) {
+      strides_equal =
+          left.stride(padded_stride_idx) == right.stride(padded_stride_idx);
     }
     return (left.extents() == right.extents()) && strides_equal;
   }
@@ -793,17 +824,15 @@ public:
   /**
    * Inequality operator between `layout_right_padded`s
    *
-   * This overload only participates in overload resolution if `OtherExtents::rank() == extents_type::rank()`.
+   * This overload only participates in overload resolution if
+   * `OtherExtents::rank() == extents_type::rank()`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
       class _Mapping,
-      /* requires */ (
-          detail::is_layout_right_padded_mapping<_Mapping>::value
-          && (_Mapping::extents_type::rank() == extents_type::rank())
-          )
-      )
-  friend constexpr bool operator!=(const mapping &left, const _Mapping &right) noexcept
-  {
+      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value &&
+                      (_Mapping::extents_type::rank() == extents_type::rank())))
+  MDSPAN_INLINE_FUNCTION friend constexpr bool
+  operator!=(const mapping &left, const _Mapping &right) noexcept {
     return !(left == right);
   }
 #endif


### PR DESCRIPTION
Fixes #326

Additionally, some device code cannot use `std::array` so this adds a "non-standard" constructor to `layout_stride` that accepts a raw array to support this use case