### PR TITLE
mdarray: Add CTAD from possibly multidimensional C array

### DIFF
--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -364,6 +364,14 @@ public:
     static_assert( std::is_constructible<extents_type, OtherExtents>::value, "");
   }
 
+#if 0
+  // Corresponds to deduction guide from std::initializer_list<value_type>
+  MDSPAN_INLINE_FUNCTION
+  constexpr mdarray(std::initializer_list<value_type> values)
+    : map_(extents_type{}), ctr_{values}
+  {}
+#endif // 0
+  
   // Corresponds to deduction guide from C array
   MDSPAN_TEMPLATE_REQUIRES(
     class CArray,
@@ -599,6 +607,24 @@ mdarray(CArray& values) -> mdarray<
   layout_right,
   decltype(impl::carray_to_array(values))
 >;
+
+#if 0
+// Adding a deduction guide from initializer_list<T> breaks the above
+// C array deduction guide, because construction from
+// initializer_list<T> catches every possible creation of an mdarray
+// from curly braces.
+//
+// We may not know values.size() at compile time,
+// so we have to use a dynamically allocated container.
+template<class T>
+mdarray(std::initializer_list<T> values) ->
+mdarray<
+  std::remove_cvref_t<T>,
+  dextents<std::size_t, 1>,
+  layout_right,
+  std::vector<std::remove_cvref_t<T>>
+>;
+#endif // 0  
 
 } // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -120,6 +120,13 @@ constexpr auto tail(std::index_sequence<First, Rest...>) {
   return std::index_sequence<Rest...>{};
 }
 
+template<class CArray> requires (
+  std::is_array_v<CArray> &&
+  std::rank_v<CArray> > 1u
+  )
+constexpr auto
+carray_to_array(CArray& values);
+
 template<class CArray, std::size_t ... Indices> requires (
   std::is_array_v<CArray> &&
   std::rank_v<CArray> > 1u
@@ -154,7 +161,7 @@ carray_to_array_impl(CArray& values, std::index_sequence<Indices...> seq)
     return result;
   }
 }
-  
+
 template<class CArray> requires (
   std::is_array_v<CArray> &&
   std::rank_v<CArray> > 1u
@@ -165,7 +172,7 @@ carray_to_array(CArray& values)
   return carray_to_array_impl(values,
     std::make_index_sequence<std::rank_v<CArray>>());
 }
-  
+
 template<class CArray, std::size_t ... Indices> requires (
   std::is_array_v<CArray> &&
   std::rank_v<CArray> >= 1u
@@ -389,7 +396,7 @@ public:
       std::rank_v<CArray> == 1u
     )
   )
-  MDSPAN_INLINE_FUNCTION    
+  MDSPAN_INLINE_FUNCTION
   constexpr mdarray(CArray& values)
     : map_(extents_type{}), ctr_{impl::carray_to_array(values)}
   {}
@@ -402,11 +409,11 @@ public:
       std::rank_v<CArray> > 1u
     )
   )
-  MDSPAN_INLINE_FUNCTION    
+  MDSPAN_INLINE_FUNCTION
   constexpr mdarray(CArray& values)
     : map_(extents_type{}), ctr_{impl::carray_to_array(values)}
   {}
-  
+
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mdarray& operator= (const mdarray&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mdarray& operator= (mdarray&&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
@@ -643,6 +650,6 @@ mdarray(CArray& values) -> mdarray<
   layout_right,
   decltype(impl::carray_to_array(values))
 >;
-  
+
 } // end namespace MDSPAN_IMPL_PROPOSED_NAMESPACE
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,7 @@ if(NOT MDSPAN_ENABLE_CUDA AND NOT MDSPAN_ENABLE_HIP)
 mdspan_add_test(test_mdarray_ctors)
 mdspan_add_test(test_mdarray_to_mdspan)
 endif()
+mdspan_add_test(test_mdarray_carray_ctad)
 
 if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
 if((CMAKE_CXX_COMPILER_ID STREQUAL Clang) OR ((CMAKE_CXX_COMPILER_ID STREQUAL GNU) AND (CMAKE_CXX_COMPILER_VERSION GREATER_EQUAL 12.0.0)))

--- a/tests/test_mdarray_carray_ctad.cpp
+++ b/tests/test_mdarray_carray_ctad.cpp
@@ -199,3 +199,39 @@ TEST(TestMdarrayCtorDataCArray, test_mdarray_carray_ctad) {
   __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank2<float, 3, 4>()))
   __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank3<float, 3, 4, 5>()))
 }
