### PR TITLE
Adds submdspan_mapping for padded layouts

### DIFF
--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -182,6 +182,21 @@ struct deduce_layout_left_submapping<
   }
 };
 
+// We are reusing the same thing for layout_left and layout_left_padded
+// For layout_left as source StaticStride is static_extent(0)
+template<class Extents, size_t NumGaps, size_t StaticStride>
+struct Compute_S_static_layout_left {
+  // Neither StaticStride nor any of the looked for extents can zero.
+  // StaticStride never can be zero, the static_extents we are looking at are associated with 
+  // integral slice specifiers - which wouldn't be valid for zero extent
+  template<size_t ... Idx>
+  MDSPAN_INLINE_FUNCTION
+  static constexpr size_t value(std::index_sequence<Idx...>) {
+    size_t val = ((Idx>0 && Idx<=NumGaps ? (Extents::static_extent(Idx) == dynamic_extent?0:Extents::static_extent(Idx)) : 1) * ... * (StaticStride == dynamic_extent?0:StaticStride));
+    return val == 0?dynamic_extent:val;
+  }
+};
+
 } // namespace detail
 
 // Actual submdspan mapping call
@@ -202,14 +217,6 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
       std::make_index_sequence<src_ext_t::rank()>,
       SliceSpecifiers...>;
 
-  using dst_layout_t = std::conditional_t<
-      deduce_layout::layout_left_value(), layout_left,
-      std::conditional_t<
-          deduce_layout::layout_left_padded_value(),
-          MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<dynamic_extent>,
-          layout_stride>>;
-  using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
-
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
@@ -218,17 +225,19 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
       out_of_bounds ? this->required_span_size()
                     : this->operator()(detail::first_of(slices)...));
 
-  if constexpr (std::is_same_v<dst_layout_t, layout_left>) {
+  if constexpr (deduce_layout::layout_left_value()) {
     // layout_left case
+    using dst_mapping_t = typename layout_left::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext),
                                                    offset};
-  } else if constexpr (std::is_same_v<dst_layout_t,
-                                      MDSPAN_IMPL_PROPOSED_NAMESPACE::
-                                          layout_left_padded<dynamic_extent>>) {
+  } else if constexpr (deduce_layout::layout_left_padded_value()) {
+    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(0)>::value(std::make_index_sequence<Extents::rank()>());
+    using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<S_static>::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext, stride(1 + deduce_layout::gap_len)), offset};
   } else {
     // layout_stride case
+    using dst_mapping_t = typename layout_stride::mapping<dst_ext_t>;
     auto inv_map = detail::inv_map_rank(std::integral_constant<size_t, 0>(),
                                         std::index_sequence<>(), slices...);
     return submdspan_mapping_result<dst_mapping_t> {
@@ -248,6 +257,78 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
           offset
     };
   }
+#if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
+  __builtin_unreachable();
+#endif
+}
+
+// Actual submdspan mapping call
+template <size_t PaddingValue>
+template <class Extents>
+template <class... SliceSpecifiers>
+MDSPAN_INLINE_FUNCTION constexpr auto
+MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<PaddingValue>::mapping<Extents>::submdspan_mapping_impl(
+    SliceSpecifiers... slices) const {
+
+  // compute sub extents
+  using src_ext_t = Extents;
+  auto dst_ext = submdspan_extents(extents(), slices...);
+  using dst_ext_t = decltype(dst_ext);
+
+  if constexpr (Extents::rank() == 0) { // rank-0 case
+    using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<PaddingValue>::template mapping<Extents>;
+    return submdspan_mapping_result<dst_mapping_t>{*this, 0};
+  } else {
+    const bool out_of_bounds =
+        MDSPAN_IMPL_STANDARD_NAMESPACE::detail::any_slice_out_of_bounds(this->extents(), slices...);
+    auto offset = static_cast<size_t>(
+        out_of_bounds ? this->required_span_size()
+                    : this->operator()(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::first_of(slices)...));
+    if constexpr (dst_ext_t::rank() == 0) { // result rank-0
+      using dst_mapping_t = typename layout_left::template mapping<dst_ext_t>;
+      return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
+    } else { // general case
+      // Figure out if any slice's lower bound equals the corresponding extent.
+      // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+      // figure out sub layout type
+      using deduce_layout = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::deduce_layout_left_submapping<
+        typename dst_ext_t::index_type, dst_ext_t::rank(),
+        decltype(std::make_index_sequence<src_ext_t::rank()>()),
+        SliceSpecifiers...>;
+
+      if constexpr (deduce_layout::layout_left_value() && dst_ext_t::rank() == 1) { // getting rank-1 from leftmost
+        using dst_mapping_t = typename layout_left::template mapping<dst_ext_t>;
+        return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
+      } else if constexpr (deduce_layout::layout_left_padded_value()) { // can keep layout_left_padded
+        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_left<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
+        using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<S_static>::template mapping<dst_ext_t>;
+        return submdspan_mapping_result<dst_mapping_t>{
+        dst_mapping_t(dst_ext, stride(1 + deduce_layout::gap_len)), offset};
+      } else { // layout_stride
+    auto inv_map = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::inv_map_rank(std::integral_constant<size_t, 0>(),
+                                        std::index_sequence<>(), slices...);
+      using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
+    return submdspan_mapping_result<dst_mapping_t> {
+      dst_mapping_t(dst_ext,
+                    MDSPAN_IMPL_STANDARD_NAMESPACE::detail::construct_sub_strides(
+                        *this, inv_map,
+// HIP needs deduction guides to have markups so we need to be explicit
+// NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
+// the issue But Clang-CUDA also doesn't accept the use of deduction guide so
+// disable it for CUDA alltogether
+#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
+                        std::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
+                            MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...})),
+#else
+                        std::tuple{MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...})),
+#endif
+          offset
+    };
+      }
+    }
+  }
+
+
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
 #endif

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -185,9 +185,9 @@ struct deduce_layout_left_submapping<
 // We are reusing the same thing for layout_left and layout_left_padded
 // For layout_left as source StaticStride is static_extent(0)
 template<class Extents, size_t NumGaps, size_t StaticStride>
