### PR TITLE
Add fetchcontent for google benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(MDSPAN_ENABLE_SYCL "Enable SYCL tests/benchmarks/examples if tests/benchm
 option(MDSPAN_ENABLE_HIP "Enable HIP tests/benchmarks/examples if tests/benchmarks/examples are enabled." Off)
 option(MDSPAN_ENABLE_OPENMP "Enable OpenMP benchmarks if benchmarks are enabled." On)
 option(MDSPAN_USE_SYSTEM_GTEST "Use system-installed GoogleTest library for tests." Off)
+option(MDSPAN_USE_SYSTEM_BENCHMARK "Use system-installed Google Benchmark library for benchmarks." On)
 option(MDSPAN_INSTALL_STDMODE_HEADERS "Whether to install headers to emulate standard library headers and namespaces" Off)
 
 # Option to override which C++ standard to use

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -9,7 +9,20 @@ function(mdspan_add_benchmark EXENAME)
   target_compile_definitions(${EXENAME} PRIVATE MDSPAN_USE_PAREN_OPERATOR=1)
 endfunction()
 
-find_package(benchmark REQUIRED)
+if(MDSPAN_USE_SYSTEM_BENCHMARK)
+  find_package(benchmark REQUIRED)
+else()
+  set(BENCHMARK_ENABLE_TESTING OFF)
+  include(FetchContent)
+  
+  fetchcontent_declare(
+      benchmark
+      GIT_REPOSITORY https://github.com/google/benchmark.git
+      GIT_TAG v1.9.1
+  )
+  
+  fetchcontent_makeavailable(benchmark)
+endif()
 
 function(mdspan_add_cuda_benchmark EXENAME)
   add_executable(${EXENAME} ${EXENAME}.cu)


### PR DESCRIPTION
This provides a way of getting google benchmark via FetchContent.

I added a flag `MDSPAN_USE_SYSTEM_BENCHMARK` to control whether to use a system-provided library or not. As the previous behavior was to use a system library, I defaulted this to `On` (which is the opposite of what we do for googletest). I'm open to changing the default to `Off` if we think that is more desirable.