### PR TITLE
Fix CUDA errors in submdspan about int to size_t narrowing

### DIFF
--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -131,7 +131,7 @@ struct deduce_layout_left_submapping<
     IndexType, SubRank, std::index_sequence<Idx...>, SliceSpecifiers...> {
 
   using count_range = index_sequence_scan_impl<
-      0, (is_index_slice_v<SliceSpecifiers, IndexType> ? (size_t)0 : (size_t)1)...>;
+      0u, (is_index_slice_v<SliceSpecifiers, IndexType> ? 0u : 1u)...>;
 
   constexpr static int gap_len =
       (((Idx > 0 && count_range::get(Idx) == 1 &&
@@ -361,7 +361,7 @@ struct deduce_layout_right_submapping<
 
   static constexpr size_t Rank = sizeof...(Idx);
   using count_range = index_sequence_scan_impl<
-      0, (std::is_convertible_v<SliceSpecifiers, IndexType> ? (size_t)0 : (size_t)1)...>;
+      0u, (std::is_convertible_v<SliceSpecifiers, IndexType> ? 0u : 1u)...>;
   //__static_partial_sums<!std::is_convertible_v<SliceSpecifiers,
   // IndexType>...>;
   constexpr static int gap_len =

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -131,7 +131,7 @@ struct deduce_layout_left_submapping<
     IndexType, SubRank, std::index_sequence<Idx...>, SliceSpecifiers...> {
 
   using count_range = index_sequence_scan_impl<
-      0, (is_index_slice_v<SliceSpecifiers, IndexType> ? 0 : 1)...>;
+      0, (is_index_slice_v<SliceSpecifiers, IndexType> ? (size_t)0 : (size_t)1)...>;
 
   constexpr static int gap_len =
       (((Idx > 0 && count_range::get(Idx) == 1 &&
@@ -361,7 +361,7 @@ struct deduce_layout_right_submapping<
 
   static constexpr size_t Rank = sizeof...(Idx);
   using count_range = index_sequence_scan_impl<
-      0, (std::is_convertible_v<SliceSpecifiers, IndexType> ? 0 : 1)...>;
+      0, (std::is_convertible_v<SliceSpecifiers, IndexType> ? (size_t)0 : (size_t)1)...>;
   //__static_partial_sums<!std::is_convertible_v<SliceSpecifiers,
   // IndexType>...>;
   constexpr static int gap_len =


### PR DESCRIPTION
I was getting errors on CUDA 11.5.2 with GCC 9.3.0:
```
<snip>/kokkos/core/src/../../tpls/mdspan/include/mdspan/../experimental/__p2630_bits/submdspan_mapping.hpp(134): error: invalid narrowing conversion from "int" to "size_t"
<snip>/kokkos/core/src/../../tpls/mdspan/include/mdspan/../experimental/__p2630_bits/submdspan_mapping.hpp(364): error: invalid narrowing conversion from "int" to "size_t"
```
when building Kokkos `develop` (24454fa82).

I don't really know what I'm doing, so feel free to edit however you need. This fixes it for this particular build, but probably not the best way to go.