+
+#if 0
+TEST(TestMdarrayCtorInitializerList, Rank1) {
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::dextents;  
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::extents;
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
+
+  auto error_buffer = allocate_error_buffer();
+  {
+    std::size_t* errors = error_buffer.get();
+    errors[0] = 0;
+    dispatch([errors] _MDSPAN_HOST_DEVICE () {
+      KokkosEx::mdarray m{{1.0f, 2.0f, 3.0f}};
+      static_assert(std::is_same_v<typename decltype(m)::extents_type,
+                    dextents<std::size_t, 1>>);
+      static_assert(std::is_same_v<typename decltype(m)::layout_type,
+                    layout_right>);
+      static_assert(std::is_same_v<typename decltype(m)::container_type,
+                    std::vector<float>>);
+
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 1);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 1);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), 3);
+
+      for (std::size_t k = 0; k < 3; ++k) {
+#if defined(MDSPAN_USE_BRACKET_OPERATOR) && (MDSPAN_USE_BRACKET_OPERATOR != 0)
+        __MDSPAN_DEVICE_ASSERT_EQ(m[k], (static_cast<float>(k) + 1.0f));
+#else
+        __MDSPAN_DEVICE_ASSERT_EQ(m(k), (static_cast<float>(k) + 1.0f));        
+#endif
+      }
+    });
+    ASSERT_EQ(errors[0], 0);
+  }
+}
+#endif // 0

--- a/tests/test_mdarray_carray_ctad.cpp
+++ b/tests/test_mdarray_carray_ctad.cpp
@@ -24,12 +24,24 @@ namespace KokkosEx = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESP
 _MDSPAN_INLINE_VARIABLE constexpr auto dyn = MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent;
 
 
-template<class ValueType, size_t Extent>
+template<class ValueType, std::size_t Extent>
 _MDSPAN_HOST_DEVICE
 void fill_values(ValueType values[Extent])
 {
   for (std::size_t k = 0; k < Extent; ++k) {
     values[k] = static_cast<ValueType>(1) + static_cast<ValueType>(k);
+  }
+}
+
+template<class ValueType, std::size_t Extent0, std::size_t Extent1>
+_MDSPAN_HOST_DEVICE
+void fill_values(ValueType values[Extent0][Extent1])
+{
+  std::size_t k = 0;
+  for (std::size_t r = 0; r < Extent0; ++r) {
+    for (std::size_t c = 0; c < Extent1; ++c, ++k) {
+      values[r][c] = static_cast<ValueType>(1) + static_cast<ValueType>(k);
+    }
   }
 }
 
@@ -45,6 +57,7 @@ std::unique_ptr<std::size_t, ErrorBufferDeleter> allocate_error_buffer() {
 
 template<class ValueType, size_t Extent>
 void test_mdarray_ctad_carray_rank1() {
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::extents;
   using MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
 
   auto error_buffer = allocate_error_buffer();
@@ -54,8 +67,10 @@ void test_mdarray_ctad_carray_rank1() {
     dispatch([errors] _MDSPAN_HOST_DEVICE () {
       ValueType values[Extent];
       fill_values<ValueType, Extent>(values);
-    
+
       KokkosEx::mdarray m{values};
+      static_assert(std::is_same_v<typename decltype(m)::extents_type,
+                    extents<std::size_t, Extent>>);
       static_assert(std::is_same_v<typename decltype(m)::layout_type,
                     layout_right>);
       static_assert(std::is_same_v<typename decltype(m)::container_type,
@@ -65,6 +80,56 @@ void test_mdarray_ctad_carray_rank1() {
       __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
       __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), Extent);
       __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), Extent);
+
+      for (std::size_t k = 0; k < Extent; ++k) {
+#if defined(MDSPAN_USE_BRACKET_OPERATOR) && (MDSPAN_USE_BRACKET_OPERATOR != 0)
+        __MDSPAN_DEVICE_ASSERT_EQ(m[k], values[k]);
+#else
+        __MDSPAN_DEVICE_ASSERT_EQ(m(k), values[k]);
+#endif
+      }
+    });
+    ASSERT_EQ(errors[0], 0);
+  }
+}
+
+template<class ValueType, size_t Extent0, size_t Extent1>
+void test_mdarray_ctad_carray_rank2() {
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::extents;
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
+
+  auto error_buffer = allocate_error_buffer();
+  {
+    size_t* errors = error_buffer.get();
+    errors[0] = 0;
+    dispatch([errors] _MDSPAN_HOST_DEVICE () {
+      ValueType values[Extent0][Extent1];
+      fill_values<ValueType, Extent0, Extent1>(values);
+
+      KokkosEx::mdarray m{values};
+      static_assert(std::is_same_v<typename decltype(m)::extents_type,
+                    extents<std::size_t, Extent0, Extent1>>);
+      static_assert(std::is_same_v<typename decltype(m)::layout_type,
+                    layout_right>);
+      static_assert(std::is_same_v<typename decltype(m)::container_type,
+                    std::array<ValueType, Extent0 * Extent1>>);
+
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 2);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), Extent0);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.extent(1), Extent1);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), Extent0);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(1), Extent1);
+
+      for (std::size_t r = 0; r < Extent0; ++r) {
+        for (std::size_t c = 0; c < Extent1; ++c) {
+#if defined(MDSPAN_USE_BRACKET_OPERATOR) && (MDSPAN_USE_BRACKET_OPERATOR != 0)
+          __MDSPAN_DEVICE_ASSERT_EQ(m[r, c], values[r][c]);
+#else
+          __MDSPAN_DEVICE_ASSERT_EQ(m(r, c), values[r][c]);
+#endif
+        }
+      }
     });
     ASSERT_EQ(errors[0], 0);
   }
