### PR TITLE
unstdify config.hpp macros

### DIFF
--- a/compilation_tests/ctest_common.hpp
+++ b/compilation_tests/ctest_common.hpp
@@ -33,7 +33,7 @@
 // At least in the case of clang, that error is descriptive enough to see what's
 // going on if we're careful with how we do things.
 
-#if _MDSPAN_USE_CONSTEXPR_14
+#if MDSPAN_USE_CONSTEXPR_14
 
 // A nice marker in the compiler output. Also, use std::is_constant_evaluated if we have it
 #if __cpp_lib_is_constant_evaluated > 201811
@@ -117,7 +117,7 @@ struct _____constexpr_assertion_failed_ {
 #define constexpr_assert_greater_than(expr, ...) \
   _____constexpr_assertion_failed_{#__VA_ARGS__}._expected_to_be_greater_than_(expr).but_actual_value_was_((__VA_ARGS__));
 
-#endif // _MDSPAN_USE_CONSTEXPR_14
+#endif // MDSPAN_USE_CONSTEXPR_14
 
 // </editor-fold> end assert-like macros that don't break constexpr }}}1
 //==============================================================================

--- a/compilation_tests/ctest_common.hpp
+++ b/compilation_tests/ctest_common.hpp
@@ -33,7 +33,7 @@
 // At least in the case of clang, that error is descriptive enough to see what's
 // going on if we're careful with how we do things.
 
-#if MDSPAN_USE_CONSTEXPR_14
+#if MDSPAN_IMPL_USE_CONSTEXPR_14
 
 // A nice marker in the compiler output. Also, use std::is_constant_evaluated if we have it
 #if __cpp_lib_is_constant_evaluated > 201811
@@ -117,7 +117,7 @@ struct _____constexpr_assertion_failed_ {
 #define constexpr_assert_greater_than(expr, ...) \
   _____constexpr_assertion_failed_{#__VA_ARGS__}._expected_to_be_greater_than_(expr).but_actual_value_was_((__VA_ARGS__));
 
-#endif // MDSPAN_USE_CONSTEXPR_14
+#endif // MDSPAN_IMPL_USE_CONSTEXPR_14
 
 // </editor-fold> end assert-like macros that don't break constexpr }}}1
 //==============================================================================

--- a/compilation_tests/ctest_compressed_pair_layout.cpp
+++ b/compilation_tests/ctest_compressed_pair_layout.cpp
@@ -60,7 +60,7 @@ struct E3 {};
 void instantiate_tests() {
 //==============================================================================
 // <editor-fold desc="compressed pair layout: 2 leaf elements"> {{{1
-#ifdef _MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_COMPILER_MSVC
 test<CP<E0, E0>, 1, empty, non_standard_layout>();
 test<CP<E0, E1>, 1, empty, standard_layout>();
 #else
@@ -75,10 +75,10 @@ test<CP<int*, int*>, 2 * sizeof(int*), non_empty>();
 
 //==============================================================================
 // <editor-fold desc="compressed pair layout: 1 nested pair, 3 leaf element"> {{{1
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 test<CP<E0,   CP<E0,   E0>>,   3,                empty>();     // Emulation can't handle this correctly.
 #endif
-#ifdef _MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_COMPILER_MSVC
 test<CP<E0,   CP<E1,   E2>>,   2,                empty>();
 #else
 test<CP<E0,   CP<E1,   E2>>,   1,                empty>();
@@ -86,7 +86,7 @@ test<CP<E0,   CP<E1,   E2>>,   1,                empty>();
 test<CP<E0,   CP<E1,   int*>>, sizeof(int*),     non_empty>();
 test<CP<E0,   CP<int*, E2>>,   sizeof(int*),     non_empty>();
 test<CP<E0,   CP<int*, int*>>, 2 * sizeof(int*), non_empty>();
-#ifdef _MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_COMPILER_MSVC
 test<CP<int*, CP<E1,   E2>>,   2 * sizeof(int*), non_empty>();
 #else
 test<CP<int*, CP<E1,   E2>>,   sizeof(int*),     non_empty>();
@@ -94,10 +94,10 @@ test<CP<int*, CP<E1,   E2>>,   sizeof(int*),     non_empty>();
 test<CP<int*, CP<E1,   int*>>, 2 * sizeof(int*), non_empty>();
 test<CP<int*, CP<int*, E2>>,   2 * sizeof(int*), non_empty>();
 test<CP<int*, CP<int*, int*>>, 3 * sizeof(int*), non_empty>();
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 test<CP<CP<E0,   E0>,   E0>,   3,                empty>();     // Emulation can't handle this correctly.
 #endif
-#ifdef _MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_COMPILER_MSVC
 test<CP<CP<E0,   E1>,   E2>,   2,                empty>();
 test<CP<CP<E0,   E1>,   int*>, 2 * sizeof(int*), non_empty>();
 #else
@@ -115,10 +115,10 @@ test<CP<CP<int*, int*>, int*>, 3 * sizeof(int*), non_empty>();
 
 //==============================================================================
 // <editor-fold desc="compressed pair layout: 2 nested pairs, 4 leaf element"> {{{1
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 test<CP<CP<E0,   E0>,   CP<E0,  E0>>,    4,                empty>(); // Emulation can't handle this correctly.
 #endif
-#ifdef _MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_COMPILER_MSVC
 test<CP<CP<E0,   E1>,   CP<E2,   E3>>,   3,                empty>();
 test<CP<CP<E0,   E1>,   CP<E2,   int*>>, 2 * sizeof(int*), non_empty>();
 test<CP<CP<E0,   E1>,   CP<int*, E3>>,   2 * sizeof(int*), non_empty>();

--- a/compilation_tests/ctest_compressed_pair_layout.cpp
+++ b/compilation_tests/ctest_compressed_pair_layout.cpp
@@ -60,7 +60,7 @@ struct E3 {};
 void instantiate_tests() {
 //==============================================================================
 // <editor-fold desc="compressed pair layout: 2 leaf elements"> {{{1
-#ifdef MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_IMPL_COMPILER_MSVC
 test<CP<E0, E0>, 1, empty, non_standard_layout>();
 test<CP<E0, E1>, 1, empty, standard_layout>();
 #else
@@ -75,10 +75,10 @@ test<CP<int*, int*>, 2 * sizeof(int*), non_empty>();
 
 //==============================================================================
 // <editor-fold desc="compressed pair layout: 1 nested pair, 3 leaf element"> {{{1
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 test<CP<E0,   CP<E0,   E0>>,   3,                empty>();     // Emulation can't handle this correctly.
 #endif
-#ifdef MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_IMPL_COMPILER_MSVC
 test<CP<E0,   CP<E1,   E2>>,   2,                empty>();
 #else
 test<CP<E0,   CP<E1,   E2>>,   1,                empty>();
@@ -86,7 +86,7 @@ test<CP<E0,   CP<E1,   E2>>,   1,                empty>();
 test<CP<E0,   CP<E1,   int*>>, sizeof(int*),     non_empty>();
 test<CP<E0,   CP<int*, E2>>,   sizeof(int*),     non_empty>();
 test<CP<E0,   CP<int*, int*>>, 2 * sizeof(int*), non_empty>();
-#ifdef MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_IMPL_COMPILER_MSVC
 test<CP<int*, CP<E1,   E2>>,   2 * sizeof(int*), non_empty>();
 #else
 test<CP<int*, CP<E1,   E2>>,   sizeof(int*),     non_empty>();
@@ -94,10 +94,10 @@ test<CP<int*, CP<E1,   E2>>,   sizeof(int*),     non_empty>();
 test<CP<int*, CP<E1,   int*>>, 2 * sizeof(int*), non_empty>();
 test<CP<int*, CP<int*, E2>>,   2 * sizeof(int*), non_empty>();
 test<CP<int*, CP<int*, int*>>, 3 * sizeof(int*), non_empty>();
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 test<CP<CP<E0,   E0>,   E0>,   3,                empty>();     // Emulation can't handle this correctly.
 #endif
-#ifdef MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_IMPL_COMPILER_MSVC
 test<CP<CP<E0,   E1>,   E2>,   2,                empty>();
 test<CP<CP<E0,   E1>,   int*>, 2 * sizeof(int*), non_empty>();
 #else
@@ -115,10 +115,10 @@ test<CP<CP<int*, int*>, int*>, 3 * sizeof(int*), non_empty>();
 
 //==============================================================================
 // <editor-fold desc="compressed pair layout: 2 nested pairs, 4 leaf element"> {{{1
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 test<CP<CP<E0,   E0>,   CP<E0,  E0>>,    4,                empty>(); // Emulation can't handle this correctly.
 #endif
-#ifdef MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_IMPL_COMPILER_MSVC
 test<CP<CP<E0,   E1>,   CP<E2,   E3>>,   3,                empty>();
 test<CP<CP<E0,   E1>,   CP<E2,   int*>>, 2 * sizeof(int*), non_empty>();
 test<CP<CP<E0,   E1>,   CP<int*, E3>>,   2 * sizeof(int*), non_empty>();
@@ -141,4 +141,3 @@ test<CP<CP<int*, int*>, CP<int*, int*>>, 4 * sizeof(int*), non_empty>();
 // </editor-fold> end compressed pair layout: 2 nested pairs, 4 leaf elements }}}1
 //==============================================================================
 }
-

--- a/compilation_tests/ctest_constexpr_dereference.cpp
+++ b/compilation_tests/ctest_constexpr_dereference.cpp
@@ -19,7 +19,7 @@
 
 
 // Only works with newer constexpr
-#if defined(_MDSPAN_USE_CONSTEXPR_14) && _MDSPAN_USE_CONSTEXPR_14
+#if defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
 
 //==============================================================================
 
@@ -34,7 +34,7 @@ simple_static_sum_test_1(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += __MDSPAN_OP(s, row, col) * (row + add_to_row);
+      result += MDSPAN_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -87,7 +87,7 @@ simple_dynamic_sum_test_2(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += __MDSPAN_OP(s, row, col) * (row + add_to_row);
+      result += MDSPAN_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -120,7 +120,7 @@ simple_mixed_layout_left_sum_test_3(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += __MDSPAN_OP(s, row, col) * (row + add_to_row);
+      result += MDSPAN_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -150,8 +150,8 @@ multidimensional_single_element_stress_test_impl_2(
   int data[] = { 42 };
   auto s = mdspan_t(data);
   auto s_dyn = dyn_mdspan_t(data, _repeated_ptrdiff_t<1, Idxs>...);
-  auto val = __MDSPAN_OP(s, _repeated_ptrdiff_t<0, Idxs>...);
-  auto val_dyn = __MDSPAN_OP(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val = MDSPAN_OP(s, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val_dyn = MDSPAN_OP(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   constexpr_assert_equal(42, val);
   constexpr_assert_equal(42, val_dyn);
   return val == 42 && val_dyn == 42;
@@ -205,13 +205,13 @@ stress_test_2d_single_element_stress_test_impl_2(
   auto s12 = dyn_mdspan_t(data, Idx1, Idx2);
   for(ptrdiff_t i = 0; i < Idx1; ++i) {
     for(ptrdiff_t j = 0; j < Idx2; ++j) {
-      __MDSPAN_OP(s, i, j) = __MDSPAN_OP(s1, i, j) = __MDSPAN_OP(s2, i, j) = __MDSPAN_OP(s12, i, j) = 1;
+      MDSPAN_OP(s, i, j) = MDSPAN_OP(s1, i, j) = MDSPAN_OP(s2, i, j) = MDSPAN_OP(s12, i, j) = 1;
     }
   }
   int result = 0;
   for(ptrdiff_t i = 0; i < Idx1; ++i) {
     for(ptrdiff_t j = 0; j < Idx2; ++j) {
-      result += __MDSPAN_OP(s, i, j) + __MDSPAN_OP(s1, i, j) + __MDSPAN_OP(s2, i, j) + __MDSPAN_OP(s12, i, j);
+      result += MDSPAN_OP(s, i, j) + MDSPAN_OP(s1, i, j) + MDSPAN_OP(s2, i, j) + MDSPAN_OP(s12, i, j);
     }
   }
   result /= 4;
@@ -270,4 +270,4 @@ static bool _stress_2d_result =
 #endif // MDSPAN_DISABLE_EXPENSIVE_COMPILATION_TESTS
 
 
-#endif //defined(_MDSPAN_USE_CONSTEXPR_14) && _MDSPAN_USE_CONSTEXPR_14
+#endif //defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14

--- a/compilation_tests/ctest_constexpr_dereference.cpp
+++ b/compilation_tests/ctest_constexpr_dereference.cpp
@@ -19,7 +19,7 @@
 
 
 // Only works with newer constexpr
-#if defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
+#if defined(MDSPAN_IMPL_USE_CONSTEXPR_14) && MDSPAN_IMPL_USE_CONSTEXPR_14
 
 //==============================================================================
 
@@ -34,7 +34,7 @@ simple_static_sum_test_1(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += MDSPAN_OP(s, row, col) * (row + add_to_row);
+      result += MDSPAN_IMPL_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -87,7 +87,7 @@ simple_dynamic_sum_test_2(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += MDSPAN_OP(s, row, col) * (row + add_to_row);
+      result += MDSPAN_IMPL_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -120,7 +120,7 @@ simple_mixed_layout_left_sum_test_3(int add_to_row) {
   int result = 0;
   for(int col = 0; col < 3; ++col) {
     for(int row = 0; row < 3; ++row) {
-      result += MDSPAN_OP(s, row, col) * (row + add_to_row);
+      result += MDSPAN_IMPL_OP(s, row, col) * (row + add_to_row);
     }
   }
   return result;
@@ -150,8 +150,8 @@ multidimensional_single_element_stress_test_impl_2(
   int data[] = { 42 };
   auto s = mdspan_t(data);
   auto s_dyn = dyn_mdspan_t(data, _repeated_ptrdiff_t<1, Idxs>...);
-  auto val = MDSPAN_OP(s, _repeated_ptrdiff_t<0, Idxs>...);
-  auto val_dyn = MDSPAN_OP(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val = MDSPAN_IMPL_OP(s, _repeated_ptrdiff_t<0, Idxs>...);
+  auto val_dyn = MDSPAN_IMPL_OP(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   constexpr_assert_equal(42, val);
   constexpr_assert_equal(42, val_dyn);
   return val == 42 && val_dyn == 42;
@@ -205,13 +205,13 @@ stress_test_2d_single_element_stress_test_impl_2(
   auto s12 = dyn_mdspan_t(data, Idx1, Idx2);
   for(ptrdiff_t i = 0; i < Idx1; ++i) {
     for(ptrdiff_t j = 0; j < Idx2; ++j) {
-      MDSPAN_OP(s, i, j) = MDSPAN_OP(s1, i, j) = MDSPAN_OP(s2, i, j) = MDSPAN_OP(s12, i, j) = 1;
+      MDSPAN_IMPL_OP(s, i, j) = MDSPAN_IMPL_OP(s1, i, j) = MDSPAN_IMPL_OP(s2, i, j) = MDSPAN_IMPL_OP(s12, i, j) = 1;
     }
   }
   int result = 0;
   for(ptrdiff_t i = 0; i < Idx1; ++i) {
     for(ptrdiff_t j = 0; j < Idx2; ++j) {
-      result += MDSPAN_OP(s, i, j) + MDSPAN_OP(s1, i, j) + MDSPAN_OP(s2, i, j) + MDSPAN_OP(s12, i, j);
+      result += MDSPAN_IMPL_OP(s, i, j) + MDSPAN_IMPL_OP(s1, i, j) + MDSPAN_IMPL_OP(s2, i, j) + MDSPAN_IMPL_OP(s12, i, j);
     }
   }
   result /= 4;
@@ -270,4 +270,4 @@ static bool _stress_2d_result =
 #endif // MDSPAN_DISABLE_EXPENSIVE_COMPILATION_TESTS
 
 
-#endif //defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
+#endif //defined(MDSPAN_IMPL_USE_CONSTEXPR_14) && MDSPAN_IMPL_USE_CONSTEXPR_14

--- a/compilation_tests/ctest_constexpr_layouts.cpp
+++ b/compilation_tests/ctest_constexpr_layouts.cpp
@@ -19,7 +19,7 @@
 
 
 // Only works with newer constexpr
-#if defined(_MDSPAN_USE_CONSTEXPR_14) && _MDSPAN_USE_CONSTEXPR_14
+#if defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
 
 constexpr std::ptrdiff_t
 layout_stride_simple(int i) {
@@ -36,4 +36,4 @@ MDSPAN_STATIC_TEST(
   layout_stride_simple(1) == 1
 );
 
-#endif // _MDSPAN_USE_CONSTEXPR_14
+#endif // MDSPAN_USE_CONSTEXPR_14

--- a/compilation_tests/ctest_constexpr_layouts.cpp
+++ b/compilation_tests/ctest_constexpr_layouts.cpp
@@ -19,7 +19,7 @@
 
 
 // Only works with newer constexpr
-#if defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
+#if defined(MDSPAN_IMPL_USE_CONSTEXPR_14) && MDSPAN_IMPL_USE_CONSTEXPR_14
 
 constexpr std::ptrdiff_t
 layout_stride_simple(int i) {
@@ -36,4 +36,4 @@ MDSPAN_STATIC_TEST(
   layout_stride_simple(1) == 1
 );
 
-#endif // MDSPAN_USE_CONSTEXPR_14
+#endif // MDSPAN_IMPL_USE_CONSTEXPR_14

--- a/compilation_tests/ctest_constexpr_submdspan.cpp
+++ b/compilation_tests/ctest_constexpr_submdspan.cpp
@@ -18,7 +18,7 @@
 #include <mdspan/mdspan.hpp>
 
 // Only works with newer constexpr
-#if defined(_MDSPAN_USE_CONSTEXPR_14) && _MDSPAN_USE_CONSTEXPR_14
+#if defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
 
 //==============================================================================
 // <editor-fold desc="1D dynamic extent ptrdiff_t submdspan"> {{{1
@@ -31,7 +31,7 @@ dynamic_extent_1d() {
   int result = 0;
   for (size_t i = 0; i < s.extent(0); ++i) {
     auto ss = Kokkos::submdspan(s, i);
-    result += __MDSPAN_OP0(ss);
+    result += MDSPAN_OP0(ss);
   }
   // 1 + 2 + 3 + 4 + 5
   constexpr_assert_equal(15, result);
@@ -57,7 +57,7 @@ dynamic_extent_1d_all_slice() {
   int result = 0;
   auto ss = Kokkos::submdspan(s, Kokkos::full_extent);
   for (size_t i = 0; i < s.extent(0); ++i) {
-    result += __MDSPAN_OP(ss, i);
+    result += MDSPAN_OP(ss, i);
   }
   // 1 + 2 + 3 + 4 + 5
   constexpr_assert_equal(15, result);
@@ -82,7 +82,7 @@ dynamic_extent_1d_pair_full() {
   int result = 0;
   auto ss = Kokkos::submdspan(s, std::pair<std::ptrdiff_t, std::ptrdiff_t>{0, 5});
   for (size_t i = 0; i < s.extent(0); ++i) {
-    result += __MDSPAN_OP(ss, i);
+    result += MDSPAN_OP(ss, i);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
@@ -101,14 +101,14 @@ dynamic_extent_1d_pair_each() {
   for (size_t i = 0; i < s.extent(0); ++i) {
     auto ss = Kokkos::submdspan(s,
       std::pair<std::ptrdiff_t, std::ptrdiff_t>{i, i+1});
-    result += __MDSPAN_OP(ss, 0);
+    result += MDSPAN_OP(ss, 0);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
 }
 
 // MSVC ICE
-#ifndef _MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_COMPILER_MSVC
 MDSPAN_STATIC_TEST(dynamic_extent_1d_pair_each<Kokkos::layout_left>());
 MDSPAN_STATIC_TEST(dynamic_extent_1d_pair_each<Kokkos::layout_right>());
 #endif
@@ -130,14 +130,14 @@ dynamic_extent_1d_all_three() {
   int result = 0;
   for (size_t i = 0; i < s.extent(0); ++i) {
     auto ss = Kokkos::submdspan(s2, i);
-    result += __MDSPAN_OP0(ss);
+    result += MDSPAN_OP0(ss);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
 }
 
 // MSVC ICE
-#ifndef _MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_COMPILER_MSVC
 MDSPAN_STATIC_TEST(dynamic_extent_1d_all_three<Kokkos::layout_left>());
 MDSPAN_STATIC_TEST(dynamic_extent_1d_all_three<Kokkos::layout_right>());
 #endif
@@ -156,7 +156,7 @@ dynamic_extent_2d_idx_idx() {
   for(size_t row = 0; row < s.extent(0); ++row) {
     for(size_t col = 0; col < s.extent(1); ++col) {
       auto ss = Kokkos::submdspan(s, row, col);
-      result += __MDSPAN_OP0(ss);
+      result += MDSPAN_OP0(ss);
     }
   }
   constexpr_assert_equal(21, result);
@@ -177,8 +177,8 @@ dynamic_extent_2d_idx_all_idx() {
     auto srow = Kokkos::submdspan(s, row, Kokkos::full_extent);
     for(size_t col = 0; col < s.extent(1); ++col) {
       auto scol = Kokkos::submdspan(srow, col);
-      constexpr_assert_equal(__MDSPAN_OP0(scol), __MDSPAN_OP(srow, col));
-      result += __MDSPAN_OP0(scol);
+      constexpr_assert_equal(MDSPAN_OP0(scol), MDSPAN_OP(srow, col));
+      result += MDSPAN_OP0(scol);
     }
   }
   constexpr_assert_equal(21, result);
@@ -186,7 +186,7 @@ dynamic_extent_2d_idx_all_idx() {
 }
 
 // MSVC ICE
-#ifndef _MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_COMPILER_MSVC
 MDSPAN_STATIC_TEST(dynamic_extent_2d_idx_all_idx<Kokkos::layout_left>());
 MDSPAN_STATIC_TEST(dynamic_extent_2d_idx_all_idx<Kokkos::layout_right>());
 #endif
@@ -206,14 +206,14 @@ simple_static_submdspan_test_1(int add_to_row) {
     auto scol = Kokkos::submdspan(s, Kokkos::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = Kokkos::submdspan(scol, row);
-      result += __MDSPAN_OP0(srow) * (row + add_to_row);
+      result += MDSPAN_OP0(srow) * (row + add_to_row);
     }
   }
   return result;
 }
 
 // MSVC ICE
-#if !defined(_MDSPAN_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
+#if !defined(MDSPAN_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
 MDSPAN_STATIC_TEST(
   // 1 + 2 + 3 + 2*(4 + 5 + 6) + 3*(7 + 8 + 9) = 108
   simple_static_submdspan_test_1(1) == 108
@@ -248,7 +248,7 @@ mixed_submdspan_left_test_2() {
     auto scol = Kokkos::submdspan(s, Kokkos::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = Kokkos::submdspan(scol, row);
-      result += __MDSPAN_OP0(srow) * (row + 1);
+      result += MDSPAN_OP0(srow) * (row + 1);
     }
   }
   // 1 + 2 + 3 + 2*(4 + 5 + 6) + 3*(7 + 8 + 9)= 108
@@ -257,7 +257,7 @@ mixed_submdspan_left_test_2() {
     auto srow = Kokkos::submdspan(s, row, Kokkos::full_extent);
     for(int col = 0; col < 5; ++col) {
       auto scol = Kokkos::submdspan(srow, col);
-      result += __MDSPAN_OP0(scol) * (row + 1);
+      result += MDSPAN_OP0(scol) * (row + 1);
     }
   }
   result /= 2;
@@ -267,7 +267,7 @@ mixed_submdspan_left_test_2() {
 }
 
 // MSVC ICE
-#if !defined(_MDSPAN_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
+#if !defined(MDSPAN_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
 MDSPAN_STATIC_TEST(
   // 2 * (1 + 2 + 3 + 2*(4 + 5 + 6) + 3*(7 + 8 + 9)) / 2 = 108
   mixed_submdspan_left_test_2()
@@ -291,7 +291,7 @@ mixed_submdspan_test_3() {
     auto scol = Kokkos::submdspan(s, Kokkos::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = Kokkos::submdspan(scol, row);
-      result += __MDSPAN_OP0(srow) * (row + 1);
+      result += MDSPAN_OP0(srow) * (row + 1);
     }
   }
   constexpr_assert_equal(71, result);
@@ -299,7 +299,7 @@ mixed_submdspan_test_3() {
     auto srow = Kokkos::submdspan(s, row, Kokkos::full_extent);
     for(int col = 0; col < 5; ++col) {
       auto scol = Kokkos::submdspan(srow, col);
-      result += __MDSPAN_OP0(scol) * (row + 1);
+      result += MDSPAN_OP0(scol) * (row + 1);
     }
   }
   result /= 2;
@@ -309,7 +309,7 @@ mixed_submdspan_test_3() {
 }
 
 // MSVC ICE
-#ifndef _MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_COMPILER_MSVC
 MDSPAN_STATIC_TEST(
   mixed_submdspan_test_3<Kokkos::layout_right>()
 );
@@ -340,19 +340,19 @@ submdspan_single_element_stress_test_impl_2(
   auto ss_dyn = Kokkos::submdspan(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   auto ss_all = Kokkos::submdspan(s, _repeated_with_idxs_t<Kokkos::full_extent_t, Idxs>{}...);
   auto ss_all_dyn = Kokkos::submdspan(s_dyn, _repeated_with_idxs_t<Kokkos::full_extent_t, Idxs>{}...);
-  auto val = __MDSPAN_OP(ss_all, (_repeated_ptrdiff_t<0, Idxs>...));
-  auto val_dyn = __MDSPAN_OP(ss_all_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val = MDSPAN_OP(ss_all, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_dyn = MDSPAN_OP(ss_all_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
   auto ss_pair = Kokkos::submdspan(s, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
   auto ss_pair_dyn = Kokkos::submdspan(s_dyn, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
-  auto val_pair = __MDSPAN_OP(ss_pair, (_repeated_ptrdiff_t<0, Idxs>...));
-  auto val_pair_dyn = __MDSPAN_OP(ss_pair_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_pair = MDSPAN_OP(ss_pair, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_pair_dyn = MDSPAN_OP(ss_pair_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
   constexpr_assert_equal(42, ss());
   constexpr_assert_equal(42, ss_dyn());
   constexpr_assert_equal(42, val);
   constexpr_assert_equal(42, val_dyn);
   constexpr_assert_equal(42, val_pair);
   constexpr_assert_equal(42, val_pair_dyn);
-  return __MDSPAN_OP0(ss) == 42 && __MDSPAN_OP0(ss_dyn) == 42 && val == 42 && val_dyn == 42 && val_pair == 42 && val_pair_dyn == 42;
+  return MDSPAN_OP0(ss) == 42 && MDSPAN_OP0(ss_dyn) == 42 && val == 42 && val_dyn == 42 && val_pair == 42 && val_pair_dyn == 42;
 }
 
 template <class Layout, size_t... Sizes>
@@ -384,4 +384,4 @@ MDSPAN_STATIC_TEST(
 
 #endif // MDSPAN_DISABLE_EXPENSIVE_COMPILATION_TESTS
 
-#endif // defined(_MDSPAN_USE_CONSTEXPR_14) && _MDSPAN_USE_CONSTEXPR_14
+#endif // defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14

--- a/compilation_tests/ctest_constexpr_submdspan.cpp
+++ b/compilation_tests/ctest_constexpr_submdspan.cpp
@@ -18,7 +18,7 @@
 #include <mdspan/mdspan.hpp>
 
 // Only works with newer constexpr
-#if defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
+#if defined(MDSPAN_IMPL_USE_CONSTEXPR_14) && MDSPAN_IMPL_USE_CONSTEXPR_14
 
 //==============================================================================
 // <editor-fold desc="1D dynamic extent ptrdiff_t submdspan"> {{{1
@@ -31,7 +31,7 @@ dynamic_extent_1d() {
   int result = 0;
   for (size_t i = 0; i < s.extent(0); ++i) {
     auto ss = Kokkos::submdspan(s, i);
-    result += MDSPAN_OP0(ss);
+    result += MDSPAN_IMPL_OP0(ss);
   }
   // 1 + 2 + 3 + 4 + 5
   constexpr_assert_equal(15, result);
@@ -57,7 +57,7 @@ dynamic_extent_1d_all_slice() {
   int result = 0;
   auto ss = Kokkos::submdspan(s, Kokkos::full_extent);
   for (size_t i = 0; i < s.extent(0); ++i) {
-    result += MDSPAN_OP(ss, i);
+    result += MDSPAN_IMPL_OP(ss, i);
   }
   // 1 + 2 + 3 + 4 + 5
   constexpr_assert_equal(15, result);
@@ -82,7 +82,7 @@ dynamic_extent_1d_pair_full() {
   int result = 0;
   auto ss = Kokkos::submdspan(s, std::pair<std::ptrdiff_t, std::ptrdiff_t>{0, 5});
   for (size_t i = 0; i < s.extent(0); ++i) {
-    result += MDSPAN_OP(ss, i);
+    result += MDSPAN_IMPL_OP(ss, i);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
@@ -101,14 +101,14 @@ dynamic_extent_1d_pair_each() {
   for (size_t i = 0; i < s.extent(0); ++i) {
     auto ss = Kokkos::submdspan(s,
       std::pair<std::ptrdiff_t, std::ptrdiff_t>{i, i+1});
-    result += MDSPAN_OP(ss, 0);
+    result += MDSPAN_IMPL_OP(ss, 0);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
 }
 
 // MSVC ICE
-#ifndef MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_IMPL_COMPILER_MSVC
 MDSPAN_STATIC_TEST(dynamic_extent_1d_pair_each<Kokkos::layout_left>());
 MDSPAN_STATIC_TEST(dynamic_extent_1d_pair_each<Kokkos::layout_right>());
 #endif
@@ -130,14 +130,14 @@ dynamic_extent_1d_all_three() {
   int result = 0;
   for (size_t i = 0; i < s.extent(0); ++i) {
     auto ss = Kokkos::submdspan(s2, i);
-    result += MDSPAN_OP0(ss);
+    result += MDSPAN_IMPL_OP0(ss);
   }
   constexpr_assert_equal(15, result);
   return result == 15;
 }
 
 // MSVC ICE
-#ifndef MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_IMPL_COMPILER_MSVC
 MDSPAN_STATIC_TEST(dynamic_extent_1d_all_three<Kokkos::layout_left>());
 MDSPAN_STATIC_TEST(dynamic_extent_1d_all_three<Kokkos::layout_right>());
 #endif
@@ -156,7 +156,7 @@ dynamic_extent_2d_idx_idx() {
   for(size_t row = 0; row < s.extent(0); ++row) {
     for(size_t col = 0; col < s.extent(1); ++col) {
       auto ss = Kokkos::submdspan(s, row, col);
-      result += MDSPAN_OP0(ss);
+      result += MDSPAN_IMPL_OP0(ss);
     }
   }
   constexpr_assert_equal(21, result);
@@ -177,8 +177,8 @@ dynamic_extent_2d_idx_all_idx() {
     auto srow = Kokkos::submdspan(s, row, Kokkos::full_extent);
     for(size_t col = 0; col < s.extent(1); ++col) {
       auto scol = Kokkos::submdspan(srow, col);
-      constexpr_assert_equal(MDSPAN_OP0(scol), MDSPAN_OP(srow, col));
-      result += MDSPAN_OP0(scol);
+      constexpr_assert_equal(MDSPAN_IMPL_OP0(scol), MDSPAN_IMPL_OP(srow, col));
+      result += MDSPAN_IMPL_OP0(scol);
     }
   }
   constexpr_assert_equal(21, result);
@@ -186,7 +186,7 @@ dynamic_extent_2d_idx_all_idx() {
 }
 
 // MSVC ICE
-#ifndef MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_IMPL_COMPILER_MSVC
 MDSPAN_STATIC_TEST(dynamic_extent_2d_idx_all_idx<Kokkos::layout_left>());
 MDSPAN_STATIC_TEST(dynamic_extent_2d_idx_all_idx<Kokkos::layout_right>());
 #endif
@@ -206,14 +206,14 @@ simple_static_submdspan_test_1(int add_to_row) {
     auto scol = Kokkos::submdspan(s, Kokkos::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = Kokkos::submdspan(scol, row);
-      result += MDSPAN_OP0(srow) * (row + add_to_row);
+      result += MDSPAN_IMPL_OP0(srow) * (row + add_to_row);
     }
   }
   return result;
 }
 
 // MSVC ICE
-#if !defined(MDSPAN_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
+#if !defined(MDSPAN_IMPL_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
 MDSPAN_STATIC_TEST(
   // 1 + 2 + 3 + 2*(4 + 5 + 6) + 3*(7 + 8 + 9) = 108
   simple_static_submdspan_test_1(1) == 108
@@ -248,7 +248,7 @@ mixed_submdspan_left_test_2() {
     auto scol = Kokkos::submdspan(s, Kokkos::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = Kokkos::submdspan(scol, row);
-      result += MDSPAN_OP0(srow) * (row + 1);
+      result += MDSPAN_IMPL_OP0(srow) * (row + 1);
     }
   }
   // 1 + 2 + 3 + 2*(4 + 5 + 6) + 3*(7 + 8 + 9)= 108
@@ -257,7 +257,7 @@ mixed_submdspan_left_test_2() {
     auto srow = Kokkos::submdspan(s, row, Kokkos::full_extent);
     for(int col = 0; col < 5; ++col) {
       auto scol = Kokkos::submdspan(srow, col);
-      result += MDSPAN_OP0(scol) * (row + 1);
+      result += MDSPAN_IMPL_OP0(scol) * (row + 1);
     }
   }
   result /= 2;
@@ -267,7 +267,7 @@ mixed_submdspan_left_test_2() {
 }
 
 // MSVC ICE
-#if !defined(MDSPAN_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
+#if !defined(MDSPAN_IMPL_COMPILER_MSVC) && (!defined(__GNUC__) || (__GNUC__>=6 && __GNUC_MINOR__>=4))
 MDSPAN_STATIC_TEST(
   // 2 * (1 + 2 + 3 + 2*(4 + 5 + 6) + 3*(7 + 8 + 9)) / 2 = 108
   mixed_submdspan_left_test_2()
@@ -291,7 +291,7 @@ mixed_submdspan_test_3() {
     auto scol = Kokkos::submdspan(s, Kokkos::full_extent, col);
     for(int row = 0; row < 3; ++row) {
       auto srow = Kokkos::submdspan(scol, row);
-      result += MDSPAN_OP0(srow) * (row + 1);
+      result += MDSPAN_IMPL_OP0(srow) * (row + 1);
     }
   }
   constexpr_assert_equal(71, result);
@@ -299,7 +299,7 @@ mixed_submdspan_test_3() {
     auto srow = Kokkos::submdspan(s, row, Kokkos::full_extent);
     for(int col = 0; col < 5; ++col) {
       auto scol = Kokkos::submdspan(srow, col);
-      result += MDSPAN_OP0(scol) * (row + 1);
+      result += MDSPAN_IMPL_OP0(scol) * (row + 1);
     }
   }
   result /= 2;
@@ -309,7 +309,7 @@ mixed_submdspan_test_3() {
 }
 
 // MSVC ICE
-#ifndef MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_IMPL_COMPILER_MSVC
 MDSPAN_STATIC_TEST(
   mixed_submdspan_test_3<Kokkos::layout_right>()
 );
@@ -340,19 +340,19 @@ submdspan_single_element_stress_test_impl_2(
   auto ss_dyn = Kokkos::submdspan(s_dyn, _repeated_ptrdiff_t<0, Idxs>...);
   auto ss_all = Kokkos::submdspan(s, _repeated_with_idxs_t<Kokkos::full_extent_t, Idxs>{}...);
   auto ss_all_dyn = Kokkos::submdspan(s_dyn, _repeated_with_idxs_t<Kokkos::full_extent_t, Idxs>{}...);
-  auto val = MDSPAN_OP(ss_all, (_repeated_ptrdiff_t<0, Idxs>...));
-  auto val_dyn = MDSPAN_OP(ss_all_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val = MDSPAN_IMPL_OP(ss_all, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_dyn = MDSPAN_IMPL_OP(ss_all_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
   auto ss_pair = Kokkos::submdspan(s, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
   auto ss_pair_dyn = Kokkos::submdspan(s_dyn, _repeated_with_idxs_t<std::pair<ptrdiff_t, ptrdiff_t>, Idxs>{0, 1}...);
-  auto val_pair = MDSPAN_OP(ss_pair, (_repeated_ptrdiff_t<0, Idxs>...));
-  auto val_pair_dyn = MDSPAN_OP(ss_pair_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_pair = MDSPAN_IMPL_OP(ss_pair, (_repeated_ptrdiff_t<0, Idxs>...));
+  auto val_pair_dyn = MDSPAN_IMPL_OP(ss_pair_dyn, (_repeated_ptrdiff_t<0, Idxs>...));
   constexpr_assert_equal(42, ss());
   constexpr_assert_equal(42, ss_dyn());
   constexpr_assert_equal(42, val);
   constexpr_assert_equal(42, val_dyn);
   constexpr_assert_equal(42, val_pair);
   constexpr_assert_equal(42, val_pair_dyn);
-  return MDSPAN_OP0(ss) == 42 && MDSPAN_OP0(ss_dyn) == 42 && val == 42 && val_dyn == 42 && val_pair == 42 && val_pair_dyn == 42;
+  return MDSPAN_IMPL_OP0(ss) == 42 && MDSPAN_IMPL_OP0(ss_dyn) == 42 && val == 42 && val_dyn == 42 && val_pair == 42 && val_pair_dyn == 42;
 }
 
 template <class Layout, size_t... Sizes>
@@ -384,4 +384,4 @@ MDSPAN_STATIC_TEST(
 
 #endif // MDSPAN_DISABLE_EXPENSIVE_COMPILATION_TESTS
 
-#endif // defined(MDSPAN_USE_CONSTEXPR_14) && MDSPAN_USE_CONSTEXPR_14
+#endif // defined(MDSPAN_IMPL_USE_CONSTEXPR_14) && MDSPAN_IMPL_USE_CONSTEXPR_14

--- a/compilation_tests/ctest_mdarray_type_check.cpp
+++ b/compilation_tests/ctest_mdarray_type_check.cpp
@@ -18,7 +18,7 @@
 #include <experimental/mdarray>
 #include <complex>
 
-#if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 #include <concepts>
 #endif
 
@@ -27,7 +27,7 @@ namespace KokkosEx = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESP
 using E1 = Kokkos::extents<int32_t, Kokkos::dynamic_extent, 3>;
 using M1 = KokkosEx::mdarray<float, E1, Kokkos::layout_left>;
 
-#if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 template<class T>
 constexpr bool is_copyable = std::copyable<T>;
 #else

--- a/compilation_tests/ctest_mdarray_type_check.cpp
+++ b/compilation_tests/ctest_mdarray_type_check.cpp
@@ -18,7 +18,7 @@
 #include <experimental/mdarray>
 #include <complex>
 
-#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+#if defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 #include <concepts>
 #endif
 
@@ -27,7 +27,7 @@ namespace KokkosEx = MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESP
 using E1 = Kokkos::extents<int32_t, Kokkos::dynamic_extent, 3>;
 using M1 = KokkosEx::mdarray<float, E1, Kokkos::layout_left>;
 
-#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+#if defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 template<class T>
 constexpr bool is_copyable = std::copyable<T>;
 #else

--- a/compilation_tests/ctest_no_unique_address.cpp
+++ b/compilation_tests/ctest_no_unique_address.cpp
@@ -43,7 +43,7 @@ MDSPAN_STATIC_TEST(
   sizeof(Kokkos::extents<size_t,45, Kokkos::dynamic_extent, 1>) == sizeof(ptrdiff_t)
 );
 
-#ifdef _MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#ifdef MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS
 MDSPAN_STATIC_TEST(
   std::is_empty<Kokkos::extents<size_t,1, 2, 3>>::value
 );
@@ -65,7 +65,7 @@ MDSPAN_STATIC_TEST(
   >) == sizeof(size_t)
 );
 
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS) && !defined(_MDSPAN_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS) && !defined(MDSPAN_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 MDSPAN_STATIC_TEST(
   std::is_empty<Kokkos::layout_right::template mapping<
     Kokkos::extents<size_t,42, 123, 73>

--- a/compilation_tests/ctest_no_unique_address.cpp
+++ b/compilation_tests/ctest_no_unique_address.cpp
@@ -43,7 +43,7 @@ MDSPAN_STATIC_TEST(
   sizeof(Kokkos::extents<size_t,45, Kokkos::dynamic_extent, 1>) == sizeof(ptrdiff_t)
 );
 
-#ifdef MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#ifdef MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS
 MDSPAN_STATIC_TEST(
   std::is_empty<Kokkos::extents<size_t,1, 2, 3>>::value
 );
@@ -65,7 +65,7 @@ MDSPAN_STATIC_TEST(
   >) == sizeof(size_t)
 );
 
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS) && !defined(MDSPAN_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS) && !defined(MDSPAN_IMPL_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 MDSPAN_STATIC_TEST(
   std::is_empty<Kokkos::layout_right::template mapping<
     Kokkos::extents<size_t,42, 123, 73>

--- a/compilation_tests/ctest_standard_layout.cpp
+++ b/compilation_tests/ctest_standard_layout.cpp
@@ -132,7 +132,7 @@ struct layout_stride_as_member_should_be_standard_layout :
 };
 
 // Fails with MSVC which adds some padding
-#ifndef _MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_COMPILER_MSVC
 MDSPAN_STATIC_TEST(
   std::is_standard_layout<layout_stride_as_member_should_be_standard_layout>::value
 );

--- a/compilation_tests/ctest_standard_layout.cpp
+++ b/compilation_tests/ctest_standard_layout.cpp
@@ -132,7 +132,7 @@ struct layout_stride_as_member_should_be_standard_layout :
 };
 
 // Fails with MSVC which adds some padding
-#ifndef MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_IMPL_COMPILER_MSVC
 MDSPAN_STATIC_TEST(
   std::is_standard_layout<layout_stride_as_member_should_be_standard_layout>::value
 );
@@ -168,6 +168,3 @@ MDSPAN_STATIC_TEST(
 
 // </editor-fold> end mdspan }}}1
 //==============================================================================
-
-
-

--- a/compilation_tests/ctest_trivially_copyable.cpp
+++ b/compilation_tests/ctest_trivially_copyable.cpp
@@ -129,7 +129,7 @@ struct layout_stride_as_member_should_be_standard_layout :
 };
 
 // Fails with MSVC which adds some padding
-#ifndef _MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_COMPILER_MSVC
 MDSPAN_STATIC_TEST(
   std::is_trivially_copyable<layout_stride_as_member_should_be_standard_layout>::value
 );

--- a/compilation_tests/ctest_trivially_copyable.cpp
+++ b/compilation_tests/ctest_trivially_copyable.cpp
@@ -129,7 +129,7 @@ struct layout_stride_as_member_should_be_standard_layout :
 };
 
 // Fails with MSVC which adds some padding
-#ifndef MDSPAN_COMPILER_MSVC
+#ifndef MDSPAN_IMPL_COMPILER_MSVC
 MDSPAN_STATIC_TEST(
   std::is_trivially_copyable<layout_stride_as_member_should_be_standard_layout>::value
 );
@@ -164,6 +164,3 @@ MDSPAN_STATIC_TEST(
 
 // </editor-fold> end mdspan }}}1
 //==============================================================================
-
-
-

--- a/examples/godbolt_starter/godbolt_starter.cpp
+++ b/examples/godbolt_starter/godbolt_starter.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 // https://godbolt.org/z/ehErvsTce
 #include <mdspan/mdspan.hpp>
 #include <iostream>

--- a/examples/godbolt_starter/godbolt_starter.cpp
+++ b/examples/godbolt_starter/godbolt_starter.cpp
@@ -14,7 +14,7 @@
 //
 //@HEADER
 
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 // https://godbolt.org/z/ehErvsTce
 #include <mdspan/mdspan.hpp>
 #include <iostream>

--- a/examples/restrict_accessor/restrict_accessor.cpp
+++ b/examples/restrict_accessor/restrict_accessor.cpp
@@ -28,7 +28,7 @@
 namespace {
 
 
-#if defined(_MDSPAN_COMPILER_MSVC) || defined(__INTEL_COMPILER)
+#if defined(MDSPAN_COMPILER_MSVC) || defined(__INTEL_COMPILER)
 #  define _MDSPAN_RESTRICT_KEYWORD __restrict
 #elif defined(__GNUC__) || defined(__clang__)
 #  define _MDSPAN_RESTRICT_KEYWORD __restrict__

--- a/examples/restrict_accessor/restrict_accessor.cpp
+++ b/examples/restrict_accessor/restrict_accessor.cpp
@@ -28,7 +28,7 @@
 namespace {
 
 
-#if defined(MDSPAN_COMPILER_MSVC) || defined(__INTEL_COMPILER)
+#if defined(MDSPAN_IMPL_COMPILER_MSVC) || defined(__INTEL_COMPILER)
 #  define _MDSPAN_RESTRICT_KEYWORD __restrict
 #elif defined(__GNUC__) || defined(__clang__)
 #  define _MDSPAN_RESTRICT_KEYWORD __restrict__

--- a/include/experimental/__p0009_bits/compressed_pair.hpp
+++ b/include/experimental/__p0009_bits/compressed_pair.hpp
@@ -18,7 +18,7 @@
 #include "macros.hpp"
 #include "trait_backports.hpp"
 
-#if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  include "no_unique_address.hpp"
 #endif
 
@@ -28,8 +28,8 @@ namespace detail {
 // For no unique address emulation, this is the case taken when neither are empty.
 // For real `[[no_unique_address]]`, this case is always taken.
 template <class _T1, class _T2, class _Enable = void> struct __compressed_pair {
-  _MDSPAN_NO_UNIQUE_ADDRESS _T1 __t1_val{};
-  _MDSPAN_NO_UNIQUE_ADDRESS _T2 __t2_val{};
+  MDSPAN_NO_UNIQUE_ADDRESS _T1 __t1_val{};
+  MDSPAN_NO_UNIQUE_ADDRESS _T2 __t2_val{};
   MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T1 &__first() noexcept { return __t1_val; }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
     return __t1_val;
@@ -58,7 +58,7 @@ template <class _T1, class _T2, class _Enable = void> struct __compressed_pair {
       : __t1_val((_T1Like &&) __t1), __t2_val((_T2Like &&) __t2) {}
 };
 
-#if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 
 // First empty.
 template <class _T1, class _T2>
@@ -142,7 +142,7 @@ struct __compressed_pair<
     std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T1) && _MDSPAN_TRAIT(std::is_empty, _T2)>>
     // We need to use the __no_unique_address_emulation wrapper here to avoid
     // base class ambiguities.
-#ifdef _MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_COMPILER_MSVC
 // MSVC doesn't allow you to access public static member functions of a type
 // when you *happen* to privately inherit from that type.
     : protected __no_unique_address_emulation<_T1, 0>,
@@ -189,7 +189,7 @@ struct __compressed_pair<
   { }
 };
 
-#endif // !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#endif // !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 
 } // end namespace detail
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p0009_bits/compressed_pair.hpp
+++ b/include/experimental/__p0009_bits/compressed_pair.hpp
@@ -18,7 +18,7 @@
 #include "macros.hpp"
 #include "trait_backports.hpp"
 
-#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  include "no_unique_address.hpp"
 #endif
 
@@ -28,8 +28,8 @@ namespace detail {
 // For no unique address emulation, this is the case taken when neither are empty.
 // For real `[[no_unique_address]]`, this case is always taken.
 template <class _T1, class _T2, class _Enable = void> struct __compressed_pair {
-  MDSPAN_NO_UNIQUE_ADDRESS _T1 __t1_val{};
-  MDSPAN_NO_UNIQUE_ADDRESS _T2 __t2_val{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T1 __t1_val{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T2 __t2_val{};
   MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 _T1 &__first() noexcept { return __t1_val; }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
     return __t1_val;
@@ -58,7 +58,7 @@ template <class _T1, class _T2, class _Enable = void> struct __compressed_pair {
       : __t1_val((_T1Like &&) __t1), __t2_val((_T2Like &&) __t2) {}
 };
 
-#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 
 // First empty.
 template <class _T1, class _T2>
@@ -142,7 +142,7 @@ struct __compressed_pair<
     std::enable_if_t<_MDSPAN_TRAIT(std::is_empty, _T1) && _MDSPAN_TRAIT(std::is_empty, _T2)>>
     // We need to use the __no_unique_address_emulation wrapper here to avoid
     // base class ambiguities.
-#ifdef MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_IMPL_COMPILER_MSVC
 // MSVC doesn't allow you to access public static member functions of a type
 // when you *happen* to privately inherit from that type.
     : protected __no_unique_address_emulation<_T1, 0>,
@@ -189,7 +189,7 @@ struct __compressed_pair<
   { }
 };
 
-#endif // !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#endif // !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 
 } // end namespace detail
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -31,9 +31,9 @@
 #endif
 
 #ifdef _MSVC_LANG
-#define MDSPAN_CPLUSPLUS _MSVC_LANG
+#define MDSPAN_IMPL_CPLUSPLUS _MSVC_LANG
 #else
-#define MDSPAN_CPLUSPLUS __cplusplus
+#define MDSPAN_IMPL_CPLUSPLUS __cplusplus
 #endif
 
 #define MDSPAN_CXX_STD_14 201402L
@@ -46,56 +46,56 @@
 #define MDSPAN_CXX_STD_23 202100L
 #endif
 
-#define MDSPAN_HAS_CXX_14 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14)
-#define MDSPAN_HAS_CXX_17 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_17)
-#define MDSPAN_HAS_CXX_20 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_20)
-#define MDSPAN_HAS_CXX_23 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_23)
+#define MDSPAN_HAS_CXX_14 (MDSPAN_IMPL_CPLUSPLUS >= MDSPAN_CXX_STD_14)
+#define MDSPAN_HAS_CXX_17 (MDSPAN_IMPL_CPLUSPLUS >= MDSPAN_CXX_STD_17)
+#define MDSPAN_HAS_CXX_20 (MDSPAN_IMPL_CPLUSPLUS >= MDSPAN_CXX_STD_20)
+#define MDSPAN_HAS_CXX_23 (MDSPAN_IMPL_CPLUSPLUS >= MDSPAN_CXX_STD_23)
 
-static_assert(MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or later.");
+static_assert(MDSPAN_IMPL_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or later.");
 
-#ifndef MDSPAN_COMPILER_CLANG
+#ifndef MDSPAN_IMPL_COMPILER_CLANG
 #  if defined(__clang__)
-#    define MDSPAN_COMPILER_CLANG __clang__
+#    define MDSPAN_IMPL_COMPILER_CLANG __clang__
 #  endif
 #endif
 
-#if !defined(MDSPAN_COMPILER_MSVC) && !defined(MDSPAN_COMPILER_MSVC_CLANG)
+#if !defined(MDSPAN_IMPL_COMPILER_MSVC) && !defined(MDSPAN_IMPL_COMPILER_MSVC_CLANG)
 #  if defined(_MSC_VER)
-#    if !defined(MDSPAN_COMPILER_CLANG)
-#      define MDSPAN_COMPILER_MSVC _MSC_VER
+#    if !defined(MDSPAN_IMPL_COMPILER_CLANG)
+#      define MDSPAN_IMPL_COMPILER_MSVC _MSC_VER
 #    else
-#      define MDSPAN_COMPILER_MSVC_CLANG _MSC_VER
+#      define MDSPAN_IMPL_COMPILER_MSVC_CLANG _MSC_VER
 #    endif
 #  endif
 #endif
 
-#ifndef MDSPAN_COMPILER_INTEL
+#ifndef MDSPAN_IMPL_COMPILER_INTEL
 #  ifdef __INTEL_COMPILER
-#    define MDSPAN_COMPILER_INTEL __INTEL_COMPILER
+#    define MDSPAN_IMPL_COMPILER_INTEL __INTEL_COMPILER
 #  endif
 #endif
 
-#ifndef MDSPAN_COMPILER_APPLECLANG
+#ifndef MDSPAN_IMPL_COMPILER_APPLECLANG
 #  ifdef __apple_build_version__
-#    define MDSPAN_COMPILER_APPLECLANG __apple_build_version__
+#    define MDSPAN_IMPL_COMPILER_APPLECLANG __apple_build_version__
 #  endif
 #endif
 
-#ifndef MDSPAN_HAS_CUDA
+#ifndef MDSPAN_IMPL_HAS_CUDA
 #  if defined(__CUDACC__)
-#    define MDSPAN_HAS_CUDA __CUDACC__
+#    define MDSPAN_IMPL_HAS_CUDA __CUDACC__
 #  endif
 #endif
 
-#ifndef MDSPAN_HAS_HIP
+#ifndef MDSPAN_IMPL_HAS_HIP
 #  if defined(__HIPCC__)
-#    define MDSPAN_HAS_HIP __HIPCC__
+#    define MDSPAN_IMPL_HAS_HIP __HIPCC__
 #  endif
 #endif
 
-#ifndef MDSPAN_HAS_SYCL
+#ifndef MDSPAN_IMPL_HAS_SYCL
 #  if defined(SYCL_LANGUAGE_VERSION)
-#    define MDSPAN_HAS_SYCL SYCL_LANGUAGE_VERSION
+#    define MDSPAN_IMPL_HAS_SYCL SYCL_LANGUAGE_VERSION
 #  endif
 #endif
 
@@ -107,133 +107,133 @@ static_assert(MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or l
 #  endif
 #endif
 
-#ifndef MDSPAN_PRESERVE_STANDARD_LAYOUT
+#ifndef MDSPAN_IMPL_PRESERVE_STANDARD_LAYOUT
 // Preserve standard layout by default, but we're not removing the old version
 // that turns this off until we're sure this doesn't have an unreasonable cost
 // to the compiler or optimizer.
-#  define MDSPAN_PRESERVE_STANDARD_LAYOUT 1
+#  define MDSPAN_IMPL_PRESERVE_STANDARD_LAYOUT 1
 #endif
 
-#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  if ((MDSPAN_IMPL_HAS_CPP_ATTRIBUTE(no_unique_address) >= 201803L) && \
        (!defined(__NVCC__) || MDSPAN_HAS_CXX_20) && \
-       (!defined(MDSPAN_COMPILER_MSVC) || MDSPAN_HAS_CXX_20))
-#    define MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
-#    define MDSPAN_NO_UNIQUE_ADDRESS [[no_unique_address]]
+       (!defined(MDSPAN_IMPL_COMPILER_MSVC) || MDSPAN_HAS_CXX_20))
+#    define MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
+#    define MDSPAN_IMPL_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #  else
-#    define MDSPAN_NO_UNIQUE_ADDRESS
+#    define MDSPAN_IMPL_NO_UNIQUE_ADDRESS
 #  endif
 #endif
 
 // NVCC older than 11.6 chokes on the no-unique-address-emulation
 // so just pretend to use it (to avoid the full blown EBO workaround
 // which NVCC also doesn't like ...), and leave the macro empty
-#ifndef MDSPAN_NO_UNIQUE_ADDRESS
+#ifndef MDSPAN_IMPL_NO_UNIQUE_ADDRESS
 #  if defined(__NVCC__)
-#    define MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
-#    define MDSPAN_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#    define MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
+#    define MDSPAN_IMPL_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS
 #  endif
-#  define MDSPAN_NO_UNIQUE_ADDRESS
+#  define MDSPAN_IMPL_NO_UNIQUE_ADDRESS
 #endif
 
 // AMDs HIP compiler seems to have issues with concepts
 // it pretends concepts exist, but doesn't ship <concept>
 #ifndef __HIPCC__
-#ifndef MDSPAN_USE_CONCEPTS
+#ifndef MDSPAN_IMPL_USE_CONCEPTS
 #  if defined(__cpp_concepts) && __cpp_concepts >= 201507L
-#    define MDSPAN_USE_CONCEPTS 1
+#    define MDSPAN_IMPL_USE_CONCEPTS 1
 #  endif
 #endif
 #endif
 
-#ifndef MDSPAN_USE_FOLD_EXPRESSIONS
+#ifndef MDSPAN_IMPL_USE_FOLD_EXPRESSIONS
 #  if (defined(__cpp_fold_expressions) && __cpp_fold_expressions >= 201603L) \
           || (!defined(__cpp_fold_expressions) && MDSPAN_HAS_CXX_17)
-#    define MDSPAN_USE_FOLD_EXPRESSIONS 1
+#    define MDSPAN_IMPL_USE_FOLD_EXPRESSIONS 1
 #  endif
 #endif
 
-#ifndef MDSPAN_USE_INLINE_VARIABLES
+#ifndef MDSPAN_IMPL_USE_INLINE_VARIABLES
 #  if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L \
          || (!defined(__cpp_inline_variables) && MDSPAN_HAS_CXX_17)
-#    define MDSPAN_USE_INLINE_VARIABLES 1
+#    define MDSPAN_IMPL_USE_INLINE_VARIABLES 1
 #  endif
 #endif
 
-#ifndef MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
+#ifndef MDSPAN_IMPL_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
 #  if (!(defined(__cpp_lib_type_trait_variable_templates) && __cpp_lib_type_trait_variable_templates >= 201510L) \
           || !MDSPAN_HAS_CXX_17)
-#    if !(defined(MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_17)
-#      define MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS 1
+#    if !(defined(MDSPAN_IMPL_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_17)
+#      define MDSPAN_IMPL_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS 1
 #    endif
 #  endif
 #endif
 
-#ifndef MDSPAN_USE_VARIABLE_TEMPLATES
+#ifndef MDSPAN_IMPL_USE_VARIABLE_TEMPLATES
 #  if (defined(__cpp_variable_templates) && __cpp_variable_templates >= 201304 && MDSPAN_HAS_CXX_17) \
         || (!defined(__cpp_variable_templates) && MDSPAN_HAS_CXX_17)
-#    define MDSPAN_USE_VARIABLE_TEMPLATES 1
+#    define MDSPAN_IMPL_USE_VARIABLE_TEMPLATES 1
 #  endif
-#endif // MDSPAN_USE_VARIABLE_TEMPLATES
+#endif // MDSPAN_IMPL_USE_VARIABLE_TEMPLATES
 
-#ifndef MDSPAN_USE_CONSTEXPR_14
+#ifndef MDSPAN_IMPL_USE_CONSTEXPR_14
 #  if (defined(__cpp_constexpr) && __cpp_constexpr >= 201304) \
         || (!defined(__cpp_constexpr) && MDSPAN_HAS_CXX_14) \
         && (!(defined(__INTEL_COMPILER) && __INTEL_COMPILER <= 1700))
-#    define MDSPAN_USE_CONSTEXPR_14 1
+#    define MDSPAN_IMPL_USE_CONSTEXPR_14 1
 #  endif
 #endif
 
-#ifndef MDSPAN_USE_INTEGER_SEQUENCE
-#  if defined(MDSPAN_COMPILER_MSVC)
+#ifndef MDSPAN_IMPL_USE_INTEGER_SEQUENCE_14
+#  if defined(MDSPAN_IMPL_COMPILER_MSVC)
 #    if (defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence >= 201304)
-#      define MDSPAN_USE_INTEGER_SEQUENCE 1
+#      define MDSPAN_IMPL_USE_INTEGER_SEQUENCE_14 1
 #    endif
 #  endif
 #endif
-#ifndef MDSPAN_USE_INTEGER_SEQUENCE
+#ifndef MDSPAN_IMPL_USE_INTEGER_SEQUENCE_14
 #  if (defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence >= 201304) \
         || (!defined(__cpp_lib_integer_sequence) && MDSPAN_HAS_CXX_14) \
         /* as far as I can tell, libc++ seems to think this is a C++11 feature... */ \
         || (defined(__GLIBCXX__) && __GLIBCXX__ > 20150422 && __GNUC__ < 5 && !defined(__INTEL_CXX11_MODE__))
      // several compilers lie about integer_sequence working properly unless the C++14 standard is used
-#    define MDSPAN_USE_INTEGER_SEQUENCE 1
-#  elif defined(MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
+#    define MDSPAN_IMPL_USE_INTEGER_SEQUENCE_14 1
+#  elif defined(MDSPAN_IMPL_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
      // appleclang seems to be missing the __cpp_lib_... macros, but doesn't seem to lie about C++14 making
      // integer_sequence work
-#    define MDSPAN_USE_INTEGER_SEQUENCE 1
+#    define MDSPAN_IMPL_USE_INTEGER_SEQUENCE_14 1
 #  endif
 #endif
 
-#ifndef MDSPAN_USE_RETURN_TYPE_DEDUCTION
+#ifndef MDSPAN_IMPL_USE_RETURN_TYPE_DEDUCTION
 #  if (defined(__cpp_return_type_deduction) && __cpp_return_type_deduction >= 201304) \
           || (!defined(__cpp_return_type_deduction) && MDSPAN_HAS_CXX_14)
-#    define MDSPAN_USE_RETURN_TYPE_DEDUCTION 1
+#    define MDSPAN_IMPL_USE_RETURN_TYPE_DEDUCTION 1
 #  endif
 #endif
 
-#ifndef MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
+#ifndef MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
 #  if (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10 >= 1170)) && \
       ((defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703) || \
        (!defined(__cpp_deduction_guides) && MDSPAN_HAS_CXX_17))
-#    define MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION 1
+#    define MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION 1
 #  endif
 #endif
 
-#ifndef MDSPAN_USE_STANDARD_TRAIT_ALIASES
+#ifndef MDSPAN_IMPL_USE_STANDARD_TRAIT_ALIASES
 #  if (defined(__cpp_lib_transformation_trait_aliases) && __cpp_lib_transformation_trait_aliases >= 201304) \
           || (!defined(__cpp_lib_transformation_trait_aliases) && MDSPAN_HAS_CXX_14)
-#    define MDSPAN_USE_STANDARD_TRAIT_ALIASES 1
-#  elif defined(MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
+#    define MDSPAN_IMPL_USE_STANDARD_TRAIT_ALIASES 1
+#  elif defined(MDSPAN_IMPL_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
      // appleclang seems to be missing the __cpp_lib_... macros, but doesn't seem to lie about C++14
-#    define MDSPAN_USE_STANDARD_TRAIT_ALIASES 1
+#    define MDSPAN_IMPL_USE_STANDARD_TRAIT_ALIASES 1
 #  endif
 #endif
 
-#ifndef MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND
+#ifndef MDSPAN_IMPL_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND
 #  ifdef __GNUC__
 #    if __GNUC__ < 9
-#      define MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND 1
+#      define MDSPAN_IMPL_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND 1
 #    endif
 #  endif
 #endif
@@ -250,7 +250,7 @@ static_assert(MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or l
 #  if defined(__cpp_multidimensional_subscript)
 // The following if/else is necessary to workaround a clang issue
 // relative to using a parameter pack inside a bracket operator in C++2b/C++23 mode
-#    if defined(MDSPAN_COMPILER_CLANG) &&                                         \
+#    if defined(MDSPAN_IMPL_COMPILER_CLANG) &&                                         \
         ((__clang_major__ < 17) ||                                                 \
          (__clang_major__ == 17 && __clang_minor__ == 0 &&                         \
           __clang_patchlevel__ == 0))
@@ -272,27 +272,27 @@ static_assert(MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or l
 #endif
 
 #if MDSPAN_USE_BRACKET_OPERATOR
-#  define MDSPAN_OP(mds,...) mds[__VA_ARGS__]
+#  define MDSPAN_IMPL_OP(mds,...) mds[__VA_ARGS__]
 // Corentins demo compiler for subscript chokes on empty [] call,
 // though I believe the proposal supports it?
 #ifdef MDSPAN_NO_EMPTY_BRACKET_OPERATOR
-#  define MDSPAN_OP0(mds) mds.accessor().access(mds.data_handle(),0)
+#  define MDSPAN_IMPL_OP0(mds) mds.accessor().access(mds.data_handle(),0)
 #else
-#  define MDSPAN_OP0(mds) mds[]
+#  define MDSPAN_IMPL_OP0(mds) mds[]
 #endif
-#  define MDSPAN_OP1(mds, a) mds[a]
-#  define MDSPAN_OP2(mds, a, b) mds[a,b]
-#  define MDSPAN_OP3(mds, a, b, c) mds[a,b,c]
-#  define MDSPAN_OP4(mds, a, b, c, d) mds[a,b,c,d]
-#  define MDSPAN_OP5(mds, a, b, c, d, e) mds[a,b,c,d,e]
-#  define MDSPAN_OP6(mds, a, b, c, d, e, f) mds[a,b,c,d,e,f]
+#  define MDSPAN_IMPL_OP1(mds, a) mds[a]
+#  define MDSPAN_IMPL_OP2(mds, a, b) mds[a,b]
+#  define MDSPAN_IMPL_OP3(mds, a, b, c) mds[a,b,c]
+#  define MDSPAN_IMPL_OP4(mds, a, b, c, d) mds[a,b,c,d]
+#  define MDSPAN_IMPL_OP5(mds, a, b, c, d, e) mds[a,b,c,d,e]
+#  define MDSPAN_IMPL_OP6(mds, a, b, c, d, e, f) mds[a,b,c,d,e,f]
 #else
-#  define MDSPAN_OP(mds,...) mds(__VA_ARGS__)
-#  define MDSPAN_OP0(mds) mds()
-#  define MDSPAN_OP1(mds, a) mds(a)
-#  define MDSPAN_OP2(mds, a, b) mds(a,b)
-#  define MDSPAN_OP3(mds, a, b, c) mds(a,b,c)
-#  define MDSPAN_OP4(mds, a, b, c, d) mds(a,b,c,d)
-#  define MDSPAN_OP5(mds, a, b, c, d, e) mds(a,b,c,d,e)
-#  define MDSPAN_OP6(mds, a, b, c, d, e, f) mds(a,b,c,d,e,f)
+#  define MDSPAN_IMPL_OP(mds,...) mds(__VA_ARGS__)
+#  define MDSPAN_IMPL_OP0(mds) mds()
+#  define MDSPAN_IMPL_OP1(mds, a) mds(a)
+#  define MDSPAN_IMPL_OP2(mds, a, b) mds(a,b)
+#  define MDSPAN_IMPL_OP3(mds, a, b, c) mds(a,b,c)
+#  define MDSPAN_IMPL_OP4(mds, a, b, c, d) mds(a,b,c,d)
+#  define MDSPAN_IMPL_OP5(mds, a, b, c, d, e) mds(a,b,c,d,e)
+#  define MDSPAN_IMPL_OP6(mds, a, b, c, d, e, f) mds(a,b,c,d,e,f)
 #endif

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -15,11 +15,15 @@
 //@HEADER
 #pragma once
 
-#ifndef __has_include
-#  define __has_include(x) 0
+#ifndef MDSPAN_IMPL_HAS_INCLUDE
+#  ifndef __has_include
+#    define MDSPAN_IMPL_HAS_INCLUDE(x) 0
+#  else
+#    define MDSPAN_IMPL_HAS_INCLUDE(x) __has_include(x)
+#  endif
 #endif
 
-#if __has_include(<version>)
+#if MDSPAN_IMPL_HAS_INCLUDE(<version>)
 #  include <version>
 #else
 #  include <type_traits>
@@ -27,9 +31,9 @@
 #endif
 
 #ifdef _MSVC_LANG
-#define _MDSPAN_CPLUSPLUS _MSVC_LANG
+#define MDSPAN_CPLUSPLUS _MSVC_LANG
 #else
-#define _MDSPAN_CPLUSPLUS __cplusplus
+#define MDSPAN_CPLUSPLUS __cplusplus
 #endif
 
 #define MDSPAN_CXX_STD_14 201402L
@@ -42,190 +46,194 @@
 #define MDSPAN_CXX_STD_23 202100L
 #endif
 
-#define MDSPAN_HAS_CXX_14 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14)
-#define MDSPAN_HAS_CXX_17 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_17)
-#define MDSPAN_HAS_CXX_20 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_20)
-#define MDSPAN_HAS_CXX_23 (_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_23)
+#define MDSPAN_HAS_CXX_14 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14)
+#define MDSPAN_HAS_CXX_17 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_17)
+#define MDSPAN_HAS_CXX_20 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_20)
+#define MDSPAN_HAS_CXX_23 (MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_23)
 
-static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or later.");
+static_assert(MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or later.");
 
-#ifndef _MDSPAN_COMPILER_CLANG
+#ifndef MDSPAN_COMPILER_CLANG
 #  if defined(__clang__)
-#    define _MDSPAN_COMPILER_CLANG __clang__
+#    define MDSPAN_COMPILER_CLANG __clang__
 #  endif
 #endif
 
-#if !defined(_MDSPAN_COMPILER_MSVC) && !defined(_MDSPAN_COMPILER_MSVC_CLANG)
+#if !defined(MDSPAN_COMPILER_MSVC) && !defined(MDSPAN_COMPILER_MSVC_CLANG)
 #  if defined(_MSC_VER)
-#    if !defined(_MDSPAN_COMPILER_CLANG)
-#      define _MDSPAN_COMPILER_MSVC _MSC_VER
+#    if !defined(MDSPAN_COMPILER_CLANG)
+#      define MDSPAN_COMPILER_MSVC _MSC_VER
 #    else
-#      define _MDSPAN_COMPILER_MSVC_CLANG _MSC_VER
+#      define MDSPAN_COMPILER_MSVC_CLANG _MSC_VER
 #    endif
 #  endif
 #endif
 
-#ifndef _MDSPAN_COMPILER_INTEL
+#ifndef MDSPAN_COMPILER_INTEL
 #  ifdef __INTEL_COMPILER
-#    define _MDSPAN_COMPILER_INTEL __INTEL_COMPILER
+#    define MDSPAN_COMPILER_INTEL __INTEL_COMPILER
 #  endif
 #endif
 
-#ifndef _MDSPAN_COMPILER_APPLECLANG
+#ifndef MDSPAN_COMPILER_APPLECLANG
 #  ifdef __apple_build_version__
-#    define _MDSPAN_COMPILER_APPLECLANG __apple_build_version__
+#    define MDSPAN_COMPILER_APPLECLANG __apple_build_version__
 #  endif
 #endif
 
-#ifndef _MDSPAN_HAS_CUDA
+#ifndef MDSPAN_HAS_CUDA
 #  if defined(__CUDACC__)
-#    define _MDSPAN_HAS_CUDA __CUDACC__
+#    define MDSPAN_HAS_CUDA __CUDACC__
 #  endif
 #endif
 
-#ifndef _MDSPAN_HAS_HIP
+#ifndef MDSPAN_HAS_HIP
 #  if defined(__HIPCC__)
-#    define _MDSPAN_HAS_HIP __HIPCC__
+#    define MDSPAN_HAS_HIP __HIPCC__
 #  endif
 #endif
 
-#ifndef _MDSPAN_HAS_SYCL
+#ifndef MDSPAN_HAS_SYCL
 #  if defined(SYCL_LANGUAGE_VERSION)
-#    define _MDSPAN_HAS_SYCL SYCL_LANGUAGE_VERSION
+#    define MDSPAN_HAS_SYCL SYCL_LANGUAGE_VERSION
 #  endif
 #endif
 
-#ifndef __has_cpp_attribute
-#  define __has_cpp_attribute(x) 0
+#ifndef MDSPAN_IMPL_HAS_CPP_ATTRIBUTE
+#  ifndef __has_cpp_attribute
+#    define MDSPAN_IMPL_HAS_CPP_ATTRIBUTE(x) 0
+#  else
+#    define MDSPAN_IMPL_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+#  endif
 #endif
 
-#ifndef _MDSPAN_PRESERVE_STANDARD_LAYOUT
+#ifndef MDSPAN_PRESERVE_STANDARD_LAYOUT
 // Preserve standard layout by default, but we're not removing the old version
 // that turns this off until we're sure this doesn't have an unreasonable cost
 // to the compiler or optimizer.
-#  define _MDSPAN_PRESERVE_STANDARD_LAYOUT 1
+#  define MDSPAN_PRESERVE_STANDARD_LAYOUT 1
 #endif
 
-#if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-#  if ((__has_cpp_attribute(no_unique_address) >= 201803L) && \
+#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#  if ((MDSPAN_IMPL_HAS_CPP_ATTRIBUTE(no_unique_address) >= 201803L) && \
        (!defined(__NVCC__) || MDSPAN_HAS_CXX_20) && \
-       (!defined(_MDSPAN_COMPILER_MSVC) || MDSPAN_HAS_CXX_20))
-#    define _MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
-#    define _MDSPAN_NO_UNIQUE_ADDRESS [[no_unique_address]]
+       (!defined(MDSPAN_COMPILER_MSVC) || MDSPAN_HAS_CXX_20))
+#    define MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
+#    define MDSPAN_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #  else
-#    define _MDSPAN_NO_UNIQUE_ADDRESS
+#    define MDSPAN_NO_UNIQUE_ADDRESS
 #  endif
 #endif
 
 // NVCC older than 11.6 chokes on the no-unique-address-emulation
 // so just pretend to use it (to avoid the full blown EBO workaround
 // which NVCC also doesn't like ...), and leave the macro empty
-#ifndef _MDSPAN_NO_UNIQUE_ADDRESS
+#ifndef MDSPAN_NO_UNIQUE_ADDRESS
 #  if defined(__NVCC__)
-#    define _MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
-#    define _MDSPAN_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS
+#    define MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
+#    define MDSPAN_USE_FAKE_ATTRIBUTE_NO_UNIQUE_ADDRESS
 #  endif
-#  define _MDSPAN_NO_UNIQUE_ADDRESS
+#  define MDSPAN_NO_UNIQUE_ADDRESS
 #endif
 
 // AMDs HIP compiler seems to have issues with concepts
 // it pretends concepts exist, but doesn't ship <concept>
 #ifndef __HIPCC__
-#ifndef _MDSPAN_USE_CONCEPTS
+#ifndef MDSPAN_USE_CONCEPTS
 #  if defined(__cpp_concepts) && __cpp_concepts >= 201507L
-#    define _MDSPAN_USE_CONCEPTS 1
+#    define MDSPAN_USE_CONCEPTS 1
 #  endif
 #endif
 #endif
 
-#ifndef _MDSPAN_USE_FOLD_EXPRESSIONS
+#ifndef MDSPAN_USE_FOLD_EXPRESSIONS
 #  if (defined(__cpp_fold_expressions) && __cpp_fold_expressions >= 201603L) \
           || (!defined(__cpp_fold_expressions) && MDSPAN_HAS_CXX_17)
-#    define _MDSPAN_USE_FOLD_EXPRESSIONS 1
+#    define MDSPAN_USE_FOLD_EXPRESSIONS 1
 #  endif
 #endif
 
-#ifndef _MDSPAN_USE_INLINE_VARIABLES
+#ifndef MDSPAN_USE_INLINE_VARIABLES
 #  if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L \
          || (!defined(__cpp_inline_variables) && MDSPAN_HAS_CXX_17)
-#    define _MDSPAN_USE_INLINE_VARIABLES 1
+#    define MDSPAN_USE_INLINE_VARIABLES 1
 #  endif
 #endif
 
-#ifndef _MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
+#ifndef MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
 #  if (!(defined(__cpp_lib_type_trait_variable_templates) && __cpp_lib_type_trait_variable_templates >= 201510L) \
           || !MDSPAN_HAS_CXX_17)
-#    if !(defined(_MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_17)
-#      define _MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS 1
+#    if !(defined(MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_17)
+#      define MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS 1
 #    endif
 #  endif
 #endif
 
-#ifndef _MDSPAN_USE_VARIABLE_TEMPLATES
+#ifndef MDSPAN_USE_VARIABLE_TEMPLATES
 #  if (defined(__cpp_variable_templates) && __cpp_variable_templates >= 201304 && MDSPAN_HAS_CXX_17) \
         || (!defined(__cpp_variable_templates) && MDSPAN_HAS_CXX_17)
-#    define _MDSPAN_USE_VARIABLE_TEMPLATES 1
+#    define MDSPAN_USE_VARIABLE_TEMPLATES 1
 #  endif
-#endif // _MDSPAN_USE_VARIABLE_TEMPLATES
+#endif // MDSPAN_USE_VARIABLE_TEMPLATES
 
-#ifndef _MDSPAN_USE_CONSTEXPR_14
+#ifndef MDSPAN_USE_CONSTEXPR_14
 #  if (defined(__cpp_constexpr) && __cpp_constexpr >= 201304) \
         || (!defined(__cpp_constexpr) && MDSPAN_HAS_CXX_14) \
         && (!(defined(__INTEL_COMPILER) && __INTEL_COMPILER <= 1700))
-#    define _MDSPAN_USE_CONSTEXPR_14 1
+#    define MDSPAN_USE_CONSTEXPR_14 1
 #  endif
 #endif
 
-#ifndef _MDSPAN_USE_INTEGER_SEQUENCE
-#  if defined(_MDSPAN_COMPILER_MSVC)
+#ifndef MDSPAN_USE_INTEGER_SEQUENCE
+#  if defined(MDSPAN_COMPILER_MSVC)
 #    if (defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence >= 201304)
-#      define _MDSPAN_USE_INTEGER_SEQUENCE 1
+#      define MDSPAN_USE_INTEGER_SEQUENCE 1
 #    endif
 #  endif
 #endif
-#ifndef _MDSPAN_USE_INTEGER_SEQUENCE
+#ifndef MDSPAN_USE_INTEGER_SEQUENCE
 #  if (defined(__cpp_lib_integer_sequence) && __cpp_lib_integer_sequence >= 201304) \
         || (!defined(__cpp_lib_integer_sequence) && MDSPAN_HAS_CXX_14) \
         /* as far as I can tell, libc++ seems to think this is a C++11 feature... */ \
         || (defined(__GLIBCXX__) && __GLIBCXX__ > 20150422 && __GNUC__ < 5 && !defined(__INTEL_CXX11_MODE__))
      // several compilers lie about integer_sequence working properly unless the C++14 standard is used
-#    define _MDSPAN_USE_INTEGER_SEQUENCE 1
-#  elif defined(_MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
+#    define MDSPAN_USE_INTEGER_SEQUENCE 1
+#  elif defined(MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
      // appleclang seems to be missing the __cpp_lib_... macros, but doesn't seem to lie about C++14 making
      // integer_sequence work
-#    define _MDSPAN_USE_INTEGER_SEQUENCE 1
+#    define MDSPAN_USE_INTEGER_SEQUENCE 1
 #  endif
 #endif
 
-#ifndef _MDSPAN_USE_RETURN_TYPE_DEDUCTION
+#ifndef MDSPAN_USE_RETURN_TYPE_DEDUCTION
 #  if (defined(__cpp_return_type_deduction) && __cpp_return_type_deduction >= 201304) \
           || (!defined(__cpp_return_type_deduction) && MDSPAN_HAS_CXX_14)
-#    define _MDSPAN_USE_RETURN_TYPE_DEDUCTION 1
+#    define MDSPAN_USE_RETURN_TYPE_DEDUCTION 1
 #  endif
 #endif
 
-#ifndef _MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
+#ifndef MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
 #  if (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10 >= 1170)) && \
       ((defined(__cpp_deduction_guides) && __cpp_deduction_guides >= 201703) || \
        (!defined(__cpp_deduction_guides) && MDSPAN_HAS_CXX_17))
-#    define _MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION 1
+#    define MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION 1
 #  endif
 #endif
 
-#ifndef _MDSPAN_USE_STANDARD_TRAIT_ALIASES
+#ifndef MDSPAN_USE_STANDARD_TRAIT_ALIASES
 #  if (defined(__cpp_lib_transformation_trait_aliases) && __cpp_lib_transformation_trait_aliases >= 201304) \
           || (!defined(__cpp_lib_transformation_trait_aliases) && MDSPAN_HAS_CXX_14)
-#    define _MDSPAN_USE_STANDARD_TRAIT_ALIASES 1
-#  elif defined(_MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
+#    define MDSPAN_USE_STANDARD_TRAIT_ALIASES 1
+#  elif defined(MDSPAN_COMPILER_APPLECLANG) && MDSPAN_HAS_CXX_14
      // appleclang seems to be missing the __cpp_lib_... macros, but doesn't seem to lie about C++14
-#    define _MDSPAN_USE_STANDARD_TRAIT_ALIASES 1
+#    define MDSPAN_USE_STANDARD_TRAIT_ALIASES 1
 #  endif
 #endif
 
-#ifndef _MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND
+#ifndef MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND
 #  ifdef __GNUC__
 #    if __GNUC__ < 9
-#      define _MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND 1
+#      define MDSPAN_DEFAULTED_CONSTRUCTORS_INHERITANCE_WORKAROUND 1
 #    endif
 #  endif
 #endif
@@ -242,7 +250,7 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #  if defined(__cpp_multidimensional_subscript)
 // The following if/else is necessary to workaround a clang issue
 // relative to using a parameter pack inside a bracket operator in C++2b/C++23 mode
-#    if defined(_MDSPAN_COMPILER_CLANG) &&                                         \
+#    if defined(MDSPAN_COMPILER_CLANG) &&                                         \
         ((__clang_major__ < 17) ||                                                 \
          (__clang_major__ == 17 && __clang_minor__ == 0 &&                         \
           __clang_patchlevel__ == 0))
@@ -264,27 +272,27 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #endif
 
 #if MDSPAN_USE_BRACKET_OPERATOR
-#  define __MDSPAN_OP(mds,...) mds[__VA_ARGS__]
+#  define MDSPAN_OP(mds,...) mds[__VA_ARGS__]
 // Corentins demo compiler for subscript chokes on empty [] call,
 // though I believe the proposal supports it?
 #ifdef MDSPAN_NO_EMPTY_BRACKET_OPERATOR
-#  define __MDSPAN_OP0(mds) mds.accessor().access(mds.data_handle(),0)
+#  define MDSPAN_OP0(mds) mds.accessor().access(mds.data_handle(),0)
 #else
-#  define __MDSPAN_OP0(mds) mds[]
+#  define MDSPAN_OP0(mds) mds[]
 #endif
-#  define __MDSPAN_OP1(mds, a) mds[a]
-#  define __MDSPAN_OP2(mds, a, b) mds[a,b]
-#  define __MDSPAN_OP3(mds, a, b, c) mds[a,b,c]
-#  define __MDSPAN_OP4(mds, a, b, c, d) mds[a,b,c,d]
-#  define __MDSPAN_OP5(mds, a, b, c, d, e) mds[a,b,c,d,e]
-#  define __MDSPAN_OP6(mds, a, b, c, d, e, f) mds[a,b,c,d,e,f]
+#  define MDSPAN_OP1(mds, a) mds[a]
+#  define MDSPAN_OP2(mds, a, b) mds[a,b]
+#  define MDSPAN_OP3(mds, a, b, c) mds[a,b,c]
+#  define MDSPAN_OP4(mds, a, b, c, d) mds[a,b,c,d]
+#  define MDSPAN_OP5(mds, a, b, c, d, e) mds[a,b,c,d,e]
+#  define MDSPAN_OP6(mds, a, b, c, d, e, f) mds[a,b,c,d,e,f]
 #else
-#  define __MDSPAN_OP(mds,...) mds(__VA_ARGS__)
-#  define __MDSPAN_OP0(mds) mds()
-#  define __MDSPAN_OP1(mds, a) mds(a)
-#  define __MDSPAN_OP2(mds, a, b) mds(a,b)
-#  define __MDSPAN_OP3(mds, a, b, c) mds(a,b,c)
-#  define __MDSPAN_OP4(mds, a, b, c, d) mds(a,b,c,d)
-#  define __MDSPAN_OP5(mds, a, b, c, d, e) mds(a,b,c,d,e)
-#  define __MDSPAN_OP6(mds, a, b, c, d, e, f) mds(a,b,c,d,e,f)
+#  define MDSPAN_OP(mds,...) mds(__VA_ARGS__)
+#  define MDSPAN_OP0(mds) mds()
+#  define MDSPAN_OP1(mds, a) mds(a)
+#  define MDSPAN_OP2(mds, a, b) mds(a,b)
+#  define MDSPAN_OP3(mds, a, b, c) mds(a,b,c)
+#  define MDSPAN_OP4(mds, a, b, c, d) mds(a,b,c,d)
+#  define MDSPAN_OP5(mds, a, b, c, d, e) mds(a,b,c,d,e)
+#  define MDSPAN_OP6(mds, a, b, c, d, e, f) mds(a,b,c,d,e,f)
 #endif

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -154,7 +154,7 @@ struct index_sequence_scan_impl<R, FirstVal, Values...> {
 template <size_t R, size_t FirstVal>
 struct index_sequence_scan_impl<R, FirstVal> {
 #if defined(__NVCC__) || defined(__NVCOMPILER) ||                              \
-    defined(_MDSPAN_COMPILER_INTEL)
+    defined(MDSPAN_COMPILER_INTEL)
   // NVCC warns about pointless comparison with 0 for R==0 and r being const
   // evaluatable and also 0.
   MDSPAN_INLINE_FUNCTION
@@ -217,7 +217,7 @@ private:
       _MDSPAN_FOLD_PLUS_RIGHT((Values == dyn_tag), 0);
 
   // Dynamic values member
-  _MDSPAN_NO_UNIQUE_ADDRESS possibly_empty_array<TDynamic, m_size_dynamic>
+  MDSPAN_NO_UNIQUE_ADDRESS possibly_empty_array<TDynamic, m_size_dynamic>
       m_dyn_vals;
 
   // static mapping of indices to the position in the dynamic values array
@@ -403,7 +403,7 @@ private:
   // internal storage type using maybe_static_array
   using vals_t =
       detail::maybe_static_array<IndexType, size_t, dynamic_extent, Extents...>;
-  _MDSPAN_NO_UNIQUE_ADDRESS vals_t m_vals;
+  MDSPAN_NO_UNIQUE_ADDRESS vals_t m_vals;
 
 public:
   // [mdspan.extents.obs], observers of multidimensional index space
@@ -590,7 +590,7 @@ template <class IndexType, size_t Rank>
 using dextents = typename detail::__make_dextents<IndexType, Rank>::type;
 
 // Deduction guide for extents
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 template <class... IndexTypes>
 extents(IndexTypes...)
     -> extents<size_t,

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -154,7 +154,7 @@ struct index_sequence_scan_impl<R, FirstVal, Values...> {
 template <size_t R, size_t FirstVal>
 struct index_sequence_scan_impl<R, FirstVal> {
 #if defined(__NVCC__) || defined(__NVCOMPILER) ||                              \
-    defined(MDSPAN_COMPILER_INTEL)
+    defined(MDSPAN_IMPL_COMPILER_INTEL)
   // NVCC warns about pointless comparison with 0 for R==0 and r being const
   // evaluatable and also 0.
   MDSPAN_INLINE_FUNCTION
@@ -217,7 +217,7 @@ private:
       _MDSPAN_FOLD_PLUS_RIGHT((Values == dyn_tag), 0);
 
   // Dynamic values member
-  MDSPAN_NO_UNIQUE_ADDRESS possibly_empty_array<TDynamic, m_size_dynamic>
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS possibly_empty_array<TDynamic, m_size_dynamic>
       m_dyn_vals;
 
   // static mapping of indices to the position in the dynamic values array
@@ -403,7 +403,7 @@ private:
   // internal storage type using maybe_static_array
   using vals_t =
       detail::maybe_static_array<IndexType, size_t, dynamic_extent, Extents...>;
-  MDSPAN_NO_UNIQUE_ADDRESS vals_t m_vals;
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS vals_t m_vals;
 
 public:
   // [mdspan.extents.obs], observers of multidimensional index space
@@ -590,7 +590,7 @@ template <class IndexType, size_t Rank>
 using dextents = typename detail::__make_dextents<IndexType, Rank>::type;
 
 // Deduction guide for extents
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 template <class... IndexTypes>
 extents(IndexTypes...)
     -> extents<size_t,

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -248,7 +248,7 @@ class layout_left::mapping {
     }
 
 private:
-   _MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
 
    // [mdspan.submdspan.mapping], submdspan mapping specialization
    template<class... SliceSpecifiers>

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -248,7 +248,7 @@ class layout_left::mapping {
     }
 
 private:
-   MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type __extents{};
 
    // [mdspan.submdspan.mapping], submdspan mapping specialization
    template<class... SliceSpecifiers>
@@ -266,4 +266,3 @@ private:
 
 
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
-

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -245,7 +245,7 @@ class layout_right::mapping {
     }
 
 private:
-   _MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
 
    // [mdspan.submdspan.mapping], submdspan mapping specialization
    template<class... SliceSpecifiers>

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -245,7 +245,7 @@ class layout_right::mapping {
     }
 
 private:
-   MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type __extents{};
 
    // [mdspan.submdspan.mapping], submdspan mapping specialization
    template<class... SliceSpecifiers>
@@ -262,4 +262,3 @@ private:
 };
 
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
-

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -21,7 +21,7 @@
 #include "compressed_pair.hpp"
 #include "utility.hpp"
 
-#if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  include "no_unique_address.hpp"
 #endif
 
@@ -32,7 +32,7 @@
 #ifdef __cpp_lib_span
 #include <span>
 #endif
-#if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20 && defined(__cpp_lib_concepts)
+#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20 && defined(__cpp_lib_concepts)
 #  include <concepts>
 #endif
 
@@ -52,7 +52,7 @@ namespace detail {
   constexpr bool __is_mapping_of =
     std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
 
-#if defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 #  if !defined(__cpp_lib_concepts)
   namespace internal {
   namespace detail {
@@ -87,7 +87,7 @@ namespace detail {
 struct layout_stride {
   template <class Extents>
   class mapping
-#if !defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     : private detail::__no_unique_address_emulation<
         detail::__compressed_pair<
           Extents,
@@ -115,15 +115,15 @@ struct layout_stride {
     using __strides_storage_t = detail::possibly_empty_array<index_type, extents_type::rank()>;
     using __member_pair_t = detail::__compressed_pair<extents_type, __strides_storage_t>;
 
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-    _MDSPAN_NO_UNIQUE_ADDRESS __member_pair_t __members;
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+    MDSPAN_NO_UNIQUE_ADDRESS __member_pair_t __members;
 #else
     using __base_t = detail::__no_unique_address_emulation<__member_pair_t>;
 #endif
 
     MDSPAN_FORCE_INLINE_FUNCTION constexpr __strides_storage_t const&
     __strides_storage() const noexcept {
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return __members.__second();
 #else
       return this->__base_t::__ref().__second();
@@ -131,7 +131,7 @@ struct layout_stride {
     }
     MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 __strides_storage_t&
     __strides_storage() noexcept {
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return __members.__second();
 #else
       return this->__base_t::__ref().__second();
@@ -258,7 +258,7 @@ struct layout_stride {
 
     //----------------------------------------------------------------------------
 
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     MDSPAN_INLINE_FUNCTION constexpr explicit
     mapping(__member_pair_t&& __m) : __members(::std::move(__m)) {}
 #else
@@ -271,14 +271,14 @@ struct layout_stride {
     //--------------------------------------------------------------------------------
 
     MDSPAN_INLINE_FUNCTION constexpr mapping() noexcept
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           extents_type(),
           __strides_storage_t(strides_storage(detail::with_rank<extents_type::rank()>{}))
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -301,13 +301,13 @@ struct layout_stride {
       extents_type const& e,
       std::array<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           e, __strides_storage_t(__impl::fill_strides(s))
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -340,13 +340,13 @@ struct layout_stride {
       // Need to avoid zero-length c-array
       const IntegralTypes (&s)[extents_type::rank()>0?extents_type::rank():1]
     ) noexcept
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           e, __strides_storage_t(__impl::fill_strides(mdspan_non_standard, s))
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -377,13 +377,13 @@ struct layout_stride {
       extents_type const& e,
       std::span<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           e, __strides_storage_t(__impl::fill_strides(s))
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -400,7 +400,7 @@ struct layout_stride {
     }
 #endif // __cpp_lib_span
 
-#if !(defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
+#if !(defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
     MDSPAN_TEMPLATE_REQUIRES(
       class StridedLayoutMapping,
       /* requires */ (
@@ -427,13 +427,13 @@ struct layout_stride {
     ) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(StridedLayoutMapping const& other) noexcept // NOLINT(google-explicit-constructor)
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           other.extents(), __strides_storage_t(__impl::fill_strides(other))
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -453,7 +453,7 @@ struct layout_stride {
     mapping& operator=(mapping const&) noexcept = default;
 
     MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept {
-#if defined(_MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return __members.__first();
 #else
       return this->__base_t::__ref().__first();
@@ -555,7 +555,7 @@ struct layout_stride {
       return __strides_storage()[r];
     }
 
-#if !(defined(_MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
+#if !(defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
     MDSPAN_TEMPLATE_REQUIRES(
       class StridedLayoutMapping,
       /* requires */ (

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -21,7 +21,7 @@
 #include "compressed_pair.hpp"
 #include "utility.hpp"
 
-#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  include "no_unique_address.hpp"
 #endif
 
@@ -32,7 +32,7 @@
 #ifdef __cpp_lib_span
 #include <span>
 #endif
-#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20 && defined(__cpp_lib_concepts)
+#if defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20 && defined(__cpp_lib_concepts)
 #  include <concepts>
 #endif
 
@@ -52,7 +52,7 @@ namespace detail {
   constexpr bool __is_mapping_of =
     std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
 
-#if defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
+#if defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 #  if !defined(__cpp_lib_concepts)
   namespace internal {
   namespace detail {
@@ -87,7 +87,7 @@ namespace detail {
 struct layout_stride {
   template <class Extents>
   class mapping
-#if !defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     : private detail::__no_unique_address_emulation<
         detail::__compressed_pair<
           Extents,
@@ -115,15 +115,15 @@ struct layout_stride {
     using __strides_storage_t = detail::possibly_empty_array<index_type, extents_type::rank()>;
     using __member_pair_t = detail::__compressed_pair<extents_type, __strides_storage_t>;
 
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-    MDSPAN_NO_UNIQUE_ADDRESS __member_pair_t __members;
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+    MDSPAN_IMPL_NO_UNIQUE_ADDRESS __member_pair_t __members;
 #else
     using __base_t = detail::__no_unique_address_emulation<__member_pair_t>;
 #endif
 
     MDSPAN_FORCE_INLINE_FUNCTION constexpr __strides_storage_t const&
     __strides_storage() const noexcept {
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return __members.__second();
 #else
       return this->__base_t::__ref().__second();
@@ -131,7 +131,7 @@ struct layout_stride {
     }
     MDSPAN_FORCE_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14 __strides_storage_t&
     __strides_storage() noexcept {
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return __members.__second();
 #else
       return this->__base_t::__ref().__second();
@@ -258,7 +258,7 @@ struct layout_stride {
 
     //----------------------------------------------------------------------------
 
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     MDSPAN_INLINE_FUNCTION constexpr explicit
     mapping(__member_pair_t&& __m) : __members(::std::move(__m)) {}
 #else
@@ -271,14 +271,14 @@ struct layout_stride {
     //--------------------------------------------------------------------------------
 
     MDSPAN_INLINE_FUNCTION constexpr mapping() noexcept
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           extents_type(),
           __strides_storage_t(strides_storage(detail::with_rank<extents_type::rank()>{}))
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -301,13 +301,13 @@ struct layout_stride {
       extents_type const& e,
       std::array<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           e, __strides_storage_t(__impl::fill_strides(s))
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -340,13 +340,13 @@ struct layout_stride {
       // Need to avoid zero-length c-array
       const IntegralTypes (&s)[extents_type::rank()>0?extents_type::rank():1]
     ) noexcept
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           e, __strides_storage_t(__impl::fill_strides(mdspan_non_standard, s))
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -377,13 +377,13 @@ struct layout_stride {
       extents_type const& e,
       std::span<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           e, __strides_storage_t(__impl::fill_strides(s))
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -400,7 +400,7 @@ struct layout_stride {
     }
 #endif // __cpp_lib_span
 
-#if !(defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
+#if !(defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
     MDSPAN_TEMPLATE_REQUIRES(
       class StridedLayoutMapping,
       /* requires */ (
@@ -427,13 +427,13 @@ struct layout_stride {
     ) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION _MDSPAN_CONSTEXPR_14
     mapping(StridedLayoutMapping const& other) noexcept // NOLINT(google-explicit-constructor)
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       : __members{
 #else
       : __base_t(__base_t{__member_pair_t(
 #endif
           other.extents(), __strides_storage_t(__impl::fill_strides(other))
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
         )})
@@ -453,7 +453,7 @@ struct layout_stride {
     mapping& operator=(mapping const&) noexcept = default;
 
     MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept {
-#if defined(MDSPAN_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
+#if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return __members.__first();
 #else
       return this->__base_t::__ref().__first();
@@ -555,7 +555,7 @@ struct layout_stride {
       return __strides_storage()[r];
     }
 
-#if !(defined(MDSPAN_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
+#if !(defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
     MDSPAN_TEMPLATE_REQUIRES(
       class StridedLayoutMapping,
       /* requires */ (

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -21,12 +21,12 @@
 #include <cstdio>
 #include <cstdlib>
 #include <type_traits> // std::is_void
-#if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_SYCL)
+#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_SYCL)
 #include "assert.h"
 #endif
 
 #ifndef _MDSPAN_HOST_DEVICE
-#  if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP)
+#  if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP)
 #    define _MDSPAN_HOST_DEVICE __host__ __device__
 #  else
 #    define _MDSPAN_HOST_DEVICE
@@ -34,7 +34,7 @@
 #endif
 
 #ifndef MDSPAN_FORCE_INLINE_FUNCTION
-#  ifdef _MDSPAN_COMPILER_MSVC // Microsoft compilers
+#  ifdef MDSPAN_COMPILER_MSVC // Microsoft compilers
 #    define MDSPAN_FORCE_INLINE_FUNCTION __forceinline _MDSPAN_HOST_DEVICE
 #  else
 #    define MDSPAN_FORCE_INLINE_FUNCTION __attribute__((always_inline)) _MDSPAN_HOST_DEVICE
@@ -49,7 +49,7 @@
 #  define MDSPAN_FUNCTION _MDSPAN_HOST_DEVICE
 #endif
 
-#ifdef _MDSPAN_HAS_HIP
+#ifdef MDSPAN_HAS_HIP
 #  define MDSPAN_DEDUCTION_GUIDE _MDSPAN_HOST_DEVICE
 #else
 #  define MDSPAN_DEDUCTION_GUIDE
@@ -109,13 +109,13 @@
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 namespace detail {
 
-#if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP)
+#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP)
 MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
 {
   printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
   assert(0);
 }
-#elif defined(_MDSPAN_HAS_SYCL)
+#elif defined(MDSPAN_HAS_SYCL)
 MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
 {
   sycl::ext::oneapi::experimental::printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
@@ -177,7 +177,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 
 // These compatibility macros don't help with partial ordering, but they should do the trick
 // for what we need to do with concepts in mdspan
-#ifdef _MDSPAN_USE_CONCEPTS
+#ifdef MDSPAN_USE_CONCEPTS
 #  define MDSPAN_CLOSE_ANGLE_REQUIRES(REQ) > requires REQ
 #  define MDSPAN_FUNCTION_REQUIRES(PAREN_PREQUALS, FNAME, PAREN_PARAMS, QUALS, REQ) \
      MDSPAN_PP_REMOVE_PARENS(PAREN_PREQUALS) FNAME PAREN_PARAMS QUALS requires REQ \
@@ -192,7 +192,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
      /**/
 #endif
 
-#if defined(_MDSPAN_COMPILER_MSVC) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
+#if defined(MDSPAN_COMPILER_MSVC) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
 #  define MDSPAN_TEMPLATE_REQUIRES(...) \
       MDSPAN_PP_CAT( \
         MDSPAN_PP_CAT(MDSPAN_TEMPLATE_REQUIRES_, MDSPAN_PP_COUNT(__VA_ARGS__))\
@@ -298,7 +298,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 //==============================================================================
 // <editor-fold desc="inline variables"> {{{1
 
-#ifdef _MDSPAN_USE_INLINE_VARIABLES
+#ifdef MDSPAN_USE_INLINE_VARIABLES
 #  define _MDSPAN_INLINE_VARIABLE inline
 #else
 #  define _MDSPAN_INLINE_VARIABLE
@@ -310,7 +310,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 //==============================================================================
 // <editor-fold desc="Return type deduction"> {{{1
 
-#if _MDSPAN_USE_RETURN_TYPE_DEDUCTION
+#if MDSPAN_USE_RETURN_TYPE_DEDUCTION
 #  define _MDSPAN_DEDUCE_RETURN_TYPE_SINGLE_LINE(SIGNATURE, BODY) \
     auto MDSPAN_PP_REMOVE_PARENS(SIGNATURE) { return MDSPAN_PP_REMOVE_PARENS(BODY); }
 #  define _MDSPAN_DEDUCE_DECLTYPE_AUTO_RETURN_TYPE_SINGLE_LINE(SIGNATURE, BODY) \
@@ -335,7 +335,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 
 struct __mdspan_enable_fold_comma { };
 
-#ifdef _MDSPAN_USE_FOLD_EXPRESSIONS
+#ifdef MDSPAN_USE_FOLD_EXPRESSIONS
 #  define _MDSPAN_FOLD_AND(...) ((__VA_ARGS__) && ...)
 #  define _MDSPAN_FOLD_AND_TEMPLATE(...) ((__VA_ARGS__) && ...)
 #  define _MDSPAN_FOLD_OR(...) ((__VA_ARGS__) || ...)
@@ -353,7 +353,7 @@ namespace __fold_compatibility_impl {
 // We could probably be more clever here, but at the (small) risk of losing some compiler understanding.  For the
 // few operations we need, it's not worth generalizing over the operation
 
-#if _MDSPAN_USE_RETURN_TYPE_DEDUCTION
+#if MDSPAN_USE_RETURN_TYPE_DEDUCTION
 
 MDSPAN_FORCE_INLINE_FUNCTION
 constexpr decltype(auto) __fold_right_and_impl() {
@@ -670,7 +670,7 @@ struct __bools;
 //==============================================================================
 // <editor-fold desc="Variable template compatibility"> {{{1
 
-#if _MDSPAN_USE_VARIABLE_TEMPLATES
+#if MDSPAN_USE_VARIABLE_TEMPLATES
 #  define _MDSPAN_TRAIT(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
 #else
 #  define _MDSPAN_TRAIT(TRAIT, ...) TRAIT<__VA_ARGS__>::value
@@ -682,7 +682,7 @@ struct __bools;
 //==============================================================================
 // <editor-fold desc="Pre-C++14 constexpr"> {{{1
 
-#if _MDSPAN_USE_CONSTEXPR_14
+#if MDSPAN_USE_CONSTEXPR_14
 #  define _MDSPAN_CONSTEXPR_14 constexpr
 // Workaround for a bug (I think?) in EDG frontends
 #  ifdef __EDG__

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -21,12 +21,12 @@
 #include <cstdio>
 #include <cstdlib>
 #include <type_traits> // std::is_void
-#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_SYCL)
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
 #include "assert.h"
 #endif
 
 #ifndef _MDSPAN_HOST_DEVICE
-#  if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP)
+#  if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP)
 #    define _MDSPAN_HOST_DEVICE __host__ __device__
 #  else
 #    define _MDSPAN_HOST_DEVICE
@@ -34,7 +34,7 @@
 #endif
 
 #ifndef MDSPAN_FORCE_INLINE_FUNCTION
-#  ifdef MDSPAN_COMPILER_MSVC // Microsoft compilers
+#  ifdef MDSPAN_IMPL_COMPILER_MSVC // Microsoft compilers
 #    define MDSPAN_FORCE_INLINE_FUNCTION __forceinline _MDSPAN_HOST_DEVICE
 #  else
 #    define MDSPAN_FORCE_INLINE_FUNCTION __attribute__((always_inline)) _MDSPAN_HOST_DEVICE
@@ -49,7 +49,7 @@
 #  define MDSPAN_FUNCTION _MDSPAN_HOST_DEVICE
 #endif
 
-#ifdef MDSPAN_HAS_HIP
+#ifdef MDSPAN_IMPL_HAS_HIP
 #  define MDSPAN_DEDUCTION_GUIDE _MDSPAN_HOST_DEVICE
 #else
 #  define MDSPAN_DEDUCTION_GUIDE
@@ -109,13 +109,13 @@
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 namespace detail {
 
-#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP)
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP)
 MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
 {
   printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
   assert(0);
 }
-#elif defined(MDSPAN_HAS_SYCL)
+#elif defined(MDSPAN_IMPL_HAS_SYCL)
 MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
 {
   sycl::ext::oneapi::experimental::printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
@@ -177,7 +177,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 
 // These compatibility macros don't help with partial ordering, but they should do the trick
 // for what we need to do with concepts in mdspan
-#ifdef MDSPAN_USE_CONCEPTS
+#ifdef MDSPAN_IMPL_USE_CONCEPTS
 #  define MDSPAN_CLOSE_ANGLE_REQUIRES(REQ) > requires REQ
 #  define MDSPAN_FUNCTION_REQUIRES(PAREN_PREQUALS, FNAME, PAREN_PARAMS, QUALS, REQ) \
      MDSPAN_PP_REMOVE_PARENS(PAREN_PREQUALS) FNAME PAREN_PARAMS QUALS requires REQ \
@@ -192,7 +192,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
      /**/
 #endif
 
-#if defined(MDSPAN_COMPILER_MSVC) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
+#if defined(MDSPAN_IMPL_COMPILER_MSVC) && (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL)
 #  define MDSPAN_TEMPLATE_REQUIRES(...) \
       MDSPAN_PP_CAT( \
         MDSPAN_PP_CAT(MDSPAN_TEMPLATE_REQUIRES_, MDSPAN_PP_COUNT(__VA_ARGS__))\
@@ -298,7 +298,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 //==============================================================================
 // <editor-fold desc="inline variables"> {{{1
 
-#ifdef MDSPAN_USE_INLINE_VARIABLES
+#ifdef MDSPAN_IMPL_USE_INLINE_VARIABLES
 #  define _MDSPAN_INLINE_VARIABLE inline
 #else
 #  define _MDSPAN_INLINE_VARIABLE
@@ -310,7 +310,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 //==============================================================================
 // <editor-fold desc="Return type deduction"> {{{1
 
-#if MDSPAN_USE_RETURN_TYPE_DEDUCTION
+#if MDSPAN_IMPL_USE_RETURN_TYPE_DEDUCTION
 #  define _MDSPAN_DEDUCE_RETURN_TYPE_SINGLE_LINE(SIGNATURE, BODY) \
     auto MDSPAN_PP_REMOVE_PARENS(SIGNATURE) { return MDSPAN_PP_REMOVE_PARENS(BODY); }
 #  define _MDSPAN_DEDUCE_DECLTYPE_AUTO_RETURN_TYPE_SINGLE_LINE(SIGNATURE, BODY) \
@@ -335,7 +335,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 
 struct __mdspan_enable_fold_comma { };
 
-#ifdef MDSPAN_USE_FOLD_EXPRESSIONS
+#ifdef MDSPAN_IMPL_USE_FOLD_EXPRESSIONS
 #  define _MDSPAN_FOLD_AND(...) ((__VA_ARGS__) && ...)
 #  define _MDSPAN_FOLD_AND_TEMPLATE(...) ((__VA_ARGS__) && ...)
 #  define _MDSPAN_FOLD_OR(...) ((__VA_ARGS__) || ...)
@@ -353,7 +353,7 @@ namespace __fold_compatibility_impl {
 // We could probably be more clever here, but at the (small) risk of losing some compiler understanding.  For the
 // few operations we need, it's not worth generalizing over the operation
 
-#if MDSPAN_USE_RETURN_TYPE_DEDUCTION
+#if MDSPAN_IMPL_USE_RETURN_TYPE_DEDUCTION
 
 MDSPAN_FORCE_INLINE_FUNCTION
 constexpr decltype(auto) __fold_right_and_impl() {
@@ -670,7 +670,7 @@ struct __bools;
 //==============================================================================
 // <editor-fold desc="Variable template compatibility"> {{{1
 
-#if MDSPAN_USE_VARIABLE_TEMPLATES
+#if MDSPAN_IMPL_USE_VARIABLE_TEMPLATES
 #  define _MDSPAN_TRAIT(TRAIT, ...) TRAIT##_v<__VA_ARGS__>
 #else
 #  define _MDSPAN_TRAIT(TRAIT, ...) TRAIT<__VA_ARGS__>::value
@@ -682,7 +682,7 @@ struct __bools;
 //==============================================================================
 // <editor-fold desc="Pre-C++14 constexpr"> {{{1
 
-#if MDSPAN_USE_CONSTEXPR_14
+#if MDSPAN_IMPL_USE_CONSTEXPR_14
 #  define _MDSPAN_CONSTEXPR_14 constexpr
 // Workaround for a bug (I think?) in EDG frontends
 #  ifdef __EDG__

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -333,7 +333,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   friend constexpr void swap(mdspan& x, mdspan& y) noexcept {
     // can't call the std::swap inside on HIP
-    #if !defined(_MDSPAN_HAS_HIP) && !defined(_MDSPAN_HAS_CUDA)
+    #if !defined(MDSPAN_HAS_HIP) && !defined(MDSPAN_HAS_CUDA)
     using std::swap;
     swap(x.__ptr_ref(), y.__ptr_ref());
     swap(x.__mapping_ref(), y.__mapping_ref());
@@ -382,7 +382,7 @@ private:
 
 };
 
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 MDSPAN_TEMPLATE_REQUIRES(
   class ElementType, class... SizeTypes,
   /* requires */ _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, SizeTypes, size_t) /* && ... */) &&

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -333,7 +333,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   friend constexpr void swap(mdspan& x, mdspan& y) noexcept {
     // can't call the std::swap inside on HIP
-    #if !defined(MDSPAN_HAS_HIP) && !defined(MDSPAN_HAS_CUDA)
+    #if !defined(MDSPAN_IMPL_HAS_HIP) && !defined(MDSPAN_IMPL_HAS_CUDA)
     using std::swap;
     swap(x.__ptr_ref(), y.__ptr_ref());
     swap(x.__mapping_ref(), y.__mapping_ref());
@@ -382,7 +382,7 @@ private:
 
 };
 
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 MDSPAN_TEMPLATE_REQUIRES(
   class ElementType, class... SizeTypes,
   /* requires */ _MDSPAN_FOLD_AND(_MDSPAN_TRAIT(std::is_convertible, SizeTypes, size_t) /* && ... */) &&

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -46,7 +46,7 @@ struct __no_unique_address_emulation<
                 // won't be called at the right time, so don't use this
                 // specialization
                 _MDSPAN_TRAIT(std::is_trivially_destructible, _T)>> :
-#ifdef _MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_COMPILER_MSVC
     // MSVC doesn't allow you to access public static member functions of a type
     // when you *happen* to privately inherit from that type.
     protected

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -46,7 +46,7 @@ struct __no_unique_address_emulation<
                 // won't be called at the right time, so don't use this
                 // specialization
                 _MDSPAN_TRAIT(std::is_trivially_destructible, _T)>> :
-#ifdef MDSPAN_COMPILER_MSVC
+#ifdef MDSPAN_IMPL_COMPILER_MSVC
     // MSVC doesn't allow you to access public static member functions of a type
     // when you *happen* to privately inherit from that type.
     protected

--- a/include/experimental/__p0009_bits/trait_backports.hpp
+++ b/include/experimental/__p0009_bits/trait_backports.hpp
@@ -25,9 +25,9 @@
 //==============================================================================
 // <editor-fold desc="Variable template trait backports (e.g., is_void_v)"> {{{1
 
-#ifdef _MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
+#ifdef MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
 
-#if _MDSPAN_USE_VARIABLE_TEMPLATES
+#if MDSPAN_USE_VARIABLE_TEMPLATES
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
 #define _MDSPAN_BACKPORT_TRAIT(TRAIT) \
@@ -46,9 +46,9 @@ _MDSPAN_BACKPORT_TRAIT(is_void)
 
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
-#endif // _MDSPAN_USE_VARIABLE_TEMPLATES
+#endif // MDSPAN_USE_VARIABLE_TEMPLATES
 
-#endif // _MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
+#endif // MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
 
 // </editor-fold> end Variable template trait backports (e.g., is_void_v) }}}1
 //==============================================================================
@@ -56,7 +56,7 @@ _MDSPAN_BACKPORT_TRAIT(is_void)
 //==============================================================================
 // <editor-fold desc="integer sequence (ugh...)"> {{{1
 
-#if !defined(_MDSPAN_USE_INTEGER_SEQUENCE) || !_MDSPAN_USE_INTEGER_SEQUENCE
+#if !defined(MDSPAN_USE_INTEGER_SEQUENCE) || !MDSPAN_USE_INTEGER_SEQUENCE
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
@@ -107,7 +107,7 @@ using index_sequence_for = make_index_sequence<sizeof...(T)>;
 //==============================================================================
 // <editor-fold desc="standard trait aliases"> {{{1
 
-#if !defined(_MDSPAN_USE_STANDARD_TRAIT_ALIASES) || !_MDSPAN_USE_STANDARD_TRAIT_ALIASES
+#if !defined(MDSPAN_USE_STANDARD_TRAIT_ALIASES) || !MDSPAN_USE_STANDARD_TRAIT_ALIASES
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 

--- a/include/experimental/__p0009_bits/trait_backports.hpp
+++ b/include/experimental/__p0009_bits/trait_backports.hpp
@@ -25,9 +25,9 @@
 //==============================================================================
 // <editor-fold desc="Variable template trait backports (e.g., is_void_v)"> {{{1
 
-#ifdef MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
+#ifdef MDSPAN_IMPL_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
 
-#if MDSPAN_USE_VARIABLE_TEMPLATES
+#if MDSPAN_IMPL_USE_VARIABLE_TEMPLATES
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
 #define _MDSPAN_BACKPORT_TRAIT(TRAIT) \
@@ -46,9 +46,9 @@ _MDSPAN_BACKPORT_TRAIT(is_void)
 
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
-#endif // MDSPAN_USE_VARIABLE_TEMPLATES
+#endif // MDSPAN_IMPL_USE_VARIABLE_TEMPLATES
 
-#endif // MDSPAN_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
+#endif // MDSPAN_IMPL_NEEDS_TRAIT_VARIABLE_TEMPLATE_BACKPORTS
 
 // </editor-fold> end Variable template trait backports (e.g., is_void_v) }}}1
 //==============================================================================
@@ -56,7 +56,7 @@ _MDSPAN_BACKPORT_TRAIT(is_void)
 //==============================================================================
 // <editor-fold desc="integer sequence (ugh...)"> {{{1
 
-#if !defined(MDSPAN_USE_INTEGER_SEQUENCE) || !MDSPAN_USE_INTEGER_SEQUENCE
+#if !defined(MDSPAN_IMPL_USE_INTEGER_SEQUENCE_14) || !MDSPAN_IMPL_USE_INTEGER_SEQUENCE_14
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
@@ -107,7 +107,7 @@ using index_sequence_for = make_index_sequence<sizeof...(T)>;
 //==============================================================================
 // <editor-fold desc="standard trait aliases"> {{{1
 
-#if !defined(MDSPAN_USE_STANDARD_TRAIT_ALIASES) || !MDSPAN_USE_STANDARD_TRAIT_ALIASES
+#if !defined(MDSPAN_IMPL_USE_STANDARD_TRAIT_ALIASES) || !MDSPAN_IMPL_USE_STANDARD_TRAIT_ALIASES
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 

--- a/include/experimental/__p2630_bits/strided_slice.hpp
+++ b/include/experimental/__p2630_bits/strided_slice.hpp
@@ -36,9 +36,9 @@ struct strided_slice {
   using extent_type = ExtentType;
   using stride_type = StrideType;
 
-  _MDSPAN_NO_UNIQUE_ADDRESS OffsetType offset{};
-  _MDSPAN_NO_UNIQUE_ADDRESS ExtentType extent{};
-  _MDSPAN_NO_UNIQUE_ADDRESS StrideType stride{};
+  MDSPAN_NO_UNIQUE_ADDRESS OffsetType offset{};
+  MDSPAN_NO_UNIQUE_ADDRESS ExtentType extent{};
+  MDSPAN_NO_UNIQUE_ADDRESS StrideType stride{};
 
   static_assert(std::is_integral_v<OffsetType> || __mdspan_is_integral_constant<OffsetType>::value);
   static_assert(std::is_integral_v<ExtentType> || __mdspan_is_integral_constant<ExtentType>::value);

--- a/include/experimental/__p2630_bits/strided_slice.hpp
+++ b/include/experimental/__p2630_bits/strided_slice.hpp
@@ -36,9 +36,9 @@ struct strided_slice {
   using extent_type = ExtentType;
   using stride_type = StrideType;
 
-  MDSPAN_NO_UNIQUE_ADDRESS OffsetType offset{};
-  MDSPAN_NO_UNIQUE_ADDRESS ExtentType extent{};
-  MDSPAN_NO_UNIQUE_ADDRESS StrideType stride{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS OffsetType offset{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS ExtentType extent{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS StrideType stride{};
 
   static_assert(std::is_integral_v<OffsetType> || __mdspan_is_integral_constant<OffsetType>::value);
   static_assert(std::is_integral_v<ExtentType> || __mdspan_is_integral_constant<ExtentType>::value);

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -46,7 +46,7 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 // Return type of submdspan_mapping overloads
 //******************************************
 template <class LayoutMapping> struct submdspan_mapping_result {
-  _MDSPAN_NO_UNIQUE_ADDRESS LayoutMapping mapping{};
+  MDSPAN_NO_UNIQUE_ADDRESS LayoutMapping mapping{};
   size_t offset;
 };
 
@@ -182,7 +182,7 @@ struct deduce_layout_left_submapping<
     // e.g. R I I I F F F R I I for obtaining a rank-5 from a rank-10
     return ((((Idx == 0)                                       && is_range_slice_v<SliceSpecifiers, IndexType>) ||
              ((Idx > 0 && Idx <= gap_len)                     && is_index_slice_v<SliceSpecifiers, IndexType>) ||
-             ((Idx > gap_len && Idx < gap_len + SubRank - 1) && std::is_same_v<SliceSpecifiers, full_extent_t>) || 
+             ((Idx > gap_len && Idx < gap_len + SubRank - 1) && std::is_same_v<SliceSpecifiers, full_extent_t>) ||
              ((Idx == gap_len + SubRank - 1)                  && is_range_slice_v<SliceSpecifiers, IndexType>) ||
              ((Idx >  gap_len + SubRank - 1)                  && is_index_slice_v<SliceSpecifiers, IndexType>)) && ... );
   }
@@ -254,7 +254,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA altogether
-#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
                         detail::tuple<decltype(detail::stride_of(slices))...>{
                             detail::stride_of(slices)...}).values),
 #else
@@ -332,7 +332,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<PaddingValue>::mapping<Extent
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
-#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
                             MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...}).values),
 #else
@@ -487,7 +487,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA altogether
-#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(detail::stride_of(slices))...>{
                             detail::stride_of(slices)...}).values),
 #else
@@ -557,7 +557,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<PaddingValue>::mapping<Exten
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
-#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
                             MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...}).values),
 #else
@@ -605,7 +605,7 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
-#if defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
                       MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(detail::stride_of(slices))...>(
                           detail::stride_of(slices)...)).values),
 #else

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -46,7 +46,7 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 // Return type of submdspan_mapping overloads
 //******************************************
 template <class LayoutMapping> struct submdspan_mapping_result {
-  MDSPAN_NO_UNIQUE_ADDRESS LayoutMapping mapping{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS LayoutMapping mapping{};
   size_t offset;
 };
 
@@ -254,7 +254,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA altogether
-#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_CUDA)
                         detail::tuple<decltype(detail::stride_of(slices))...>{
                             detail::stride_of(slices)...}).values),
 #else
@@ -332,7 +332,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<PaddingValue>::mapping<Extent
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
-#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
                             MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...}).values),
 #else
@@ -487,7 +487,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA altogether
-#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(detail::stride_of(slices))...>{
                             detail::stride_of(slices)...}).values),
 #else
@@ -557,7 +557,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<PaddingValue>::mapping<Exten
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
-#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_CUDA)
                         MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices))...>{
                             MDSPAN_IMPL_STANDARD_NAMESPACE::detail::stride_of(slices)...}).values),
 #else
@@ -605,7 +605,7 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
 // NVCC 11.0 has a bug with deduction guide here, tested that 11.2 does not have
 // the issue but Clang-CUDA also doesn't accept the use of deduction guide so
 // disable it for CUDA alltogether
-#if defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_CUDA)
                       MDSPAN_IMPL_STANDARD_NAMESPACE::detail::tuple<decltype(detail::stride_of(slices))...>(
                           detail::stride_of(slices)...)).values),
 #else

--- a/tests/foo_customizations.hpp
+++ b/tests/foo_customizations.hpp
@@ -245,7 +245,7 @@ class layout_foo::mapping {
 #endif
 
 private:
-   _MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
 
 };
 

--- a/tests/foo_customizations.hpp
+++ b/tests/foo_customizations.hpp
@@ -245,10 +245,9 @@ class layout_foo::mapping {
 #endif
 
 private:
-   MDSPAN_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type __extents{};
 
 };
 
 }
 #endif
-

--- a/tests/offload_utils.hpp
+++ b/tests/offload_utils.hpp
@@ -14,11 +14,11 @@
 //
 //@HEADER
 
-#ifdef _MDSPAN_HAS_SYCL
+#ifdef MDSPAN_HAS_SYCL
 #include <sycl/sycl.hpp>
 #endif
 
-#ifdef _MDSPAN_HAS_HIP
+#ifdef MDSPAN_HAS_HIP
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 #endif
@@ -28,7 +28,7 @@
 namespace {
 bool dispatch_host = true;
 
-#ifdef _MDSPAN_HAS_SYCL
+#ifdef MDSPAN_HAS_SYCL
 #define __MDSPAN_DEVICE_ASSERT_EQ(LHS, RHS) \
 if (!(LHS == RHS)) { \
   sycl::ext::oneapi::experimental::printf("expected equality of %s and %s\n", #LHS, #RHS); \
@@ -42,9 +42,9 @@ if (!(LHS == RHS)) { \
 }
 #endif
 
-#if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP)
+#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP)
 
-#if defined(_MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_HAS_CUDA)
 void deviceSynchronize() { (void) cudaDeviceSynchronize(); }
 template<class T>
 void mallocManaged(T** ptr, size_t size) { (void) cudaMallocManaged(ptr, size); }
@@ -52,7 +52,7 @@ template<class T>
 void freeManaged(T* ptr) { (void) cudaFree(ptr); }
 #endif
 
-#if defined(_MDSPAN_HAS_HIP)
+#if defined(MDSPAN_HAS_HIP)
 void deviceSynchronize() { (void) hipDeviceSynchronize(); }
 template<class T>
 void mallocManaged(T** ptr, size_t size) { (void) hipMallocManaged(ptr, size); }
@@ -100,9 +100,9 @@ void free_array(T* ptr) {
  A;
 
 #define __MDSPAN_TESTS_DISPATCH_DEFINED
-#endif // _MDSPAN_HAS_CUDA
+#endif // MDSPAN_HAS_CUDA
 
-#ifdef _MDSPAN_HAS_SYCL
+#ifdef MDSPAN_HAS_SYCL
 
 sycl::queue get_test_queue()
 {
@@ -154,7 +154,7 @@ void free_array(T* ptr) {
  A;
 
 #define __MDSPAN_TESTS_DISPATCH_DEFINED
-#endif // _MDSPAN_HAS_SYCL
+#endif // MDSPAN_HAS_SYCL
 
 #ifndef __MDSPAN_TESTS_DISPATCH_DEFINED
 template<class LAMBDA>

--- a/tests/offload_utils.hpp
+++ b/tests/offload_utils.hpp
@@ -14,11 +14,11 @@
 //
 //@HEADER
 
-#ifdef MDSPAN_HAS_SYCL
+#ifdef MDSPAN_IMPL_HAS_SYCL
 #include <sycl/sycl.hpp>
 #endif
 
-#ifdef MDSPAN_HAS_HIP
+#ifdef MDSPAN_IMPL_HAS_HIP
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 #endif
@@ -28,7 +28,7 @@
 namespace {
 bool dispatch_host = true;
 
-#ifdef MDSPAN_HAS_SYCL
+#ifdef MDSPAN_IMPL_HAS_SYCL
 #define __MDSPAN_DEVICE_ASSERT_EQ(LHS, RHS) \
 if (!(LHS == RHS)) { \
   sycl::ext::oneapi::experimental::printf("expected equality of %s and %s\n", #LHS, #RHS); \
@@ -42,9 +42,9 @@ if (!(LHS == RHS)) { \
 }
 #endif
 
-#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP)
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP)
 
-#if defined(MDSPAN_HAS_CUDA)
+#if defined(MDSPAN_IMPL_HAS_CUDA)
 void deviceSynchronize() { (void) cudaDeviceSynchronize(); }
 template<class T>
 void mallocManaged(T** ptr, size_t size) { (void) cudaMallocManaged(ptr, size); }
@@ -52,7 +52,7 @@ template<class T>
 void freeManaged(T* ptr) { (void) cudaFree(ptr); }
 #endif
 
-#if defined(MDSPAN_HAS_HIP)
+#if defined(MDSPAN_IMPL_HAS_HIP)
 void deviceSynchronize() { (void) hipDeviceSynchronize(); }
 template<class T>
 void mallocManaged(T** ptr, size_t size) { (void) hipMallocManaged(ptr, size); }
@@ -100,9 +100,9 @@ void free_array(T* ptr) {
  A;
 
 #define __MDSPAN_TESTS_DISPATCH_DEFINED
-#endif // MDSPAN_HAS_CUDA
+#endif // MDSPAN_IMPL_HAS_CUDA
 
-#ifdef MDSPAN_HAS_SYCL
+#ifdef MDSPAN_IMPL_HAS_SYCL
 
 sycl::queue get_test_queue()
 {
@@ -154,7 +154,7 @@ void free_array(T* ptr) {
  A;
 
 #define __MDSPAN_TESTS_DISPATCH_DEFINED
-#endif // MDSPAN_HAS_SYCL
+#endif // MDSPAN_IMPL_HAS_SYCL
 
 #ifndef __MDSPAN_TESTS_DISPATCH_DEFINED
 template<class LAMBDA>

--- a/tests/test_element_access.cpp
+++ b/tests/test_element_access.cpp
@@ -22,7 +22,7 @@
 TEST(TestElementAccess, element_access_with_std_array) {
     std::array<double, 6> a{};
     Kokkos::mdspan<double, Kokkos::extents<size_t,2, 3>> s(a.data());
-    ASSERT_EQ(__MDSPAN_OP(s, (std::array<int, 2>{1, 2})), 0);
-    __MDSPAN_OP(s, (std::array<int, 2>{0, 1})) = 3.14;
-    ASSERT_EQ(__MDSPAN_OP(s, (std::array<int, 2>{0, 1})), 3.14);
+    ASSERT_EQ(MDSPAN_OP(s, (std::array<int, 2>{1, 2})), 0);
+    MDSPAN_OP(s, (std::array<int, 2>{0, 1})) = 3.14;
+    ASSERT_EQ(MDSPAN_OP(s, (std::array<int, 2>{0, 1})), 3.14);
 }

--- a/tests/test_element_access.cpp
+++ b/tests/test_element_access.cpp
@@ -22,7 +22,7 @@
 TEST(TestElementAccess, element_access_with_std_array) {
     std::array<double, 6> a{};
     Kokkos::mdspan<double, Kokkos::extents<size_t,2, 3>> s(a.data());
-    ASSERT_EQ(MDSPAN_OP(s, (std::array<int, 2>{1, 2})), 0);
-    MDSPAN_OP(s, (std::array<int, 2>{0, 1})) = 3.14;
-    ASSERT_EQ(MDSPAN_OP(s, (std::array<int, 2>{0, 1})), 3.14);
+    ASSERT_EQ(MDSPAN_IMPL_OP(s, (std::array<int, 2>{1, 2})), 0);
+    MDSPAN_IMPL_OP(s, (std::array<int, 2>{0, 1})) = 3.14;
+    ASSERT_EQ(MDSPAN_IMPL_OP(s, (std::array<int, 2>{0, 1})), 3.14);
 }

--- a/tests/test_exhaustive_layouts.cpp
+++ b/tests/test_exhaustive_layouts.cpp
@@ -365,7 +365,7 @@ TYPED_TEST_SUITE(TestLayoutConversion_L2R, layout_conversion_test_types_left_to_
 TYPED_TEST(TestLayoutConversion, implicit_conversion) {
   typename TestFixture::map_2_t map2 = this->create_map2(this->exts2);
   typename TestFixture::map_1_t map1;
-  #if MDSPAN_HAS_CXX_20 && !defined(_MDSPAN_COMPILER_MSVC)
+  #if MDSPAN_HAS_CXX_20 && !defined(MDSPAN_COMPILER_MSVC)
   static_assert(TestFixture::implicit ==
    (
     (

--- a/tests/test_exhaustive_layouts.cpp
+++ b/tests/test_exhaustive_layouts.cpp
@@ -365,7 +365,7 @@ TYPED_TEST_SUITE(TestLayoutConversion_L2R, layout_conversion_test_types_left_to_
 TYPED_TEST(TestLayoutConversion, implicit_conversion) {
   typename TestFixture::map_2_t map2 = this->create_map2(this->exts2);
   typename TestFixture::map_1_t map1;
-  #if MDSPAN_HAS_CXX_20 && !defined(MDSPAN_COMPILER_MSVC)
+  #if MDSPAN_HAS_CXX_20 && !defined(MDSPAN_IMPL_COMPILER_MSVC)
   static_assert(TestFixture::implicit ==
    (
     (
@@ -401,4 +401,3 @@ TYPED_TEST(TestLayoutConversion, implicit_conversion) {
   }
 #endif
 }
-

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -425,7 +425,7 @@ TYPED_TEST(TestExtentsCompatCtors, construct_from_all_array) {
     ASSERT_EQ(e2.extent(r), (r+1)*5);
 }
 
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 TEST(TestExtentsCTADPack, test_extents_ctad_pack) {
   Kokkos::extents m0;
   ASSERT_EQ(m0.rank(), 0);

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -425,7 +425,7 @@ TYPED_TEST(TestExtentsCompatCtors, construct_from_all_array) {
     ASSERT_EQ(e2.extent(r), (r+1)*5);
 }
 
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 TEST(TestExtentsCTADPack, test_extents_ctad_pack) {
   Kokkos::extents m0;
   ASSERT_EQ(m0.rank(), 0);

--- a/tests/test_layout_ctors.cpp
+++ b/tests/test_layout_ctors.cpp
@@ -203,7 +203,7 @@ TEST(TestLayoutLeftListInitialization, test_layout_left_extent_initialization) {
 }
 
 // FIXME: CUDA NVCC including 12.0 does not like CTAD on nested classes
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
 TEST(TestLayoutLeftCTAD, test_layout_left_ctad) {
   Kokkos::layout_left::mapping m{Kokkos::extents{16, 32}};
   ASSERT_EQ(m.extents().rank(), 2);
@@ -228,7 +228,7 @@ TEST(TestLayoutRightListInitialization, test_layout_right_extent_initialization)
 }
 
 // FIXME: CUDA NVCC including 12.0 does not like CTAD on nested classes
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
 TEST(TestLayoutRightCTAD, test_layout_right_ctad) {
   Kokkos::layout_right::mapping m{Kokkos::extents{16, 32}};
   ASSERT_EQ(m.extents().rank(), 2);

--- a/tests/test_layout_ctors.cpp
+++ b/tests/test_layout_ctors.cpp
@@ -203,7 +203,7 @@ TEST(TestLayoutLeftListInitialization, test_layout_left_extent_initialization) {
 }
 
 // FIXME: CUDA NVCC including 12.0 does not like CTAD on nested classes
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
 TEST(TestLayoutLeftCTAD, test_layout_left_ctad) {
   Kokkos::layout_left::mapping m{Kokkos::extents{16, 32}};
   ASSERT_EQ(m.extents().rank(), 2);
@@ -228,7 +228,7 @@ TEST(TestLayoutRightListInitialization, test_layout_right_extent_initialization)
 }
 
 // FIXME: CUDA NVCC including 12.0 does not like CTAD on nested classes
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
 TEST(TestLayoutRightCTAD, test_layout_right_ctad) {
   Kokkos::layout_right::mapping m{Kokkos::extents{16, 32}};
   ASSERT_EQ(m.extents().rank(), 2);

--- a/tests/test_layout_preconditions.cpp
+++ b/tests/test_layout_preconditions.cpp
@@ -22,7 +22,7 @@ TEST(TestConvertingConstructionFromLayoutStride, precondition_failure) {
 
   const auto stride = Kokkos::layout_stride::mapping<E>{E{}, std::array<size_t, 2>{2, 8}};
 
-#if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_SYCL)
+#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_SYCL)
   ASSERT_DEATH(Kokkos::layout_left::mapping<E>{stride}, "");
   ASSERT_DEATH(Kokkos::layout_right::mapping<E>{stride}, "");
 #else

--- a/tests/test_layout_preconditions.cpp
+++ b/tests/test_layout_preconditions.cpp
@@ -22,7 +22,7 @@ TEST(TestConvertingConstructionFromLayoutStride, precondition_failure) {
 
   const auto stride = Kokkos::layout_stride::mapping<E>{E{}, std::array<size_t, 2>{2, 8}};
 
-#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_SYCL)
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   ASSERT_DEATH(Kokkos::layout_left::mapping<E>{stride}, "");
   ASSERT_DEATH(Kokkos::layout_right::mapping<E>{stride}, "");
 #else

--- a/tests/test_layout_stride.cpp
+++ b/tests/test_layout_stride.cpp
@@ -152,7 +152,7 @@ TYPED_TEST(TestLayoutEquality, equality_op) {
 }
 
 // FIXME: CUDA NVCC including 12.0 does not like CTAD on nested classes
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
 TEST(TestLayoutStrideCTAD, test_ctad) {
   // This is not possible wiht the array constructor we actually provide
   /*

--- a/tests/test_layout_stride.cpp
+++ b/tests/test_layout_stride.cpp
@@ -152,7 +152,7 @@ TYPED_TEST(TestLayoutEquality, equality_op) {
 }
 
 // FIXME: CUDA NVCC including 12.0 does not like CTAD on nested classes
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION) && !defined(__NVCC__)
 TEST(TestLayoutStrideCTAD, test_ctad) {
   // This is not possible wiht the array constructor we actually provide
   /*

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -3,7 +3,7 @@
 
 TEST(mdspan_macros, precondition_violation)
 {
-#if defined(_MDSPAN_HAS_CUDA) || defined(_MDSPAN_HAS_HIP) || defined(_MDSPAN_HAS_SYCL)
+#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_SYCL)
   constexpr auto msg = "";
 #else
   constexpr auto msg = "hello, world!";

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -3,7 +3,7 @@
 
 TEST(mdspan_macros, precondition_violation)
 {
-#if defined(MDSPAN_HAS_CUDA) || defined(MDSPAN_HAS_HIP) || defined(MDSPAN_HAS_SYCL)
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   constexpr auto msg = "";
 #else
   constexpr auto msg = "hello, world!";

--- a/tests/test_mdarray_ctors.cpp
+++ b/tests/test_mdarray_ctors.cpp
@@ -63,7 +63,7 @@ template<>
 struct mdarray_values<0> {
   template<class MDA>
   static void check(const MDA& m) {
-    ASSERT_EQ(__MDSPAN_OP(m), 42);
+    ASSERT_EQ(MDSPAN_OP(m), 42);
   }
   template<class pointer, class extents_type>
   static void fill(const pointer& ptr, const extents_type&, bool) {
@@ -77,7 +77,7 @@ struct mdarray_values<1> {
   static void check(const MDA& m) {
     using index_type = typename MDA::index_type;
     for(index_type i=0; i<m.extent(0); i++)
-      ASSERT_EQ(__MDSPAN_OP(m,i), 42 + i);
+      ASSERT_EQ(MDSPAN_OP(m,i), 42 + i);
   }
   template<class pointer, class extents_type>
   static void fill(const pointer& ptr, const extents_type& ext, bool) {
@@ -94,7 +94,7 @@ struct mdarray_values<2> {
     using index_type = typename MDA::index_type;
     for(index_type i=0; i<m.extent(0); i++)
       for(index_type j=0; j<m.extent(1); j++) {
-        auto tmp = __MDSPAN_OP(m,i,j);
+        auto tmp = MDSPAN_OP(m,i,j);
         ASSERT_EQ(tmp, 42 + i*1000 + j);
       }
   }
@@ -118,7 +118,7 @@ struct mdarray_values<3> {
     for(int i=0; i<m.extent(0); i++)
       for(int j=0; j<m.extent(1); j++)
         for(int k=0; k<m.extent(2); k++) {
-          auto tmp = __MDSPAN_OP(m,i,j,k);
+          auto tmp = MDSPAN_OP(m,i,j,k);
           ASSERT_EQ(tmp, 42 + i*1000000 + j*1000 + k);
         }
   }
@@ -180,7 +180,7 @@ void test_mdarray_ctor_data_carray() {
     __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m.stride(0), 1);
     m.data()[0] = {42};
-    auto val = __MDSPAN_OP(m,0);
+    auto val = MDSPAN_OP(m,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val, 42);
     __MDSPAN_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
   });
@@ -488,7 +488,7 @@ TEST(TestMdarrayCtorDataStdArray, test_mdarray_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(__MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -499,7 +499,7 @@ TEST(TestMdarrayCtorDataVector, test_mdarray_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(__MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -562,7 +562,7 @@ TEST(TestMdarrayListInitializationLayoutStride, test_mdarray_list_initialization
 
 #if 0
 
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 TEST(TestMdarrayCTAD, extents_pack) {
   std::array<int, 1> d{42};
   KokkosEx::mdarray m(d.data(), 64, 128);
@@ -594,7 +594,7 @@ TEST(TestMdarrayCTAD, ctad_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(__MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
   #else
   ASSERT_EQ(m.rank(), 0);
   ASSERT_EQ(m.rank_dynamic(), 0);
@@ -609,7 +609,7 @@ TEST(TestMdarrayCTAD, ctad_carray) {
   ASSERT_EQ(m2.rank_dynamic(), 1);
   ASSERT_EQ(m2.extent(0), 3);
   ASSERT_TRUE(m2.is_exhaustive());
-  ASSERT_EQ(__MDSPAN_OP(m2, 2), 3);
+  ASSERT_EQ(MDSPAN_OP(m2, 2), 3);
 }
 
 TEST(TestMdarrayCTAD, ctad_const_carray) {
@@ -622,7 +622,7 @@ TEST(TestMdarrayCTAD, ctad_const_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(__MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
   #else
   ASSERT_EQ(m.rank(), 0);
   ASSERT_EQ(m.rank_dynamic(), 0);

--- a/tests/test_mdarray_ctors.cpp
+++ b/tests/test_mdarray_ctors.cpp
@@ -63,7 +63,7 @@ template<>
 struct mdarray_values<0> {
   template<class MDA>
   static void check(const MDA& m) {
-    ASSERT_EQ(MDSPAN_OP(m), 42);
+    ASSERT_EQ(MDSPAN_IMPL_OP(m), 42);
   }
   template<class pointer, class extents_type>
   static void fill(const pointer& ptr, const extents_type&, bool) {
@@ -77,7 +77,7 @@ struct mdarray_values<1> {
   static void check(const MDA& m) {
     using index_type = typename MDA::index_type;
     for(index_type i=0; i<m.extent(0); i++)
-      ASSERT_EQ(MDSPAN_OP(m,i), 42 + i);
+      ASSERT_EQ(MDSPAN_IMPL_OP(m,i), 42 + i);
   }
   template<class pointer, class extents_type>
   static void fill(const pointer& ptr, const extents_type& ext, bool) {
@@ -94,7 +94,7 @@ struct mdarray_values<2> {
     using index_type = typename MDA::index_type;
     for(index_type i=0; i<m.extent(0); i++)
       for(index_type j=0; j<m.extent(1); j++) {
-        auto tmp = MDSPAN_OP(m,i,j);
+        auto tmp = MDSPAN_IMPL_OP(m,i,j);
         ASSERT_EQ(tmp, 42 + i*1000 + j);
       }
   }
@@ -118,7 +118,7 @@ struct mdarray_values<3> {
     for(int i=0; i<m.extent(0); i++)
       for(int j=0; j<m.extent(1); j++)
         for(int k=0; k<m.extent(2); k++) {
-          auto tmp = MDSPAN_OP(m,i,j,k);
+          auto tmp = MDSPAN_IMPL_OP(m,i,j,k);
           ASSERT_EQ(tmp, 42 + i*1000000 + j*1000 + k);
         }
   }
@@ -180,7 +180,7 @@ void test_mdarray_ctor_data_carray() {
     __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m.stride(0), 1);
     m.data()[0] = {42};
-    auto val = MDSPAN_OP(m,0);
+    auto val = MDSPAN_IMPL_OP(m,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val, 42);
     __MDSPAN_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
   });
@@ -488,7 +488,7 @@ TEST(TestMdarrayCtorDataStdArray, test_mdarray_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -499,7 +499,7 @@ TEST(TestMdarrayCtorDataVector, test_mdarray_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -562,7 +562,7 @@ TEST(TestMdarrayListInitializationLayoutStride, test_mdarray_list_initialization
 
 #if 0
 
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 TEST(TestMdarrayCTAD, extents_pack) {
   std::array<int, 1> d{42};
   KokkosEx::mdarray m(d.data(), 64, 128);
@@ -594,7 +594,7 @@ TEST(TestMdarrayCTAD, ctad_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 2), 3);
   #else
   ASSERT_EQ(m.rank(), 0);
   ASSERT_EQ(m.rank_dynamic(), 0);
@@ -609,7 +609,7 @@ TEST(TestMdarrayCTAD, ctad_carray) {
   ASSERT_EQ(m2.rank_dynamic(), 1);
   ASSERT_EQ(m2.extent(0), 3);
   ASSERT_TRUE(m2.is_exhaustive());
-  ASSERT_EQ(MDSPAN_OP(m2, 2), 3);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m2, 2), 3);
 }
 
 TEST(TestMdarrayCTAD, ctad_const_carray) {
@@ -622,7 +622,7 @@ TEST(TestMdarrayCTAD, ctad_const_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 2), 3);
   #else
   ASSERT_EQ(m.rank(), 0);
   ASSERT_EQ(m.rank_dynamic(), 0);

--- a/tests/test_mdspan_conversion.cpp
+++ b/tests/test_mdspan_conversion.cpp
@@ -24,7 +24,7 @@ TEST(TestMdspanConversionConst, test_mdspan_conversion_const) {
   std::array<double, 6> a{};
   Kokkos::mdspan<double, Kokkos::extents<uint32_t, 2, 3>> s(a.data());
   ASSERT_EQ(s.data_handle(), a.data());
-  __MDSPAN_OP(s, 0, 1) = 3.14;
+  MDSPAN_OP(s, 0, 1) = 3.14;
   Kokkos::mdspan<double const, Kokkos::extents<uint64_t, 2, 3>> c_s(s);
-  ASSERT_EQ((__MDSPAN_OP(c_s, 0, 1)), 3.14);
+  ASSERT_EQ((MDSPAN_OP(c_s, 0, 1)), 3.14);
 }

--- a/tests/test_mdspan_conversion.cpp
+++ b/tests/test_mdspan_conversion.cpp
@@ -24,7 +24,7 @@ TEST(TestMdspanConversionConst, test_mdspan_conversion_const) {
   std::array<double, 6> a{};
   Kokkos::mdspan<double, Kokkos::extents<uint32_t, 2, 3>> s(a.data());
   ASSERT_EQ(s.data_handle(), a.data());
-  MDSPAN_OP(s, 0, 1) = 3.14;
+  MDSPAN_IMPL_OP(s, 0, 1) = 3.14;
   Kokkos::mdspan<double const, Kokkos::extents<uint64_t, 2, 3>> c_s(s);
-  ASSERT_EQ((MDSPAN_OP(c_s, 0, 1)), 3.14);
+  ASSERT_EQ((MDSPAN_IMPL_OP(c_s, 0, 1)), 3.14);
 }

--- a/tests/test_mdspan_ctors.cpp
+++ b/tests/test_mdspan_ctors.cpp
@@ -59,7 +59,7 @@ void test_mdspan_ctor_data_carray() {
     __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m.stride(0), 1);
-    auto val = __MDSPAN_OP(m,0);
+    auto val = MDSPAN_OP(m,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val, 42);
     __MDSPAN_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
     __MDSPAN_DEVICE_ASSERT_EQ(m.size(), 1);
@@ -81,7 +81,7 @@ TEST(TestMdspanCtorDataStdArray, test_mdspan_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(__MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -93,7 +93,7 @@ TEST(TestMdspanCtorDataVector, test_mdspan_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(__MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -150,7 +150,7 @@ TEST(TestMdspanListInitializationLayoutStride, test_mdspan_list_initialization_l
   ASSERT_FALSE(m.is_exhaustive());
 }
 
-#if defined(_MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 TEST(TestMdspanCTAD, extents_pack) {
   std::array<int, 1> d{42};
   Kokkos::mdspan m(d.data(), 64, 128);
@@ -203,7 +203,7 @@ TEST(TestMdspanCTAD, ctad_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(__MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
   ASSERT_TRUE(m.is_exhaustive());
 
 
@@ -214,7 +214,7 @@ TEST(TestMdspanCTAD, ctad_carray) {
   ASSERT_EQ(m2.rank_dynamic(), 1);
   ASSERT_EQ(m2.extent(0), 3);
   ASSERT_TRUE(m2.is_exhaustive());
-  ASSERT_EQ(__MDSPAN_OP(m2, 2), 3);
+  ASSERT_EQ(MDSPAN_OP(m2, 2), 3);
 }
 
 TEST(TestMdspanCTAD, ctad_const_carray) {
@@ -226,7 +226,7 @@ TEST(TestMdspanCTAD, ctad_const_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(__MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
   ASSERT_TRUE(m.is_exhaustive());
 }
 

--- a/tests/test_mdspan_ctors.cpp
+++ b/tests/test_mdspan_ctors.cpp
@@ -59,7 +59,7 @@ void test_mdspan_ctor_data_carray() {
     __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m.stride(0), 1);
-    auto val = MDSPAN_OP(m,0);
+    auto val = MDSPAN_IMPL_OP(m,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val, 42);
     __MDSPAN_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
     __MDSPAN_DEVICE_ASSERT_EQ(m.size(), 1);
@@ -81,7 +81,7 @@ TEST(TestMdspanCtorDataStdArray, test_mdspan_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -93,7 +93,7 @@ TEST(TestMdspanCtorDataVector, test_mdspan_ctor_data_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.extent(0), 1);
   ASSERT_EQ(m.stride(0), 1);
-  ASSERT_EQ(MDSPAN_OP(m, 0), 42);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 0), 42);
   ASSERT_TRUE(m.is_exhaustive());
 }
 
@@ -150,7 +150,7 @@ TEST(TestMdspanListInitializationLayoutStride, test_mdspan_list_initialization_l
   ASSERT_FALSE(m.is_exhaustive());
 }
 
-#if defined(MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
+#if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
 TEST(TestMdspanCTAD, extents_pack) {
   std::array<int, 1> d{42};
   Kokkos::mdspan m(d.data(), 64, 128);
@@ -203,7 +203,7 @@ TEST(TestMdspanCTAD, ctad_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 2), 3);
   ASSERT_TRUE(m.is_exhaustive());
 
 
@@ -214,7 +214,7 @@ TEST(TestMdspanCTAD, ctad_carray) {
   ASSERT_EQ(m2.rank_dynamic(), 1);
   ASSERT_EQ(m2.extent(0), 3);
   ASSERT_TRUE(m2.is_exhaustive());
-  ASSERT_EQ(MDSPAN_OP(m2, 2), 3);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m2, 2), 3);
 }
 
 TEST(TestMdspanCTAD, ctad_const_carray) {
@@ -226,7 +226,7 @@ TEST(TestMdspanCTAD, ctad_const_carray) {
   ASSERT_EQ(m.rank_dynamic(), 0);
   ASSERT_EQ(m.static_extent(0), 5);
   ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(MDSPAN_OP(m, 2), 3);
+  ASSERT_EQ(MDSPAN_IMPL_OP(m, 2), 3);
   ASSERT_TRUE(m.is_exhaustive());
 }
 

--- a/tests/test_mdspan_swap.cpp
+++ b/tests/test_mdspan_swap.cpp
@@ -37,20 +37,20 @@ void test_mdspan_std_swap_static_extents() {
     Kokkos::layout_right::mapping<Kokkos::extents<size_t, 3, 4>> map2(exts2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
-    auto val1 = __MDSPAN_OP(m1,0,0);
+    auto val1 = MDSPAN_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
-    auto val2 = __MDSPAN_OP(m2,0,0);
+    auto val2 = MDSPAN_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
-    val1 = __MDSPAN_OP(m1,0,0);
+    val1 = MDSPAN_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
-    val2 = __MDSPAN_OP(m2,0,0);
+    val2 = MDSPAN_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
   });
   ASSERT_EQ(errors[0], 0);
@@ -77,20 +77,20 @@ void test_mdspan_std_swap_dynamic_extents() {
     Kokkos::layout_right::mapping<Kokkos::dextents<size_t,2>> map2(exts2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
-    auto val1 = __MDSPAN_OP(m1,0,0);
+    auto val1 = MDSPAN_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
-    auto val2 = __MDSPAN_OP(m2,0,0);
+    auto val2 = MDSPAN_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
-    val1 = __MDSPAN_OP(m1,0,0);
+    val1 = MDSPAN_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
-    val2 = __MDSPAN_OP(m2,0,0);
+    val2 = MDSPAN_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
   });
   ASSERT_EQ(errors[0], 0);
@@ -103,7 +103,7 @@ TEST(TestMDSpanSwap, std_swap_dynamic_extents) {
 
 // On HIP/CUDA we actually don't call through to swap via ADL
 // so the foo swap test which has side effects will fail
-#if !defined(_MDSPAN_HAS_HIP) && !defined(_MDSPAN_HAS_CUDA)
+#if !defined(MDSPAN_HAS_HIP) && !defined(MDSPAN_HAS_CUDA)
 void test_mdspan_foo_swap_dynamic_extents() {
   size_t* errors = allocate_array<size_t>(1);
   errors[0] = 0;
@@ -131,23 +131,23 @@ void test_mdspan_foo_swap_dynamic_extents() {
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle().data, data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 9);
-    auto val1 = __MDSPAN_OP(m1,0,0);
+    auto val1 = MDSPAN_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle().data, data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 7);
-    auto val2 = __MDSPAN_OP(m2,0,0);
+    auto val2 = MDSPAN_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle().data, data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 77);
-    val1 = __MDSPAN_OP(m1,0,0);
+    val1 = MDSPAN_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle().data, data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 99);
-    val2 = __MDSPAN_OP(m2,0,0);
+    val2 = MDSPAN_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(flag1, 99);
     __MDSPAN_DEVICE_ASSERT_EQ(flag2, 77);

--- a/tests/test_mdspan_swap.cpp
+++ b/tests/test_mdspan_swap.cpp
@@ -37,20 +37,20 @@ void test_mdspan_std_swap_static_extents() {
     Kokkos::layout_right::mapping<Kokkos::extents<size_t, 3, 4>> map2(exts2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
-    auto val1 = MDSPAN_OP(m1,0,0);
+    auto val1 = MDSPAN_IMPL_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
-    auto val2 = MDSPAN_OP(m2,0,0);
+    auto val2 = MDSPAN_IMPL_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
-    val1 = MDSPAN_OP(m1,0,0);
+    val1 = MDSPAN_IMPL_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
-    val2 = MDSPAN_OP(m2,0,0);
+    val2 = MDSPAN_IMPL_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
   });
   ASSERT_EQ(errors[0], 0);
@@ -77,20 +77,20 @@ void test_mdspan_std_swap_dynamic_extents() {
     Kokkos::layout_right::mapping<Kokkos::dextents<size_t,2>> map2(exts2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
-    auto val1 = MDSPAN_OP(m1,0,0);
+    auto val1 = MDSPAN_IMPL_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
-    auto val2 = MDSPAN_OP(m2,0,0);
+    auto val2 = MDSPAN_IMPL_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
-    val1 = MDSPAN_OP(m1,0,0);
+    val1 = MDSPAN_IMPL_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
-    val2 = MDSPAN_OP(m2,0,0);
+    val2 = MDSPAN_IMPL_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
   });
   ASSERT_EQ(errors[0], 0);
@@ -103,7 +103,7 @@ TEST(TestMDSpanSwap, std_swap_dynamic_extents) {
 
 // On HIP/CUDA we actually don't call through to swap via ADL
 // so the foo swap test which has side effects will fail
-#if !defined(MDSPAN_HAS_HIP) && !defined(MDSPAN_HAS_CUDA)
+#if !defined(MDSPAN_IMPL_HAS_HIP) && !defined(MDSPAN_IMPL_HAS_CUDA)
 void test_mdspan_foo_swap_dynamic_extents() {
   size_t* errors = allocate_array<size_t>(1);
   errors[0] = 0;
@@ -131,23 +131,23 @@ void test_mdspan_foo_swap_dynamic_extents() {
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle().data, data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 9);
-    auto val1 = MDSPAN_OP(m1,0,0);
+    auto val1 = MDSPAN_IMPL_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle().data, data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 7);
-    auto val2 = MDSPAN_OP(m2,0,0);
+    auto val2 = MDSPAN_IMPL_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle().data, data2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
     __MDSPAN_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 77);
-    val1 = MDSPAN_OP(m1,0,0);
+    val1 = MDSPAN_IMPL_OP(m1,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle().data, data1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
     __MDSPAN_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 99);
-    val2 = MDSPAN_OP(m2,0,0);
+    val2 = MDSPAN_IMPL_OP(m2,0,0);
     __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
     __MDSPAN_DEVICE_ASSERT_EQ(flag1, 99);
     __MDSPAN_DEVICE_ASSERT_EQ(flag2, 77);

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -28,71 +28,71 @@ _MDSPAN_INLINE_VARIABLE constexpr auto dyn = Kokkos::dynamic_extent;
 TEST(TestSubmdspanLayoutRightStaticSizedRankReducing3Dto1D, test_submdspan_layout_right_static_sized_rank_reducing_3d_to_1d) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  __MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, 1, 1, Kokkos::full_extent);
   static_assert(decltype(sub0)::rank()==1,"unexpected submdspan rank");
   ASSERT_EQ(sub0.rank(),         1);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      4);
-  ASSERT_EQ((__MDSPAN_OP(sub0, 1)), 42);
+  ASSERT_EQ((MDSPAN_OP(sub0, 1)), 42);
 }
 
 TEST(TestSubmdspanLayoutLeftStaticSizedRankReducing3Dto1D, test_submdspan_layout_left_static_sized_rank_reducing_3d_to_1d) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>, Kokkos::layout_left> m(d.data());
-  __MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, 1, 1, Kokkos::full_extent);
   ASSERT_EQ(sub0.rank(),         1);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      4);
-  ASSERT_EQ((__MDSPAN_OP(sub0, 1)), 42);
+  ASSERT_EQ((MDSPAN_OP(sub0, 1)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedRankReducingNested3Dto0D, test_submdspan_layout_right_static_sized_rank_reducing_nested_3d_to_0d) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  __MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, 1, Kokkos::full_extent, Kokkos::full_extent);
   ASSERT_EQ(sub0.rank(),         2);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      3);
   ASSERT_EQ(sub0.extent(1),      4);
-  ASSERT_EQ((__MDSPAN_OP(sub0, 1, 1)), 42);
+  ASSERT_EQ((MDSPAN_OP(sub0, 1, 1)), 42);
   auto sub1 = Kokkos::submdspan(sub0, 1, Kokkos::full_extent);
   ASSERT_EQ(sub1.rank(),         1);
   ASSERT_EQ(sub1.rank_dynamic(), 0);
   ASSERT_EQ(sub1.extent(0),      4);
-  ASSERT_EQ((__MDSPAN_OP(sub1,1)),42);
+  ASSERT_EQ((MDSPAN_OP(sub1,1)),42);
   auto sub2 = Kokkos::submdspan(sub1, 1);
   ASSERT_EQ(sub2.rank(),         0);
   ASSERT_EQ(sub2.rank_dynamic(), 0);
-  ASSERT_EQ((__MDSPAN_OP0(sub2)), 42);
+  ASSERT_EQ((MDSPAN_OP0(sub2)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedPairs, test_submdspan_layout_right_static_sized_pairs) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  __MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, std::pair<int,int>{1, 2}, std::pair<int,int>{1, 3}, std::pair<int,int>{1, 4});
   ASSERT_EQ(sub0.rank(),         3);
   ASSERT_EQ(sub0.rank_dynamic(), 3);
   ASSERT_EQ(sub0.extent(0),      1);
   ASSERT_EQ(sub0.extent(1),      2);
   ASSERT_EQ(sub0.extent(2),      3);
-  ASSERT_EQ((__MDSPAN_OP(sub0, 0, 0, 0)), 42);
+  ASSERT_EQ((MDSPAN_OP(sub0, 0, 0, 0)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedTuples, test_submdspan_layout_right_static_sized_tuples) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  __MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, std::tuple<int,int>{1, 2}, std::tuple<int,int>{1, 3}, std::tuple<int,int>{1, 4});
   ASSERT_EQ(sub0.rank(),         3);
   ASSERT_EQ(sub0.rank_dynamic(), 3);
   ASSERT_EQ(sub0.extent(0),      1);
   ASSERT_EQ(sub0.extent(1),      2);
   ASSERT_EQ(sub0.extent(2),      3);
-  ASSERT_EQ((__MDSPAN_OP(sub0, 0, 0, 0)),       42);
+  ASSERT_EQ((MDSPAN_OP(sub0, 0, 0, 0)),       42);
 }
 
 
@@ -334,7 +334,7 @@ struct TestSubMDSpan<
     if constexpr (SrcMDSpan::rank() == 0) {
       return (&src_mds[]==&sub_mds[]);
     } else if constexpr (SubMDSpan::rank() == 0) {
-      return (&src_mds[SrcIdx...]==&sub_mds[]); 
+      return (&src_mds[SrcIdx...]==&sub_mds[]);
     } else {
       if(sub_mds.size() == 0) return true;
       return (&src_mds[SrcIdx...]==&sub_mds[SubIdx...]);
@@ -379,7 +379,7 @@ TYPED_TEST(TestSubMDSpan, submdspan_return_type) {
   __MDSPAN_TESTS_RUN_TEST(TestFixture::run());
 }
 
-#ifdef _MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
+#ifdef MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
 TEST(TestSubmdspanIssue4060, Rank1) {
   auto x = std::array<int, 3>{};
   auto A = Kokkos::mdspan{x.data(), Kokkos::extents{3}};

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -28,71 +28,71 @@ _MDSPAN_INLINE_VARIABLE constexpr auto dyn = Kokkos::dynamic_extent;
 TEST(TestSubmdspanLayoutRightStaticSizedRankReducing3Dto1D, test_submdspan_layout_right_static_sized_rank_reducing_3d_to_1d) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_IMPL_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, 1, 1, Kokkos::full_extent);
   static_assert(decltype(sub0)::rank()==1,"unexpected submdspan rank");
   ASSERT_EQ(sub0.rank(),         1);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      4);
-  ASSERT_EQ((MDSPAN_OP(sub0, 1)), 42);
+  ASSERT_EQ((MDSPAN_IMPL_OP(sub0, 1)), 42);
 }
 
 TEST(TestSubmdspanLayoutLeftStaticSizedRankReducing3Dto1D, test_submdspan_layout_left_static_sized_rank_reducing_3d_to_1d) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>, Kokkos::layout_left> m(d.data());
-  MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_IMPL_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, 1, 1, Kokkos::full_extent);
   ASSERT_EQ(sub0.rank(),         1);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      4);
-  ASSERT_EQ((MDSPAN_OP(sub0, 1)), 42);
+  ASSERT_EQ((MDSPAN_IMPL_OP(sub0, 1)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedRankReducingNested3Dto0D, test_submdspan_layout_right_static_sized_rank_reducing_nested_3d_to_0d) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_IMPL_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, 1, Kokkos::full_extent, Kokkos::full_extent);
   ASSERT_EQ(sub0.rank(),         2);
   ASSERT_EQ(sub0.rank_dynamic(), 0);
   ASSERT_EQ(sub0.extent(0),      3);
   ASSERT_EQ(sub0.extent(1),      4);
-  ASSERT_EQ((MDSPAN_OP(sub0, 1, 1)), 42);
+  ASSERT_EQ((MDSPAN_IMPL_OP(sub0, 1, 1)), 42);
   auto sub1 = Kokkos::submdspan(sub0, 1, Kokkos::full_extent);
   ASSERT_EQ(sub1.rank(),         1);
   ASSERT_EQ(sub1.rank_dynamic(), 0);
   ASSERT_EQ(sub1.extent(0),      4);
-  ASSERT_EQ((MDSPAN_OP(sub1,1)),42);
+  ASSERT_EQ((MDSPAN_IMPL_OP(sub1,1)),42);
   auto sub2 = Kokkos::submdspan(sub1, 1);
   ASSERT_EQ(sub2.rank(),         0);
   ASSERT_EQ(sub2.rank_dynamic(), 0);
-  ASSERT_EQ((MDSPAN_OP0(sub2)), 42);
+  ASSERT_EQ((MDSPAN_IMPL_OP0(sub2)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedPairs, test_submdspan_layout_right_static_sized_pairs) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_IMPL_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, std::pair<int,int>{1, 2}, std::pair<int,int>{1, 3}, std::pair<int,int>{1, 4});
   ASSERT_EQ(sub0.rank(),         3);
   ASSERT_EQ(sub0.rank_dynamic(), 3);
   ASSERT_EQ(sub0.extent(0),      1);
   ASSERT_EQ(sub0.extent(1),      2);
   ASSERT_EQ(sub0.extent(2),      3);
-  ASSERT_EQ((MDSPAN_OP(sub0, 0, 0, 0)), 42);
+  ASSERT_EQ((MDSPAN_IMPL_OP(sub0, 0, 0, 0)), 42);
 }
 
 TEST(TestSubmdspanLayoutRightStaticSizedTuples, test_submdspan_layout_right_static_sized_tuples) {
   std::vector<int> d(2 * 3 * 4, 0);
   Kokkos::mdspan<int, Kokkos::extents<size_t,2, 3, 4>> m(d.data());
-  MDSPAN_OP(m, 1, 1, 1) = 42;
+  MDSPAN_IMPL_OP(m, 1, 1, 1) = 42;
   auto sub0 = Kokkos::submdspan(m, std::tuple<int,int>{1, 2}, std::tuple<int,int>{1, 3}, std::tuple<int,int>{1, 4});
   ASSERT_EQ(sub0.rank(),         3);
   ASSERT_EQ(sub0.rank_dynamic(), 3);
   ASSERT_EQ(sub0.extent(0),      1);
   ASSERT_EQ(sub0.extent(1),      2);
   ASSERT_EQ(sub0.extent(2),      3);
-  ASSERT_EQ((MDSPAN_OP(sub0, 0, 0, 0)),       42);
+  ASSERT_EQ((MDSPAN_IMPL_OP(sub0, 0, 0, 0)),       42);
 }
 
 
@@ -379,7 +379,7 @@ TYPED_TEST(TestSubMDSpan, submdspan_return_type) {
   __MDSPAN_TESTS_RUN_TEST(TestFixture::run());
 }
 
-#ifdef MDSPAN_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
+#ifdef MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION
 TEST(TestSubmdspanIssue4060, Rank1) {
   auto x = std::array<int, 3>{};
   auto A = Kokkos::mdspan{x.data(), Kokkos::extents{3}};


### PR DESCRIPTION
I used the [bugprone-reserved-identifier](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/reserved-identifier.html) clang-tidy check to find these, and a global search/replace to fix them. I kept these changes isolated to ones _declared_ in config.hpp and plan on doing more later. (As you can see, even just the config.hpp ones touch basically every file)