### PR TITLE
Workaround icpc warnings for missing return types

### DIFF
--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -59,8 +59,8 @@ MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
   } else {
     return dynamic_extent;
   }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
+  // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
   return 0;
 #endif
 }
@@ -105,9 +105,9 @@ struct padded_extent {
     } else {
       return init_padding(exts, padding_value);
     }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
-  return {};
+    // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+    return {};
 #endif
   }
 
@@ -120,9 +120,9 @@ struct padded_extent {
     } else {
       return {};
     }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
-  return {};
+    // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+    return {};
 #endif
   }
 
@@ -135,9 +135,9 @@ struct padded_extent {
     } else {
       return {};
     }
-  // Missing return statement warning from NVCC
-#ifdef __NVCC__
-  return {};
+    // Missing return statement warning from NVCC and ICC
+#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+    return {};
 #endif
   }
 };


### PR DESCRIPTION
As suggested in https://github.com/kokkos/kokkos/pull/7079 by @ndellingwood.