### PR TITLE
remove cmake logic for `-fconcepts` and `-fconcepts-ts` flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,27 +81,6 @@ endif()
 
 ################################################################################
 
-if(MDSPAN_ENABLE_CONCEPTS)
-  if(CMAKE_CXX_STANDARD GREATER_EQUAL 20)
-    include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag("-fconcepts" COMPILER_SUPPORTS_FCONCEPTS)
-    if(COMPILER_SUPPORTS_FCONCEPTS)
-      message(STATUS "Using \"-fconcepts\" to enable concepts support")
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts")
-    else()
-      check_cxx_compiler_flag("-fconcepts-ts" COMPILER_SUPPORTS_FCONCEPTS_TS)
-      if(COMPILER_SUPPORTS_FCONCEPTS)
-        message(STATUS "Using \"-fconcepts-ts\" to enable concepts support")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fconcepts-ts")
-      endif()
-    endif()
-    # Otherwise, it's possible that the compiler supports concepts without flags,
-    # but if it doesn't, they just won't be used, which is fine
-  endif()
-endif()
-
-################################################################################
-
 if(MDSPAN_ENABLE_CUDA)
   include(CheckLanguage)
   check_language(CUDA)


### PR DESCRIPTION
I'm suggesting that we remove the logic in our cmake that tries to add the `-fconcepts` and `-fconcepts-ts` flags.

First of all, the `-fconcepts-ts` branch is broken, because the condition checks `COMPILER_SUPPORTS_FCONCEPTS` instead of `COMPILER_SUPPORTS_FCONCEPTS_TS`, so it wasn't used anyway.

Secondly, pretty much every modern compiler will enable this if you enable `-std=c++20`, and we only add this flag if we enable `-std=c++20`. In the rare cases someone is trying to build mdspan on a platform that doesn't do this, they can simply add `-DCMAKE_CXX_FLAGS=-fconcepts` to their cmake command line invocation or preset.

Note that us manually adding this flag breaks builds in small niche use cases (that can easily be worked around); i.e. when using `CMAKE_CXX_CLANG_TIDY` with gcc as clang does not recognize the flag but it is forced on. So the motivation for this is pretty minor but I think it would be good to clean up some of our cmake anyway.