### PR TITLE
Improve workaround clang bracket compilation bug

### DIFF
--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -245,7 +245,7 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #    if defined(_MDSPAN_COMPILER_CLANG) &&                                         \
         ((__clang_major__ < 17) ||                                                 \
          (__clang_major__ == 17 && __clang_minor__ == 0 &&                         \
-          __clang_patchlevel__ < 1))
+          __clang_patchlevel__ == 0))
 #      define MDSPAN_USE_BRACKET_OPERATOR 0
 #    else
 #      define MDSPAN_USE_BRACKET_OPERATOR 1

--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -242,7 +242,10 @@ static_assert(_MDSPAN_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14 or 
 #  if defined(__cpp_multidimensional_subscript)
 // The following if/else is necessary to workaround a clang issue
 // relative to using a parameter pack inside a bracket operator in C++2b/C++23 mode
-#    if defined(_MDSPAN_COMPILER_CLANG) && ((__clang_major__ == 15) || (__clang_major__ == 16))
+#    if defined(_MDSPAN_COMPILER_CLANG) &&                                         \
+        ((__clang_major__ < 17) ||                                                 \
+         (__clang_major__ == 17 && __clang_minor__ == 0 &&                         \
+          __clang_patchlevel__ < 1))
 #      define MDSPAN_USE_BRACKET_OPERATOR 0
 #    else
 #      define MDSPAN_USE_BRACKET_OPERATOR 1


### PR DESCRIPTION
Here we go again, this follows PR #364. I could still notice this issue by compiling with hipcc rocm `6.1`.

It appears that
- rocm `6.1` is based on clang `17.0.0`, see https://rocm.docs.amd.com/en/docs-6.2.0/compatibility/compatibility-matrix.html
- the fix for the bracket operator has only been released in `17.0.1` and not `17.0.0`. I think it is the entry "Fix a crash when expanding a pack as the index of a subscript expression." in https://releases.llvm.org/17.0.1/tools/clang/docs/ReleaseNotes.html?1=#bug-fixes-to-c-support with the corresponding commit https://github.com/llvm/llvm-project/commit/2528f1c84588f4a549c12dd1435cbba4a502a077#diff-3c28567b5e0c77d68f174541a0b77f5a85d093f58b89cd3675ee04a550a44880L4962

With this fix, I could compile fine with hipcc rocm `6.1`.