### PR TITLE
Fix missing constexpr and device annotation for mapping ctors

### DIFF
--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -132,6 +132,7 @@ class layout_left::mapping {
       )
     )
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+    MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(const _Mapping& __other) noexcept
       : __extents(__other.extents())
     {

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -132,7 +132,7 @@ class layout_left::mapping {
       )
     )
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
-    MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
+    MDSPAN_INLINE_FUNCTION constexpr
     mapping(const _Mapping& __other) noexcept
       : __extents(__other.extents())
     {

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -132,7 +132,7 @@ class layout_right::mapping {
         MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<_Mapping>::value
         && std::is_constructible_v<extents_type, typename _Mapping::extents_type>))
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
-    MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
+    MDSPAN_INLINE_FUNCTION constexpr
     mapping(const _Mapping &__other) noexcept
         : __extents(__other.extents())
     {

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -132,6 +132,7 @@ class layout_right::mapping {
         MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<_Mapping>::value
         && std::is_constructible_v<extents_type, typename _Mapping::extents_type>))
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+    MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(const _Mapping &__other) noexcept
         : __extents(__other.extents())
     {


### PR DESCRIPTION
Add missing `constexpr` and device annotation. Quoting [p2642](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2642r4.html#overview-mdspan.layout.leftpadded.overview)

```cpp
template<class LayoutLeftPaddedMapping>
constexpr explicit(! is_convertible_v<typename LayoutLeftPaddedMapping::extents_type, extents_type>)
mapping(const LayoutLeftPaddedMapping&) noexcept;
```

And

```cpp
template<class LayoutLeftPaddedMapping>
constexpr explicit(! is_convertible_v<typename LayoutLeftPaddedMapping::extents_type, extents_type>)
mapping(const LayoutLeftPaddedMapping& other) noexcept;
```