### PR TITLE
update actions/cache to v4

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Cache icpx install
       if: ${{ matrix.compiler_driver == 'icpx' }}
       id: cache-icpx
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /opt/intel/oneapi
         key: oneapi-${{ matrix.compiler_url}}


### PR DESCRIPTION
This fixes our CI which is disabled by github because we used a too-old actions/cache version (v2)