-struct Compute_S_static_layout_left {
-  // Neither StaticStride nor any of the looked for extents can zero.
-  // StaticStride never can be zero, the static_extents we are looking at are associated with 
+struct compute_s_static_layout_left {
+  // Neither StaticStride nor any of the provided extents can be zero.
+  // StaticStride can never be zero, the static_extents we are looking at are associated with
   // integral slice specifiers - which wouldn't be valid for zero extent
   template<size_t ... Idx>
   MDSPAN_INLINE_FUNCTION
@@ -231,7 +231,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
     return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext),
                                                    offset};
   } else if constexpr (deduce_layout::layout_left_padded_value()) {
-    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(0)>::value(std::make_index_sequence<Extents::rank()>());
+    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(0)>::value(std::make_index_sequence<Extents::rank()>());
     using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<S_static>::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext, stride(1 + deduce_layout::gap_len)), offset};
@@ -299,7 +299,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<PaddingValue>::mapping<Extent
         using dst_mapping_t = typename layout_left::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
       } else if constexpr (deduce_layout::layout_left_padded_value()) { // can keep layout_left_padded
-        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_left<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
+        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
         using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<S_static>::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext, stride(1 + deduce_layout::gap_len)), offset};
@@ -405,9 +405,9 @@ struct deduce_layout_right_submapping<
 // We are reusing the same thing for layout_right and layout_right_padded
 // For layout_right as source StaticStride is static_extent(Rank-1)
 template<class Extents, size_t NumGaps, size_t StaticStride>
-struct Compute_S_static_layout_right {
-  // Neither StaticStride nor any of the looked for extents can zero.
-  // StaticStride never can be zero, the static_extents we are looking at are associated with
+struct compute_s_static_layout_right {
+  // Neither StaticStride nor any of the provided extents can be zero.
+  // StaticStride can never be zero, the static_extents we are looking at are associated with
   // integral slice specifiers - which wouldn't be valid for zero extent
   template<size_t ... Idx>
   MDSPAN_INLINE_FUNCTION
@@ -451,7 +451,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
     return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext),
                                                    offset};
   } else if constexpr (deduce_layout::layout_right_padded_value()) {
-    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(Extents::rank() - 1)>::value(std::make_index_sequence<Extents::rank()>());
+    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(Extents::rank() - 1)>::value(std::make_index_sequence<Extents::rank()>());
     using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<S_static>::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext,
@@ -521,7 +521,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<PaddingValue>::mapping<Exten
         using dst_mapping_t = typename layout_right::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
       } else if constexpr (deduce_layout::layout_right_padded_value()) { // can keep layout_right_padded
-        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_right<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
+        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_right<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
         using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<S_static>::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext, stride(Extents::rank() - 2 - deduce_layout::gap_len)), offset};

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -262,7 +262,6 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
 #endif
 }
 
-// Actual submdspan mapping call
 template <size_t PaddingValue>
 template <class Extents>
 template <class... SliceSpecifiers>
@@ -403,6 +402,21 @@ struct deduce_layout_right_submapping<
   }
 };
 
+// We are reusing the same thing for layout_right and layout_right_padded
+// For layout_right as source StaticStride is static_extent(Rank-1)
+template<class Extents, size_t NumGaps, size_t StaticStride>
+struct Compute_S_static_layout_right {
+  // Neither StaticStride nor any of the looked for extents can zero.
+  // StaticStride never can be zero, the static_extents we are looking at are associated with
+  // integral slice specifiers - which wouldn't be valid for zero extent
+  template<size_t ... Idx>
+  MDSPAN_INLINE_FUNCTION
+  static constexpr size_t value(std::index_sequence<Idx...>) {
+    size_t val = ((Idx >= Extents::rank() - 1 - NumGaps && Idx < Extents::rank() - 1 ? (Extents::static_extent(Idx) == dynamic_extent?0:Extents::static_extent(Idx)) : 1) * ... * (StaticStride == dynamic_extent?0:StaticStride));
+    return val == 0?dynamic_extent:val;
+  }
+};
+
 } // namespace detail
 
 // Actual submdspan mapping call
