### PR TITLE
support use of mdspan/mdarray.hpp header

### DIFF
--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "../mdspan"
+#include "mdspan/mdspan.hpp"
 #include <cassert>
 #include <vector>
 

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "mdspan/mdspan.hpp"
+#include "../../mdspan/mdspan.hpp"
 #include <cassert>
 #include <vector>
 


### PR DESCRIPTION
Using `#include "mdspan/mdarray.hpp"` provided by mdspan fails with the following error:

```
In file included from /space/cwsmith/mdspan/buildMdsCuda/install/include/mdspan/mdarray.hpp:29,
                 from /space/cwsmith/mdspan/mdarrayReproducer/mdarrayReproducer.cpp:17:         
/space/cwsmith/mdspan/buildMdsCuda/install/include/mdspan/../experimental/__p1684_bits/mdarray.hpp:19:10: fatal error: ../mdspan: No such file or directory
   19 | #include "../mdspan"                                                                                                            
      |          ^~~~~~~~~~~                                                                                                            
compilation terminated. 
```

A reproducer (`mdarrayReproducer.cpp`) is below:

```
#include "mdspan/mdarray.hpp"
int main(int argc, char* argv[]) {
  return 0;
}
```

and its `CMakeLists.txt`:

```
cmake_minimum_required(VERSION 3.16)
project(mdarrayReproducer CXX)
find_package(mdspan REQUIRED)
add_executable(reproducer mdarrayReproducer.cpp)
target_link_libraries(reproducer std::mdspan)
```

This PR fixes the compilation error, but I'm not sure if it is the correct fix.  If it is merged and then brought into downstream Kokkos, it will resolve the issue discussed in https://github.com/kokkos/kokkos/pull/7671.

All mdspan tests passed when using the following cmake commands with GCC 12.3.0 and CUDA 12.1.1.

```
bdir=$PWD/buildMdsCuda
cmake -S mdspan -B $bdir \
  -DCMAKE_INSTALL_PREFIX=$bdir/install \
  -DMDSPAN_CXX_STANDARD=17 \
  -DMDSPAN_ENABLE_TESTS=on \
  -DMDSPAN_ENABLE_EXAMPLES=on \
  -DMDSPAN_ENABLE_CUDA=on \
  -DCMAKE_CUDA_FLAGS=--expt-relaxed-constexpr \
  -DCMAKE_CUDA_ARCHITECTURES=86 
cmake --build buildMdsCuda -j20 --target install
ctest --test-dir buildMdsCuda/
```