@@ -72,5 +137,5 @@ void test_mdarray_ctad_carray_rank1() {
 
 TEST(TestMdarrayCtorDataCArray, test_mdarray_carray_ctad) {
   __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank1<float, 5>()))
+  __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank2<float, 3, 4>()))
 }
-

--- a/tests/test_mdarray_carray_ctad.cpp
+++ b/tests/test_mdarray_carray_ctad.cpp
@@ -23,7 +23,6 @@ namespace KokkosEx = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESP
 
 _MDSPAN_INLINE_VARIABLE constexpr auto dyn = MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent;
 
-
 template<class ValueType, std::size_t Extent>
 _MDSPAN_HOST_DEVICE
 void fill_values(ValueType values[Extent])
@@ -45,6 +44,20 @@ void fill_values(ValueType values[Extent0][Extent1])
   }
 }
 
+template<class ValueType, std::size_t Extent0, std::size_t Extent1, std::size_t Extent2>
+_MDSPAN_HOST_DEVICE
+void fill_values(ValueType values[Extent0][Extent1][Extent2])
+{
+  std::size_t k = 0;
+  for (std::size_t x = 0; x < Extent0; ++x) {
+    for (std::size_t y = 0; y < Extent1; ++y) {
+      for (std::size_t z = 0; z < Extent2; ++z, ++k) {
+        values[x][y][z] = static_cast<ValueType>(1) + static_cast<ValueType>(k);
+      }
+    }
+  }
+}
+
 struct ErrorBufferDeleter {
   void operator() (std::size_t* ptr) const {
     free_array(ptr);
@@ -55,14 +68,14 @@ std::unique_ptr<std::size_t, ErrorBufferDeleter> allocate_error_buffer() {
   return {allocate_array<std::size_t>(1u), ErrorBufferDeleter{}};
 }
 
-template<class ValueType, size_t Extent>
+template<class ValueType, std::size_t Extent>
 void test_mdarray_ctad_carray_rank1() {
   using MDSPAN_IMPL_STANDARD_NAMESPACE::extents;
   using MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
 
   auto error_buffer = allocate_error_buffer();
   {
-    size_t* errors = error_buffer.get();
+    std::size_t* errors = error_buffer.get();
     errors[0] = 0;
     dispatch([errors] _MDSPAN_HOST_DEVICE () {
       ValueType values[Extent];
@@ -93,14 +106,14 @@ void test_mdarray_ctad_carray_rank1() {
   }
 }
 
-template<class ValueType, size_t Extent0, size_t Extent1>
+template<class ValueType, std::size_t Extent0, std::size_t Extent1>
 void test_mdarray_ctad_carray_rank2() {
   using MDSPAN_IMPL_STANDARD_NAMESPACE::extents;
   using MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
 
   auto error_buffer = allocate_error_buffer();
   {
-    size_t* errors = error_buffer.get();
+    std::size_t* errors = error_buffer.get();
     errors[0] = 0;
     dispatch([errors] _MDSPAN_HOST_DEVICE () {
       ValueType values[Extent0][Extent1];
@@ -135,7 +148,54 @@ void test_mdarray_ctad_carray_rank2() {
   }
 }
 
+template<class ValueType, std::size_t Extent0, std::size_t Extent1, std::size_t Extent2>
+void test_mdarray_ctad_carray_rank3() {
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::extents;
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
+
+  auto error_buffer = allocate_error_buffer();
+  {
+    std::size_t* errors = error_buffer.get();
+    errors[0] = 0;
+    dispatch([errors] _MDSPAN_HOST_DEVICE () {
+      ValueType values[Extent0][Extent1][Extent2];
+      fill_values<ValueType, Extent0, Extent1, Extent2>(values);
+
+      KokkosEx::mdarray m{values};
+      static_assert(std::is_same_v<typename decltype(m)::extents_type,
+                    extents<std::size_t, Extent0, Extent1, Extent2>>);
+      static_assert(std::is_same_v<typename decltype(m)::layout_type,
+                    layout_right>);
+      static_assert(std::is_same_v<typename decltype(m)::container_type,
+                    std::array<ValueType, Extent0 * Extent1 * Extent2>>);
+
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 3);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), Extent0);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.extent(1), Extent1);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.extent(2), Extent2);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), Extent0);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(1), Extent1);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(2), Extent2);
+
+      for (std::size_t x = 0; x < Extent0; ++x) {
+        for (std::size_t y = 0; y < Extent1; ++y) {
+          for (std::size_t z = 0; z < Extent2; ++z) {
+#if defined(MDSPAN_USE_BRACKET_OPERATOR) && (MDSPAN_USE_BRACKET_OPERATOR != 0)
+            __MDSPAN_DEVICE_ASSERT_EQ((m[x, y, z]), values[x][y][z]);
+#else
+            __MDSPAN_DEVICE_ASSERT_EQ((m(x, y, z)), values[x][y][z]);
+#endif
+          }
+        }
+      }
+    });
+    ASSERT_EQ(errors[0], 0);
+  }
+}
+
 TEST(TestMdarrayCtorDataCArray, test_mdarray_carray_ctad) {
   __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank1<float, 5>()))
   __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank2<float, 3, 4>()))