@@ -423,14 +437,6 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
       std::make_index_sequence<src_ext_t::rank()>,
       SliceSpecifiers...>;
 
-  using dst_layout_t = std::conditional_t<
-      deduce_layout::layout_right_value(), layout_right,
-      std::conditional_t<
-          deduce_layout::layout_right_padded_value(),
-          MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<dynamic_extent>,
-          layout_stride>>;
-  using dst_mapping_t = typename dst_layout_t::template mapping<dst_ext_t>;
-
   // Figure out if any slice's lower bound equals the corresponding extent.
   // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
   const bool out_of_bounds =
@@ -439,20 +445,21 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
       out_of_bounds ? this->required_span_size()
                     : this->operator()(detail::first_of(slices)...));
 
-  if constexpr (std::is_same_v<dst_layout_t, layout_right>) {
+  if constexpr (deduce_layout::layout_right_value()) {
     // layout_right case
+    using dst_mapping_t = typename layout_right::mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext),
                                                    offset};
-  } else if constexpr (std::is_same_v<
-                           dst_layout_t,
-                           MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<
-                               dynamic_extent>>) {
+  } else if constexpr (deduce_layout::layout_right_padded_value()) {
+    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(Extents::rank() - 1)>::value(std::make_index_sequence<Extents::rank()>());
+    using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<S_static>::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext,
                       stride(src_ext_t::rank() - 2 - deduce_layout::gap_len)),
         offset};
   } else {
     // layout_stride case
+    using dst_mapping_t = typename layout_stride::mapping<dst_ext_t>;
     auto inv_map = detail::inv_map_rank(std::integral_constant<size_t, 0>(),
                                         std::index_sequence<>(), slices...);
     return submdspan_mapping_result<dst_mapping_t> {
@@ -472,6 +479,77 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
           offset
     };
   }
