### PR TITLE
CI: Enable warning flags

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/mdspan-build
-      run: CXX=${{ matrix.compiler_prefix}}/${{ matrix.compiler_driver }} cmake $GITHUB_WORKSPACE/mdspan-src -DMDSPAN_CXX_STANDARD=${{ matrix.stdcxx }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/mdspan-install -DMDSPAN_ENABLE_TESTS=ON -DMDSPAN_ENABLE_EXAMPLES=ON -DMDSPAN_ENABLE_BENCHMARKS=${{matrix.enable_benchmark}} -DMDSPAN_ENABLE_COMP_BENCH=ON -DCMAKE_CXX_FLAGS=${{matrix.cxx_flags_extra}}
+      run: CXX=${{ matrix.compiler_prefix}}/${{ matrix.compiler_driver }} cmake $GITHUB_WORKSPACE/mdspan-src -DMDSPAN_CXX_STANDARD=${{ matrix.stdcxx }} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/mdspan-install -DMDSPAN_ENABLE_TESTS=ON -DMDSPAN_ENABLE_EXAMPLES=ON -DMDSPAN_ENABLE_BENCHMARKS=${{matrix.enable_benchmark}} -DMDSPAN_ENABLE_COMP_BENCH=ON -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -pedantic ${{matrix.cxx_flags_extra}}"
 
     - name: Build
       shell: bash

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,7 +3,7 @@ name: CMake
 on: [push, pull_request]
 
 env:
-  BUILD_TYPE: RelWithDebInfo
+  BUILD_TYPE: Debug
 
 jobs:
   build-mdspan:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,13 +20,13 @@ jobs:
           compiler_prefix: /usr/bin
         - compiler_driver: clang++
           compiler_prefix: /usr/bin
-          cxx_flags_extra: "-stdlib=libc++"
+          cxx_flags_extra: "-stdlib=libc++ -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments"
         - compiler_driver: icpx
           compiler_prefix: /opt/intel/oneapi/compiler/latest/linux/bin
           # To get new URL, look here:
           # https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#inpage-nav-6-undefined
           compiler_url: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh
-          cxx_flags_extra: "-DMDSPAN_USE_BRACKET_OPERATOR=0"
+          cxx_flags_extra: "-DMDSPAN_USE_BRACKET_OPERATOR=0 -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments"
         - enable_benchmark: ON
         - stdcxx: 14
           enable_benchmark: OFF

--- a/comp_bench/cbench_submdspan.cpp.erb
+++ b/comp_bench/cbench_submdspan.cpp.erb
@@ -3,11 +3,6 @@
 
 int test(int* data) {
   #if defined(METABENCH)
-  auto sub0 = Kokkos::mdspan<int,
-    Kokkos::extents<size_t,
-      <%= (["2"] * n).join(", ") %>
-    >
-  >(data);
   <% (32/n).times do |k| %>
   auto <%= "sub0_#{k}" %> = Kokkos::mdspan<int,
     Kokkos::extents<size_t,
@@ -23,10 +18,13 @@ int test(int* data) {
   <% end %>
   <% end %>
   return 42
-  <% (16/n).times do |k| %>
+  <% (32/n).times do |k| %>
       <%= " + sub#{n}_#{k}" %>()
   <% end %>
   ;
+  #else
+  (void) data;
+  return 1;
   #endif
 }
 

--- a/examples/aligned_accessor/aligned_accessor.cpp
+++ b/examples/aligned_accessor/aligned_accessor.cpp
@@ -72,13 +72,13 @@ using index_type = int;
 // Some compilers other than Clang or GCC like to define __clang__ or __GNUC__.
 // Thus, we order the tests from most to least specific.
 #if defined(__ICL)
-#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __declspec(align_value( BYTE_ALIGNMENT ));
+#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __declspec(align_value( BYTE_ALIGNMENT ))
   constexpr char align_attribute_method[] = "__declspec(align_value(BYTE_ALIGNMENT))";
 #elif defined(__ICC)
-#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )));
+#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )))
   constexpr char align_attribute_method[] = "__attribute__((align_value(BYTE_ALIGNMENT)))";
 #elif defined(__clang__)
-#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )));
+#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )))
   constexpr char align_attribute_method[] = "__attribute__((align_value(BYTE_ALIGNMENT)))";
 #else
 #  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT )

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -642,7 +642,7 @@ __fold_left_assign_impl(Args&&... args) {
 
 
 template <class... Args>
-constexpr __mdspan_enable_fold_comma __fold_comma_impl(Args&&... args) noexcept { return { }; }
+constexpr __mdspan_enable_fold_comma __fold_comma_impl(Args&&...) noexcept { return { }; }
 
 template <bool... Bs>
 struct __bools;


### PR DESCRIPTION
It turns out that the builds in `cmake.yml` are mostly fine with `-Werror -Wall -Wextra -pedantic`:
- We get a bunch of warnings for unused variables building in `RelWithDebInfo` since that uses `-DNDEBUG` disabling a lot of asserts. Since we want these asserts to trigger, I changed the build type to `Debug`.
- `clang` complains about `-Wc++17-attribute-extensions` when using `[[maybe_unused]]` which seems harmless.
- `clang` complains about using variadic macros with empty ellipsis via `-Wno-gnu-zero-variadic-macro-arguments` which also seems harmless
- The other changes are about redundant semicolons or unused arguments.