### PR TITLE
Remove global namespace prefix for "stderr" in violation handler. 

### DIFF
--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -124,7 +124,7 @@ MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* c
 #else
 MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
 {
-  std::fprintf(::stderr, "%s:%u: precondition failure: `%s`\n", file, line, cond);
+  std::fprintf(stderr, "%s:%u: precondition failure: `%s`\n", file, line, cond);
   std::abort();
 }
 #endif


### PR DESCRIPTION
Fixes #334 