+#if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
+  __builtin_unreachable();
+#endif
+}
+
+template <size_t PaddingValue>
+template <class Extents>
+template <class... SliceSpecifiers>
+MDSPAN_INLINE_FUNCTION constexpr auto
+MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<PaddingValue>::mapping<Extents>::submdspan_mapping_impl(
+    SliceSpecifiers... slices) const {
+
+  // compute sub extents
+  using src_ext_t = Extents;
+  auto dst_ext = submdspan_extents(extents(), slices...);
+  using dst_ext_t = decltype(dst_ext);
+
+  if constexpr (Extents::rank() == 0) { // rank-0 case
+    using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<PaddingValue>::template mapping<Extents>;
+    return submdspan_mapping_result<dst_mapping_t>{*this, 0};
+  } else {
+    // Figure out if any slice's lower bound equals the corresponding extent.
+    // If so, bypass evaluating the layout mapping.  This fixes LWG Issue 4060.
+    // figure out sub layout type
+    const bool out_of_bounds =
+        MDSPAN_IMPL_STANDARD_NAMESPACE::detail::any_slice_out_of_bounds(this->extents(), slices...);
+    auto offset = static_cast<size_t>(
+        out_of_bounds ? this->required_span_size()
+                    : this->operator()(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::first_of(slices)...));
+    if constexpr (dst_ext_t::rank() == 0) { // result rank-0
+      using dst_mapping_t = typename layout_right::template mapping<dst_ext_t>;
+      return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
+    } else { // general case
+      using deduce_layout = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::deduce_layout_right_submapping<
+        typename dst_ext_t::index_type, dst_ext_t::rank(),
+        decltype(std::make_index_sequence<src_ext_t::rank()>()),
+        SliceSpecifiers...>;
+
+      if constexpr (deduce_layout::layout_right_value() && dst_ext_t::rank() == 1) { // getting rank-1 from rightmost
+        using dst_mapping_t = typename layout_right::template mapping<dst_ext_t>;
+        return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
+      } else if constexpr (deduce_layout::layout_right_padded_value()) { // can keep layout_right_padded
+        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::Compute_S_static_layout_right<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
+        using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<S_static>::template mapping<dst_ext_t>;
+        return submdspan_mapping_result<dst_mapping_t>{
+        dst_mapping_t(dst_ext, stride(Extents::rank() - 2 - deduce_layout::gap_len)), offset};
+      } else { // layout_stride
+    auto inv_map = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::inv_map_rank(std::integral_constant<size_t, 0>(),
+                                        std::index_sequence<>(), slices...);
+      using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
+    return submdspan_mapping_result<dst_mapping_t> {
+      dst_mapping_t(dst_ext,
+                    MDSPAN_IMPL_STANDARD_NAMESPACE::detail::construct_sub_strides(
+                        *this, inv_map,
+// HIP needs deduction guides to have markups so we need to be explicit
+// NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
+// the issue But Clang-CUDA also doesn't accept the use of deduction guide so
+// disable it for CUDA alltogether
+#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
+                        std::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
+                            MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...})),
+#else
+                        std::tuple{MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...})),
+#endif
+          offset
+    };
+      }
+    }
+  }
+
+
 #if defined(__NVCC__) && !defined(__CUDA_ARCH__) && defined(__GNUC__)
   __builtin_unreachable();
 #endif

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -221,7 +221,7 @@ public:
 #endif
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping(const mapping&) noexcept = default;
-  MDSPAN_INLINE_FUNCTION_DEFAULTED mapping& operator=(const mapping&) noexcept = default;
+  MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping& operator=(const mapping&) noexcept = default;
 
   /**
    * Initializes the mapping with the given extents.
@@ -584,7 +584,7 @@ public:
 #endif
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping(const mapping&) noexcept = default;
-  MDSPAN_INLINE_FUNCTION_DEFAULTED mapping& operator=(const mapping&) noexcept = default;
+  MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping& operator=(const mapping&) noexcept = default;
 
   /**
    * Initializes the mapping with the given extents.

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -849,6 +849,19 @@ public:
     return !(left == right);
   }
 #endif
+
+   // [mdspan.submdspan.mapping], submdspan mapping specialization
+   template<class... SliceSpecifiers>
+   MDSPAN_INLINE_FUNCTION
+     constexpr auto submdspan_mapping_impl(
+       SliceSpecifiers... slices) const;
+
+   template<class... SliceSpecifiers>
+   MDSPAN_INLINE_FUNCTION
+     friend constexpr auto submdspan_mapping(
+       const mapping& src, SliceSpecifiers... slices) {
+         return src.submdspan_mapping_impl(slices...);
+     }
 };
 }
 }

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -497,10 +497,12 @@ public:
 
    // [mdspan.submdspan.mapping], submdspan mapping specialization
    template<class... SliceSpecifiers>
+   MDSPAN_INLINE_FUNCTION
      constexpr auto submdspan_mapping_impl(
        SliceSpecifiers... slices) const;
 
    template<class... SliceSpecifiers>
+   MDSPAN_INLINE_FUNCTION
      friend constexpr auto submdspan_mapping(
        const mapping& src, SliceSpecifiers... slices) {
          return src.submdspan_mapping_impl(slices...);

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -341,10 +341,10 @@ struct TestSubMDSpan<
   }
 
   static void run() {
-    typename mds_org_t::mapping_type map(typename mds_org_t::extents_type(ConstrArgs...));
-    int data[25000];
-    mds_org_t src(data, map);
     size_t* result = allocate_array<size_t>(1);
+    int* data = allocate_array<int>(25000);
+    map_t map{ typename mds_org_t::extents_type(ConstrArgs...) };
+    mds_org_t src(data, map);
 
     dispatch([=] _MDSPAN_HOST_DEVICE () {
       auto sub = Kokkos::submdspan(src, create_slice_arg(SubArgs())...);
@@ -352,6 +352,7 @@ struct TestSubMDSpan<
       result[0] = match?1:0;
     });
     EXPECT_EQ(result[0], 1);
+    free_array(data);
     free_array(result);
   }
 

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -166,6 +166,7 @@ using submdspan_test_types =
     , std::tuple<Kokkos::layout_left, Kokkos::layout_stride,  Kokkos::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,4,dyn,7>, int, Kokkos::full_extent_t, std::pair<int,int>, int, Kokkos::full_extent_t, int>
     // layout_right to layout_right_padded
     , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,2>,       args_t<10,20>,          Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, std::pair<int,int>>
+    , std::tuple<Kokkos::layout_right, layout_right_padded<20>,  Kokkos::extents<size_t,dyn,20>,   args_t<10,20>,          Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, std::pair<int,int>>
     , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,3>,       args_t<10,20,30>,       Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, std::pair<int,int>>
     , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,4>,       args_t<10,20,30,40>,    Kokkos::dextents<size_t,3>, std::pair<int,int>, Kokkos::full_extent_t, int, std::pair<int,int>>
     , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,5>,       args_t<10,20,30,40,50>, Kokkos::dextents<size_t,3>, int, std::pair<int,int>, Kokkos::full_extent_t, int, std::pair<int,int>>
@@ -206,6 +207,34 @@ using submdspan_test_types =
     , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, Kokkos::strided_slice<int,int,int>, Kokkos::full_extent_t>
     , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, Kokkos::strided_slice<int,int,int>>
     , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,4>, args_t<10,20,30,40>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, Kokkos::full_extent_t, int, Kokkos::full_extent_t>
+    // layout_right_padded to layout_right
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_right, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,0>, int, int>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_right, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,1>, int, std::pair<int,int>>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_right, Kokkos::extents<size_t,dyn,30>, args_t<10,20>, Kokkos::extents<size_t,30>, int, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<4>, Kokkos::layout_right, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,1>, int, int, std::pair<int,int>>
+    , std::tuple<layout_right_padded<4>, Kokkos::layout_right, Kokkos::extents<size_t,dyn,dyn,30>, args_t<10,20,30>, Kokkos::extents<size_t,30>, int, int, Kokkos::full_extent_t>
+    // layout_right_padded to layout_right_padded
+    , std::tuple<layout_right_padded<dyn>, layout_right_padded<dyn>, Kokkos::dextents<size_t,0>,        args_t<>, Kokkos::dextents<size_t,0>>
+    , std::tuple<layout_right_padded<4>,   layout_right_padded<4>,   Kokkos::dextents<size_t,0>,        args_t<>, Kokkos::dextents<size_t,0>>
+    , std::tuple<layout_right_padded<dyn>, layout_right_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<4>,   layout_right_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, std::pair<int, int>, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<4>,   layout_right_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, std::pair<int, int>>
+    , std::tuple<layout_right_padded<dyn>, layout_right_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, std::pair<int, int>, std::pair<int, int>>
+    , std::tuple<layout_right_padded<22>,  layout_right_padded<22>,  Kokkos::extents<size_t,10,20>,     args_t<10,20>, Kokkos::extents<size_t, 10, dyn>, Kokkos::full_extent_t, std::pair<int, int>>
+    , std::tuple<layout_right_padded<dyn>, layout_right_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<4>,   layout_right_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, std::pair<int, int>, int, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<4>,   layout_right_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, std::pair<int, int>>
+    , std::tuple<layout_right_padded<dyn>, layout_right_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, std::pair<int, int>, int, std::pair<int, int>>
+    , std::tuple<layout_right_padded<32>,  layout_right_padded<640>, Kokkos::extents<size_t,dyn,20,30>, args_t<10,20,30>, Kokkos::extents<size_t, dyn, dyn>, Kokkos::full_extent_t, int, std::pair<int, int>>
+    , std::tuple<layout_right_padded<dyn>, layout_right_padded<dyn>, Kokkos::dextents<size_t,4>,        args_t<10,20,30,40>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, Kokkos::full_extent_t, int, Kokkos::full_extent_t>
+    // layout_right_padded to layout_stride
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,1>, args_t<10>, Kokkos::dextents<size_t,1>, Kokkos::strided_slice<int,int,int>>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,1>, int, Kokkos::strided_slice<int,int,int>>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::strided_slice<int,int,int>, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, Kokkos::strided_slice<int,int,int>>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, Kokkos::strided_slice<int,int,int>, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::strided_slice<int,int,int>, int, Kokkos::full_extent_t>
+    , std::tuple<layout_right_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,4>, args_t<10,20,30,40>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, int, Kokkos::full_extent_t, Kokkos::full_extent_t>
     // Testing of customization point design
     , std::tuple<Foo::layout_foo, Foo::layout_foo, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, Kokkos::full_extent_t>
     , std::tuple<Foo::layout_foo, Foo::layout_foo, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, std::pair<int,int>>

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -102,9 +102,14 @@ TEST(TestSubmdspanLayoutRightStaticSizedTuples, test_submdspan_layout_right_stat
 template<size_t ... Args>
 using args_t = std::index_sequence<Args...>;
 
+template<size_t PaddingValue>
+using layout_left_padded = Kokkos::Experimental::layout_left_padded<PaddingValue>;
+template<size_t PaddingValue>
+using layout_right_padded = Kokkos::Experimental::layout_right_padded<PaddingValue>;
+
 using submdspan_test_types =
   ::testing::Types<
-      // LayoutLeft to LayoutLeft
+      // layout_left to layout_left
       std::tuple<Kokkos::layout_left, Kokkos::layout_left, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_left, Kokkos::layout_left, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, std::pair<int,int>>
     , std::tuple<Kokkos::layout_left, Kokkos::layout_left, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,0>, int>
@@ -119,7 +124,7 @@ using submdspan_test_types =
     , std::tuple<Kokkos::layout_left, Kokkos::layout_left, Kokkos::dextents<size_t,6>, args_t<6,4,5,6,7,8>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, std::pair<int,int>, int, int, int, int>
     , std::tuple<Kokkos::layout_left, Kokkos::layout_left, Kokkos::dextents<size_t,6>, args_t<6,4,5,6,7,8>, Kokkos::dextents<size_t,1>, Kokkos::full_extent_t, int, int, int ,int, int>
     , std::tuple<Kokkos::layout_left, Kokkos::layout_left, Kokkos::dextents<size_t,6>, args_t<6,4,5,6,7,8>, Kokkos::dextents<size_t,1>, std::pair<int,int>, int, int, int, int, int>
-    // LayoutRight to LayoutRight
+    // layout_right to layout_right
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, std::pair<int,int>>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,0>, int>
@@ -132,7 +137,7 @@ using submdspan_test_types =
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::dextents<size_t,6>, args_t<6,4,5,6,7,8>, Kokkos::dextents<size_t,3>, int, int, int, std::pair<int,int>, Kokkos::full_extent_t, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::dextents<size_t,6>, args_t<6,4,5,6,7,8>, Kokkos::dextents<size_t,2>, int, int, int, int, std::pair<int,int>, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::dextents<size_t,6>, args_t<6,4,5,6,7,8>, Kokkos::dextents<size_t,1>, int, int, int, int, int, Kokkos::full_extent_t>
-    // LayoutRight to LayoutRight Check Extents Preservation
+    // layout_right to layout_right Check Extents Preservation
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::extents<size_t,10>,           args_t<10>,          Kokkos::extents<size_t,10>, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::extents<size_t,10>,           args_t<10>,          Kokkos::extents<size_t,dyn>, std::pair<int,int>>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::extents<size_t,10>,           args_t<10>,          Kokkos::extents<size_t>, int>
@@ -145,12 +150,13 @@ using submdspan_test_types =
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,dyn,7,8>, int, int, int, std::pair<int,int>, Kokkos::full_extent_t, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,dyn,8>, int, int, int, int, std::pair<int,int>, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_right, Kokkos::extents<size_t,6,4,5,6,7,8>,  args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,8>, int, int, int, int, int, Kokkos::full_extent_t>
-    // LayoutLeft to layout_left_padded
-    , std::tuple<Kokkos::layout_left, Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>,  Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,2>, std::pair<int,int>, Kokkos::full_extent_t>
-    , std::tuple<Kokkos::layout_left, Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>,  Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,2>, std::pair<int,int>, int, Kokkos::full_extent_t>
-    , std::tuple<Kokkos::layout_left, Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>,  Kokkos::dextents<size_t,4>, args_t<10,20,30,40>, Kokkos::dextents<size_t,3>, std::pair<int,int>, int, Kokkos::full_extent_t, std::pair<int,int>>
-    , std::tuple<Kokkos::layout_left, Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>,  Kokkos::dextents<size_t,5>, args_t<10,20,30,40,50>, Kokkos::dextents<size_t,3>, std::pair<int,int>, int, Kokkos::full_extent_t, std::pair<int,int>, int>
-    // LayoutLeft to LayoutStride
+    // layout_left to layout_left_padded
+    , std::tuple<Kokkos::layout_left, layout_left_padded<dyn>, Kokkos::dextents<size_t,2>, args_t<10,20>,          Kokkos::dextents<size_t,2>, std::pair<int,int>, Kokkos::full_extent_t>
+    , std::tuple<Kokkos::layout_left, layout_left_padded<10>,  Kokkos::extents<size_t,10,dyn>, args_t<10,20>,      Kokkos::dextents<size_t,2>, std::pair<int,int>, Kokkos::full_extent_t>
+    , std::tuple<Kokkos::layout_left, layout_left_padded<dyn>, Kokkos::dextents<size_t,3>, args_t<10,20,30>,       Kokkos::dextents<size_t,2>, std::pair<int,int>, int, Kokkos::full_extent_t>
+    , std::tuple<Kokkos::layout_left, layout_left_padded<dyn>, Kokkos::dextents<size_t,4>, args_t<10,20,30,40>,    Kokkos::dextents<size_t,3>, std::pair<int,int>, int, Kokkos::full_extent_t, std::pair<int,int>>
+    , std::tuple<Kokkos::layout_left, layout_left_padded<dyn>, Kokkos::dextents<size_t,5>, args_t<10,20,30,40,50>, Kokkos::dextents<size_t,3>, std::pair<int,int>, int, Kokkos::full_extent_t, std::pair<int,int>, int>
+    // layout_left to layout_stride
     , std::tuple<Kokkos::layout_left, Kokkos::layout_stride,  Kokkos::dextents<size_t,1>,          args_t<10>,          Kokkos::dextents<size_t,1>, Kokkos::strided_slice<int,int,int>>
     , std::tuple<Kokkos::layout_left, Kokkos::layout_stride,  Kokkos::dextents<size_t,2>,          args_t<10,20>,       Kokkos::dextents<size_t,1>, Kokkos::strided_slice<int,int,int>, int>
     , std::tuple<Kokkos::layout_left, Kokkos::layout_stride,  Kokkos::dextents<size_t,2>,          args_t<10,20>,       Kokkos::dextents<size_t,2>, std::pair<int,int>, Kokkos::strided_slice<int,int,int>>
@@ -159,10 +165,10 @@ using submdspan_test_types =
     , std::tuple<Kokkos::layout_left, Kokkos::layout_stride,  Kokkos::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,6,dyn,8>, Kokkos::full_extent_t, int, std::pair<int,int>, int, int, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_left, Kokkos::layout_stride,  Kokkos::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,4,dyn,7>, int, Kokkos::full_extent_t, std::pair<int,int>, int, Kokkos::full_extent_t, int>
     // layout_right to layout_right_padded
-    , std::tuple<Kokkos::layout_right, Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent>, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, std::pair<int,int>>
-    , std::tuple<Kokkos::layout_right, Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent>, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, std::pair<int,int>>
-    , std::tuple<Kokkos::layout_right, Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent>, Kokkos::dextents<size_t,4>, args_t<10,20,30,40>, Kokkos::dextents<size_t,3>, std::pair<int,int>, Kokkos::full_extent_t, int, std::pair<int,int>>
-    , std::tuple<Kokkos::layout_right, Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent>, Kokkos::dextents<size_t,5>, args_t<10,20,30,40,50>, Kokkos::dextents<size_t,3>, int, std::pair<int,int>, Kokkos::full_extent_t, int, std::pair<int,int>>
+    , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,2>,       args_t<10,20>,          Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, std::pair<int,int>>
+    , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,3>,       args_t<10,20,30>,       Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, std::pair<int,int>>
+    , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,4>,       args_t<10,20,30,40>,    Kokkos::dextents<size_t,3>, std::pair<int,int>, Kokkos::full_extent_t, int, std::pair<int,int>>
+    , std::tuple<Kokkos::layout_right, layout_right_padded<dyn>, Kokkos::dextents<size_t,5>,       args_t<10,20,30,40,50>, Kokkos::dextents<size_t,3>, int, std::pair<int,int>, Kokkos::full_extent_t, int, std::pair<int,int>>
     // layout_right to layout_stride
     , std::tuple<Kokkos::layout_right, Kokkos::layout_stride, Kokkos::dextents<size_t,1>,          args_t<10>,          Kokkos::dextents<size_t,1>, Kokkos::strided_slice<int,int,int>>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_stride, Kokkos::dextents<size_t,1>,          args_t<10>,          Kokkos::extents<size_t,0>,  Kokkos::strided_slice<int,std::integral_constant<int,0>,std::integral_constant<int,0>>>
@@ -172,6 +178,34 @@ using submdspan_test_types =
     , std::tuple<Kokkos::layout_right, Kokkos::layout_stride, Kokkos::dextents<size_t,2>,          args_t<10,20>,       Kokkos::dextents<size_t,2>, Kokkos::strided_slice<int,int,int>, Kokkos::strided_slice<int,int,int>>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_stride, Kokkos::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,6,dyn,8>, Kokkos::full_extent_t, int, std::pair<int,int>, int, int, Kokkos::full_extent_t>
     , std::tuple<Kokkos::layout_right, Kokkos::layout_stride, Kokkos::extents<size_t,6,4,5,6,7,8>, args_t<6,4,5,6,7,8>, Kokkos::extents<size_t,4,dyn,7>, int, Kokkos::full_extent_t, std::pair<int,int>, int, Kokkos::full_extent_t, int>
+    // layout_left_padded to layout_left
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_left, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,0>, int, int>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_left, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,1>, std::pair<int,int>, int>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_left, Kokkos::extents<size_t,10,dyn>, args_t<10,20>, Kokkos::extents<size_t,10>, Kokkos::full_extent_t, int>
+    , std::tuple<layout_left_padded<4>, Kokkos::layout_left, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,1>, std::pair<int,int>, int, int>
+    , std::tuple<layout_left_padded<4>, Kokkos::layout_left, Kokkos::extents<size_t,10,dyn,dyn>, args_t<10,20,30>, Kokkos::extents<size_t,10>, Kokkos::full_extent_t, int, int>
+    // layout_left_padded to layout_left_padded
+    , std::tuple<layout_left_padded<dyn>, layout_left_padded<dyn>, Kokkos::dextents<size_t,0>,        args_t<>, Kokkos::dextents<size_t,0>>
+    , std::tuple<layout_left_padded<4>,   layout_left_padded<4>,   Kokkos::dextents<size_t,0>,        args_t<>, Kokkos::dextents<size_t,0>>
+    , std::tuple<layout_left_padded<dyn>, layout_left_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<4>,   layout_left_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, std::pair<int, int>, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<4>,   layout_left_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, std::pair<int, int>>
+    , std::tuple<layout_left_padded<dyn>, layout_left_padded<dyn>, Kokkos::dextents<size_t,2>,        args_t<10,20>, Kokkos::dextents<size_t,2>, std::pair<int, int>, std::pair<int, int>>
+    , std::tuple<layout_left_padded<12>,  layout_left_padded<12>,  Kokkos::extents<size_t,10,20>,     args_t<10,20>, Kokkos::extents<size_t, dyn, 20>, std::pair<int, int>, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<dyn>, layout_left_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<4>,   layout_left_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, std::pair<int, int>, int, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<4>,   layout_left_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, std::pair<int, int>>
+    , std::tuple<layout_left_padded<dyn>, layout_left_padded<dyn>, Kokkos::dextents<size_t,3>,        args_t<10,20,30>, Kokkos::dextents<size_t,2>, std::pair<int, int>, int, std::pair<int, int>>
+    , std::tuple<layout_left_padded<12>,  layout_left_padded<240>, Kokkos::extents<size_t,10,20,dyn>, args_t<10,20,30>, Kokkos::extents<size_t, dyn, dyn>, std::pair<int, int>, int, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<dyn>, layout_left_padded<dyn>, Kokkos::dextents<size_t,4>,        args_t<10,20,30,40>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, int, Kokkos::full_extent_t, Kokkos::full_extent_t>
+    // layout_left_padded to layout_stride
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,1>, args_t<10>, Kokkos::dextents<size_t,1>, Kokkos::strided_slice<int,int,int>>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,1>, Kokkos::strided_slice<int,int,int>, int>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::strided_slice<int,int,int>, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,2>, args_t<10,20>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, Kokkos::strided_slice<int,int,int>>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, Kokkos::strided_slice<int,int,int>, Kokkos::full_extent_t>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,3>, args_t<10,20,30>, Kokkos::dextents<size_t,2>, Kokkos::full_extent_t, int, Kokkos::strided_slice<int,int,int>>
+    , std::tuple<layout_left_padded<dyn>, Kokkos::layout_stride, Kokkos::dextents<size_t,4>, args_t<10,20,30,40>, Kokkos::dextents<size_t,3>, Kokkos::full_extent_t, Kokkos::full_extent_t, int, Kokkos::full_extent_t>
     // Testing of customization point design
     , std::tuple<Foo::layout_foo, Foo::layout_foo, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, Kokkos::full_extent_t>
     , std::tuple<Foo::layout_foo, Foo::layout_foo, Kokkos::dextents<size_t,1>, args_t<10>,          Kokkos::dextents<size_t,1>, std::pair<int,int>>

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -202,7 +202,7 @@ TEST(TestMdspan, SubmdspanStaticSlice_Left_i345_FullIndexFull) {
 
   {
     using expected_extents_type = Kokkos::extents<int, 3, 5>;
-    using expected_layout_type = Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>;
+    using expected_layout_type = Kokkos::Experimental::layout_left_padded<12>;
     using expected_output_mdspan_type = Kokkos::mdspan<float, expected_extents_type, expected_layout_type>;
 
     auto runTest = [&] (auto integralConstant) {
@@ -424,7 +424,7 @@ TEST(TestMdspan, SubmdspanStaticSlice_Left_i345_TupleFullTuple) {
 
   {
     using expected_extents_type = Kokkos::extents<int, Kokkos::dynamic_extent, 4, Kokkos::dynamic_extent>;
-    using expected_layout_type = Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>;
+    using expected_layout_type = Kokkos::Experimental::layout_left_padded<3>;
     using expected_output_mdspan_type = Kokkos::mdspan<float, expected_extents_type, expected_layout_type>;
 
     auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
@@ -438,7 +438,7 @@ TEST(TestMdspan, SubmdspanStaticSlice_Left_i345_TupleFullTuple) {
   }
   {
     using expected_extents_type = Kokkos::extents<int, 2, 4, 3>;
-    using expected_layout_type = Kokkos::Experimental::layout_left_padded<Kokkos::dynamic_extent>;
+    using expected_layout_type = Kokkos::Experimental::layout_left_padded<3>;
     using expected_output_mdspan_type = Kokkos::mdspan<float, expected_extents_type, expected_layout_type>;
 
     auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {

--- a/tests/test_submdspan_static_slice.cpp
+++ b/tests/test_submdspan_static_slice.cpp
@@ -508,7 +508,7 @@ TEST(TestMdspan, SubmdspanStaticSlice_Right_i345_TupleFullTuple) {
 
   {
     using expected_extents_type = Kokkos::extents<int, Kokkos::dynamic_extent, 4, Kokkos::dynamic_extent>;
-    using expected_layout_type = Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent>;
+    using expected_layout_type = Kokkos::Experimental::layout_right_padded<5>;
     using expected_output_mdspan_type = Kokkos::mdspan<float, expected_extents_type, expected_layout_type>;
 
     auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {
@@ -522,7 +522,7 @@ TEST(TestMdspan, SubmdspanStaticSlice_Right_i345_TupleFullTuple) {
   }
   {
     using expected_extents_type = Kokkos::extents<int, 2, 4, 3>;
-    using expected_layout_type = Kokkos::Experimental::layout_right_padded<Kokkos::dynamic_extent>;
+    using expected_layout_type = Kokkos::Experimental::layout_right_padded<5>;
     using expected_output_mdspan_type = Kokkos::mdspan<float, expected_extents_type, expected_layout_type>;
 
     auto runTest = [&] (auto sliceSpec0, auto sliceSpec1) {


### PR DESCRIPTION
This also fixes up getting the right static padding value, for some cases where submdspan_mapping of layout_left/right generates a layout_left/right_padded.
