### PR TITLE
Fix false warning on some compilers for unused variable

### DIFF
--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -115,7 +115,7 @@ struct tuple_idx_matcher {
   using type = tuple_member<T, Idx>;
   template<class Other>
   MDSPAN_FUNCTION
-  constexpr auto operator | (Other v) const {
+  constexpr auto operator | ([[maybe_unused]] Other v) const {
     if constexpr (Idx == SearchIdx) { return *this; }
     else { return v; }
   }


### PR DESCRIPTION
The typical issue we have seen occasionally with if constexpr based false warnings on unused variables. 