### PR TITLE
Fix gcc12 and gcc13 warning.

### DIFF
--- a/tests/libcxx-backports/mdspan/CustomTestAccessors.h
+++ b/tests/libcxx-backports/mdspan/CustomTestAccessors.h
@@ -51,7 +51,7 @@ struct move_counted_handle {
   constexpr move_counted_handle(const move_counted_handle&) = default;
   template <class OtherT>
     requires(std::is_constructible_v<T*, OtherT*>)
-  constexpr move_counted_handle(const move_counted_handle<OtherT>& other) : ptr(other.ptr){};
+  constexpr move_counted_handle(const move_counted_handle<OtherT>& other) : ptr(other.ptr){}
   constexpr move_counted_handle(move_counted_handle&& other) {
     ptr = other.ptr;
 #if MDSPAN_HAS_CXX_23


### PR DESCRIPTION
Fixes the following warning when using `-pedantic`
```
mdspan/tests/libcxx-backports/mdspan/CustomTestAccessors.h:54:93: error: extra ';' [-Werror=pedantic]
   54 |   constexpr move_counted_handle(const move_counted_handle<OtherT>& other) : ptr(other.ptr){};
      |                                                                                             ^
      |                                                                                             -
```