### PR TITLE
Disable empty return for _NVCOMPILER

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/mdspan-build
       shell: bash
-      run: ctest --output-on-failure --
+      run: ctest --output-on-failure
 
     - name: Install
       shell: bash

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -60,7 +60,7 @@ MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
     return dynamic_extent;
   }
   // Missing return statement warning from NVCC and ICC
-#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+#if (defined(__NVCC__) || defined(__INTEL_COMPILER)) && !defined(__NVCOMPILER)
   return 0;
 #endif
 }
@@ -106,7 +106,7 @@ struct padded_extent {
       return init_padding(exts, padding_value);
     }
     // Missing return statement warning from NVCC and ICC
-#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+#if (defined(__NVCC__) || defined(__INTEL_COMPILER)) && !defined(__NVCOMPILER)
     return {};
 #endif
   }
@@ -121,7 +121,7 @@ struct padded_extent {
       return {};
     }
     // Missing return statement warning from NVCC and ICC
-#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+#if (defined(__NVCC__) || defined(__INTEL_COMPILER)) && !defined(__NVCOMPILER)
     return {};
 #endif
   }
@@ -136,7 +136,7 @@ struct padded_extent {
       return {};
     }
     // Missing return statement warning from NVCC and ICC
-#if defined(__NVCC__) || defined(__INTEL_COMPILER)
+#if (defined(__NVCC__) || defined(__INTEL_COMPILER)) && !defined(__NVCOMPILER)
     return {};
 #endif
   }


### PR DESCRIPTION
These empty returns trigger `code_is_unreachable` warning for `nvc++` compiler. We want to incorporate changes in https://github.com/kokkos/kokkos/pull/7250.

```
"/var/jenkins/workspace/Kokkos_PR-7226/tpls/mdspan/include/mdspan/../experimental/__p2642_bits/layout_padded.hpp", line 64: warning: statement is unreachable [code_is_unreachable]
  return 0; 
  ^
          detected during:
            instantiation of class "Kokkos::Experimental::detail::static_array_type_for_padded_extent<_PaddingValue, _Extents, _ExtentToPadIdx, _Rank, Enabled> [with _PaddingValue=18446744073709551615UL, _Extents=Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>, _ExtentToPadIdx=0UL, _Rank=2UL, Enabled=void]" at line 95
            instantiation of class "Kokkos::Experimental::detail::padded_extent<_PaddingValue, _Extents, _ExtentToPadIdx> [with _PaddingValue=18446744073709551615UL, _Extents=Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>, _ExtentToPadIdx=0UL]" at line 174
            instantiation of class "Kokkos::Experimental::layout_left_padded<padding_value>::mapping<Extents> [with padding_value=18446744073709551615UL, Extents=Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>]" at line 883 of "/usr/include/c++/9/type_traits"
            instantiation of class "std::is_constructible<_Tp, _Args...> [with _Tp=Kokkos::Experimental::layout_left_padded<18446744073709551615UL>::mapping<Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>>, _Args=<Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>>]" at line 2912 of "/usr/include/c++/9/type_traits"
            instantiation of "const bool std::is_constructible_v [with _Tp=Kokkos::Experimental::layout_left_padded<18446744073709551615UL>::mapping<Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>>, _Args=<Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>>]" at line 118 of "/var/jenkins/workspace/Kokkos_PR-7226/tpls/mdspan/include/mdspan/../experimental/__p0009_bits/mdspan.hpp"
            instantiation of class "Kokkos::mdspan<ElementType, Extents, LayoutPolicy, AccessorPolicy> [with ElementType=int, Extents=Kokkos::extents<std::size_t, 18446744073709551615UL, 18446744073709551615UL>, LayoutPolicy=Kokkos::Experimental::layout_left_padded<18446744073709551615UL>, AccessorPolicy=Kokkos::Impl::SpaceAwareAccessor<Kokkos::CudaSpace::memory_space, Kokkos::default_accessor<int>>]" at line 1109 of "/var/jenkins/workspace/Kokkos_PR-7226/core/src/View/Kokkos_ViewLegacy.hpp"
            instantiation of "Kokkos::View<DataType, Properties...>::View(const Kokkos::Impl::ViewCtorProp<P...> &, std::enable_if_t<<expression>, size_t>, size_t, size_t, size_t, size_t, size_t, size_t, size_t) [with DataType=int **, Properties=<Kokkos::Cuda>, P=<Kokkos::Impl::WithoutInitializing_t, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>]" at line 49 of "/var/jenkins/workspace/Kokkos_PR-7226/core/unit_test/TestTeam.hpp"
            instantiation of "Test::_GLOBAL__N__31d3ebdc_22_TestCuda_TeamBasic_cpp_a92a69dc::TestTeamPolicy<ExecSpace, ScheduleType>::TestTeamPolicy(size_t) [with ExecSpace=Kokkos::Cuda, ScheduleType=Kokkos::Schedule<Kokkos::Static>]" at line 141 of "/var/jenkins/workspace/Kokkos_PR-7226/core/unit_test/TestTeam.hpp"
            instantiation of "void Test::_GLOBAL__N__31d3ebdc_22_TestCuda_TeamBasic_cpp_a92a69dc::TestTeamPolicy<ExecSpace, ScheduleType>::test_for(size_t) [with ExecSpace=Kokkos::Cuda, ScheduleType=Kokkos::Schedule<Kokkos::Static>]" at line 24 of "/var/jenkins/workspace/Kokkos_PR-7226/core/unit_test/TestTeamBasic.hpp"

Remark: individual warnings can be suppressed with "--diag_suppress <warning-name>"
