### PR TITLE
Replace spelled out logical operators: breaks Kokkos windows tests

### DIFF
--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -644,7 +644,7 @@ template <std::size_t N, class Layout, class Extents, class Mapping>
 constexpr void validate_strides(with_rank<N>, Layout, const Extents& ext, const Mapping& other)
 {
   static_assert(std::is_same<typename Mapping::layout_type, layout_stride>::value &&
-                (std::is_same<Layout, layout_left>::value or
+                (std::is_same<Layout, layout_left>::value ||
                  std::is_same<Layout, layout_right>::value)
                 , "This function is only intended to validate construction of "
                   "a layout_left or layout_right mapping from a layout_stride mapping.");

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -605,7 +605,7 @@ struct layout_stride {
     )
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator!=(const mapping& x, const StridedLayoutMapping& y) noexcept {
-      return not (x == y);
+      return !(x == y);
     }
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -643,7 +643,7 @@ constexpr void validate_strides(with_rank<0>, Layout, const Extents&, const Mapp
 template <std::size_t N, class Layout, class Extents, class Mapping>
 constexpr void validate_strides(with_rank<N>, Layout, const Extents& ext, const Mapping& other)
 {
-  static_assert(std::is_same<typename Mapping::layout_type, layout_stride>::value and
+  static_assert(std::is_same<typename Mapping::layout_type, layout_stride>::value &&
                 (std::is_same<Layout, layout_left>::value or
                  std::is_same<Layout, layout_right>::value)
                 , "This function is only intended to validate construction of "
@@ -657,7 +657,7 @@ constexpr void validate_strides(with_rank<N>, Layout, const Extents& ext, const 
     const std::size_t s = is_left ? r : N - 1 - r;
 
     MDSPAN_IMPL_PRECONDITION(common_integral_compare(expected_stride, other.stride(s))
-                             and "invalid strides for layout_{left,right}");
+                             && "invalid strides for layout_{left,right}");
 
     expected_stride *= ext.extent(s);
   }

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -151,7 +151,7 @@ namespace detail {
 template <bool check = MDSPAN_IMPL_CHECK_PRECONDITION>
 MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, unsigned line)
 {
-  if (not check) { return; }
+  if (!check) { return; }
   // in case the macro doesn't use the arguments for custom macros
   (void) cond;
   (void) file;
@@ -164,7 +164,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 
 #define MDSPAN_IMPL_PRECONDITION(...) \
   do { \
-    if (not (__VA_ARGS__)) { \
+    if (!(__VA_ARGS__)) { \
       MDSPAN_IMPL_STANDARD_NAMESPACE::detail::precondition(#__VA_ARGS__, __FILE__, __LINE__); \
     } \
   } while (0)

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -16,7 +16,7 @@ using with_rank = std::integral_constant<std::size_t, N>;
 template <class I1, class I2>
 constexpr bool common_integral_compare(I1 x, I2 y)
 {
-  static_assert(std::is_integral<I1>::value and
+  static_assert(std::is_integral<I1>::value &&
                 std::is_integral<I2>::value, "");
 
   using I = std::common_type_t<I1, I2>;

--- a/include/experimental/__p2642_bits/layout_padded_fwd.hpp
+++ b/include/experimental/__p2642_bits/layout_padded_fwd.hpp
@@ -102,7 +102,7 @@ constexpr void check_padded_layout_converting_constructor_mandates(MDSPAN_IMPL_S
     (extents_type::static_extent(idx) != dynamic_extent) &&
     (padding_value != dynamic_extent);
 
-  static_assert(not statically_determinable or
+  static_assert(!statically_determinable ||
                 (padding_value == 0
                  ? _LayoutExtentsType::static_extent(idx) == 0
                  : _LayoutExtentsType::static_extent(idx) % padding_value == 0),


### PR DESCRIPTION
Errors such as:
```
D:\a\kokkos\kokkos\tpls\mdspan\include\experimental\__p0009_bits\utility.hpp(19): error : expected a "," [D:\a\kokkos\kokkos\build\core\src\kokkoscore.vcxproj]
      static_assert(std::is_integral<I1>::value and
```