+  __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank3<float, 3, 4, 5>()))
 }

--- a/tests/test_mdarray_carray_ctad.cpp
+++ b/tests/test_mdarray_carray_ctad.cpp
@@ -1,0 +1,76 @@
+//@HEADER
+// ************************************************************************
+//
+//                        Kokkos v. 4.0
+//       Copyright (2022) National Technology & Engineering
+//               Solutions of Sandia, LLC (NTESS).
+//
+// Under the terms of Contract DE-NA0003525 with NTESS,
+// the U.S. Government retains certain rights in this software.
+//
+// Part of Kokkos, under the Apache License v2.0 with LLVM Exceptions.
+// See https://kokkos.org/LICENSE for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//@HEADER
+#include <mdspan/mdarray.hpp>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include "offload_utils.hpp"
+
+namespace KokkosEx = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE;
+
+_MDSPAN_INLINE_VARIABLE constexpr auto dyn = MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent;
+
+
+template<class ValueType, size_t Extent>
+_MDSPAN_HOST_DEVICE
+void fill_values(ValueType values[Extent])
+{
+  for (std::size_t k = 0; k < Extent; ++k) {
+    values[k] = static_cast<ValueType>(1) + static_cast<ValueType>(k);
+  }
+}
+
+struct ErrorBufferDeleter {
+  void operator() (std::size_t* ptr) const {
+    free_array(ptr);
+  }
+};
+
+std::unique_ptr<std::size_t, ErrorBufferDeleter> allocate_error_buffer() {
+  return {allocate_array<std::size_t>(1u), ErrorBufferDeleter{}};
+}
+
+template<class ValueType, size_t Extent>
+void test_mdarray_ctad_carray_rank1() {
+  using MDSPAN_IMPL_STANDARD_NAMESPACE::layout_right;
+
+  auto error_buffer = allocate_error_buffer();
+  {
+    size_t* errors = error_buffer.get();
+    errors[0] = 0;
+    dispatch([errors] _MDSPAN_HOST_DEVICE () {
+      ValueType values[Extent];
+      fill_values<ValueType, Extent>(values);
+    
+      KokkosEx::mdarray m{values};
+      static_assert(std::is_same_v<typename decltype(m)::layout_type,
+                    layout_right>);
+      static_assert(std::is_same_v<typename decltype(m)::container_type,
+                    std::array<ValueType, Extent>>);
+
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 1);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), Extent);
+      __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), Extent);
+    });
+    ASSERT_EQ(errors[0], 0);
+  }
+}
+
+TEST(TestMdarrayCtorDataCArray, test_mdarray_carray_ctad) {
+  __MDSPAN_TESTS_RUN_TEST((test_mdarray_ctad_carray_rank1<float, 5>()))
+}
+


### PR DESCRIPTION
Make mdarray CTAD from a possibly multidimensional C array behave as expected.

Example:

```c++
float values[5][7][11] {};
mdarray m{values};
static_assert(m.rank() == 3);
static_assert(m.static_extent(0) == 5);
static_assert(m.static_extent(1) == 7);
static_assert(m.static_extent(2) == 11);
assert(m.extent(0) == 5);
assert(m.extent(1) == 7);
assert(m.extent(2) == 11);
```

This is just a draft, because it uses `requires` instead of `MDSPAN_FUNCTION_REQUIRES`.  The latter doesn't seem to work like it used to.  I really just want to show that this is possible.