### PR TITLE
Unstdify all the things

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+Checks: >
+  -*,
+  bugprone-reserved-identifier
+HeaderFilterRegex: 'include/*'

--- a/benchmarks/stencil/cuda/stencil_3d_cuda.cu
+++ b/benchmarks/stencil/cuda/stencil_3d_cuda.cu
@@ -50,9 +50,9 @@
 
 // Whether to let mapping convert index calculation to the type used
 // to index into the mdspan
-//#define _MDSPAN_USE_MAPPING_ARG_CAST
+//#define MDSPAN_IMPL_USE_MAPPING_ARG_CAST
 // Overwrite what extents.extent() returns and what the actual storage type is
-//#define _MDSPAN_OVERWRITE_EXTENTS_SIZE_TYPE int
+//#define MDSPAN_IMPL_OVERWRITE_EXTENTS_SIZE_TYPE int
 // Choose the index type used by the code
 using idx_t = size_t;
 

--- a/compilation_tests/ctest_compressed_pair_layout.cpp
+++ b/compilation_tests/ctest_compressed_pair_layout.cpp
@@ -50,7 +50,7 @@ void test() {
 }
 
 template <class T, class U>
-using CP = Kokkos::detail::__compressed_pair<T, U>;
+using CP = Kokkos::detail::impl_compressed_pair<T, U>;
 
 struct E0 {};
 struct E1 {};

--- a/examples/aligned_accessor/aligned_accessor.cpp
+++ b/examples/aligned_accessor/aligned_accessor.cpp
@@ -49,39 +49,39 @@ using index_type = int;
 
 // NOTE (mfh 2022/08/08) BYTE_ALIGNMENT must be unsigned and a power of 2.
 #if defined(__cpp_lib_assume_aligned)
-#  define _MDSPAN_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) (std::assume_aligned< BYTE_ALIGNMENT >( POINTER ))
+#  define MDSPAN_IMPL_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) (std::assume_aligned< BYTE_ALIGNMENT >( POINTER ))
   constexpr char assume_aligned_method[] = "std::assume_aligned";
 #elif defined(__ICL)
-#  define _MDSPAN_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
+#  define MDSPAN_IMPL_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
   constexpr char assume_aligned_method[] = "(none)";
 #elif defined(__ICC)
-#  define _MDSPAN_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
+#  define MDSPAN_IMPL_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
   constexpr char assume_aligned_method[] = "(none)";
 #elif defined(__clang__)
-#  define _MDSPAN_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
+#  define MDSPAN_IMPL_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
   constexpr char assume_aligned_method[] = "(none)";
 #elif defined(__GNUC__)
   // __builtin_assume_aligned returns void*
-#  define _MDSPAN_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) reinterpret_cast< ELEMENT_TYPE* >(__builtin_assume_aligned( POINTER, BYTE_ALIGNMENT ))
+#  define MDSPAN_IMPL_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) reinterpret_cast< ELEMENT_TYPE* >(__builtin_assume_aligned( POINTER, BYTE_ALIGNMENT ))
   constexpr char assume_aligned_method[] = "__builtin_assume_aligned";
 #else
-#  define _MDSPAN_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
+#  define MDSPAN_IMPL_ASSUME_ALIGNED( ELEMENT_TYPE, POINTER, BYTE_ALIGNMENT ) POINTER
   constexpr char assume_aligned_method[] = "(none)";
 #endif
 
 // Some compilers other than Clang or GCC like to define __clang__ or __GNUC__.
 // Thus, we order the tests from most to least specific.
 #if defined(__ICL)
-#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __declspec(align_value( BYTE_ALIGNMENT ))
+#  define MDSPAN_IMPL_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __declspec(align_value( BYTE_ALIGNMENT ))
   constexpr char align_attribute_method[] = "__declspec(align_value(BYTE_ALIGNMENT))";
 #elif defined(__ICC)
-#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )))
+#  define MDSPAN_IMPL_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )))
   constexpr char align_attribute_method[] = "__attribute__((align_value(BYTE_ALIGNMENT)))";
 #elif defined(__clang__)
-#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )))
+#  define MDSPAN_IMPL_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT ) __attribute__((align_value( BYTE_ALIGNMENT )))
   constexpr char align_attribute_method[] = "__attribute__((align_value(BYTE_ALIGNMENT)))";
 #else
-#  define _MDSPAN_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT )
+#  define MDSPAN_IMPL_ALIGN_VALUE_ATTRIBUTE( BYTE_ALIGNMENT )
   constexpr char align_attribute_method[] = "(none)";
 #endif
 
@@ -121,7 +121,7 @@ struct aligned_pointer {
 #  pragma warning disable 3186
 #endif
 
-  using type = ElementType* _MDSPAN_ALIGN_VALUE_ATTRIBUTE( byte_alignment );
+  using type = ElementType* MDSPAN_IMPL_ALIGN_VALUE_ATTRIBUTE( byte_alignment );
 
 #if defined(__ICC)
 #  pragma warning pop
@@ -135,7 +135,7 @@ template<class ElementType, std::size_t byte_alignment>
 aligned_pointer_t<ElementType, byte_alignment>
 bless(ElementType* ptr, std::integral_constant<std::size_t, byte_alignment> /* ba */ )
 {
-  return _MDSPAN_ASSUME_ALIGNED( ElementType, ptr, byte_alignment );
+  return MDSPAN_IMPL_ASSUME_ALIGNED( ElementType, ptr, byte_alignment );
 }
 
 template<class ElementType, std::size_t byte_alignment>
@@ -157,7 +157,7 @@ struct aligned_accessor {
   constexpr reference access(data_handle_type p, size_t i) const noexcept {
     // This may declare alignment twice, depending on
     // if we have an attribute for marking pointer types.
-    return _MDSPAN_ASSUME_ALIGNED( ElementType, p, byte_alignment )[i];
+    return MDSPAN_IMPL_ASSUME_ALIGNED( ElementType, p, byte_alignment )[i];
   }
 
   constexpr typename offset_policy::data_handle_type
@@ -247,7 +247,7 @@ public:
 
   aligned_pointer_t<ElementType, byte_alignment> data() const
   {
-    return _MDSPAN_ASSUME_ALIGNED( ElementType, pointer, byte_alignment );
+    return MDSPAN_IMPL_ASSUME_ALIGNED( ElementType, pointer, byte_alignment );
   }
 
 private:

--- a/examples/restrict_accessor/restrict_accessor.cpp
+++ b/examples/restrict_accessor/restrict_accessor.cpp
@@ -29,14 +29,14 @@ namespace {
 
 
 #if defined(MDSPAN_IMPL_COMPILER_MSVC) || defined(__INTEL_COMPILER)
-#  define _MDSPAN_RESTRICT_KEYWORD __restrict
+#  define MDSPAN_IMPL_RESTRICT_KEYWORD __restrict
 #elif defined(__GNUC__) || defined(__clang__)
-#  define _MDSPAN_RESTRICT_KEYWORD __restrict__
+#  define MDSPAN_IMPL_RESTRICT_KEYWORD __restrict__
 #else
-#  define _MDSPAN_RESTRICT_KEYWORD
+#  define MDSPAN_IMPL_RESTRICT_KEYWORD
 #endif
 
-#define _MDSPAN_RESTRICT_POINTER( ELEMENT_TYPE ) ELEMENT_TYPE * _MDSPAN_RESTRICT_KEYWORD
+#define MDSPAN_IMPL_RESTRICT_POINTER( ELEMENT_TYPE ) ELEMENT_TYPE * MDSPAN_IMPL_RESTRICT_KEYWORD
 
 // https://en.cppreference.com/w/c/language/restrict gives examples
 // of the kinds of optimizations that may apply to restrict.  For instance,
@@ -70,7 +70,7 @@ struct restrict_accessor {
   using offset_policy = Kokkos::default_accessor<ElementType>;
   using element_type = ElementType;
   using reference = ElementType&;
-  using data_handle_type = _MDSPAN_RESTRICT_POINTER( ElementType );
+  using data_handle_type = MDSPAN_IMPL_RESTRICT_POINTER( ElementType );
 
   constexpr restrict_accessor() noexcept = default;
 
@@ -171,9 +171,9 @@ auto benchmark_add_raw_1d(const std::size_t num_trials, const index_type n, cons
 
 template<class ElementType>
 void add_restrict_raw_1d(const index_type n,
-  _MDSPAN_RESTRICT_POINTER(const ElementType) x,
-  _MDSPAN_RESTRICT_POINTER(const ElementType) y,
-  _MDSPAN_RESTRICT_POINTER(ElementType) z)
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) x,
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) y,
+  MDSPAN_IMPL_RESTRICT_POINTER(ElementType) z)
 {
   for (index_type i = 0; i < n; ++i) {
     z[i] = x[i] + y[i];
@@ -184,9 +184,9 @@ template<class ElementType>
 auto benchmark_add_restrict_raw_1d(const std::size_t num_trials, const index_type n, const ElementType* x, const ElementType* y, ElementType* z)
 {
   TICK();
-  _MDSPAN_RESTRICT_POINTER(const ElementType) x2 = x;
-  _MDSPAN_RESTRICT_POINTER(const ElementType) y2 = y;
-  _MDSPAN_RESTRICT_POINTER(ElementType) z2 = z;
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) x2 = x;
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) y2 = y;
+  MDSPAN_IMPL_RESTRICT_POINTER(ElementType) z2 = z;
   for (std::size_t trial = 0; trial < num_trials; ++trial) {
     add_restrict_raw_1d(n, x2, y2, z2);
   }
@@ -197,9 +197,9 @@ auto benchmark_add_restrict_raw_1d(const std::size_t num_trials, const index_typ
 // This checks whether the compiler's alias analysis suffices.
 template<class ElementType>
 void add_unrestrict_raw_1d(const index_type n,
-  _MDSPAN_RESTRICT_POINTER(const ElementType) x,
-  _MDSPAN_RESTRICT_POINTER(const ElementType) y,
-  _MDSPAN_RESTRICT_POINTER(ElementType) z)
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) x,
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) y,
+  MDSPAN_IMPL_RESTRICT_POINTER(ElementType) z)
 {
   const ElementType* x2 = x;
   const ElementType* y2 = y;
@@ -211,9 +211,9 @@ template<class ElementType>
 auto benchmark_add_unrestrict_raw_1d(const std::size_t num_trials, const index_type n, const ElementType* x, const ElementType* y, ElementType* z)
 {
   TICK();
-  _MDSPAN_RESTRICT_POINTER(const ElementType) x2 = x;
-  _MDSPAN_RESTRICT_POINTER(const ElementType) y2 = y;
-  _MDSPAN_RESTRICT_POINTER(ElementType) z2 = z;
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) x2 = x;
+  MDSPAN_IMPL_RESTRICT_POINTER(const ElementType) y2 = y;
+  MDSPAN_IMPL_RESTRICT_POINTER(ElementType) z2 = z;
   for (std::size_t trial = 0; trial < num_trials; ++trial) {
     add_unrestrict_raw_1d(n, x2, y2, z2);
   }

--- a/include/experimental/__p0009_bits/compressed_pair.hpp
+++ b/include/experimental/__p0009_bits/compressed_pair.hpp
@@ -27,86 +27,86 @@ namespace detail {
 
 // For no unique address emulation, this is the case taken when neither are empty.
 // For real `[[no_unique_address]]`, this case is always taken.
-template <class _T1, class _T2, class _Enable = void> struct __compressed_pair {
-  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T1 __t1_val{};
-  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T2 __t2_val{};
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &__first() noexcept { return __t1_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
-    return __t1_val;
+template <class _T1, class _T2, class Enable = void> struct impl_compressed_pair {
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T1 m_t1_val{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T2 m_t2_val{};
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &first() noexcept { return m_t1_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &first() const noexcept {
+    return m_t1_val;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &__second() noexcept { return __t2_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
-    return __t2_val;
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &second() noexcept { return m_t2_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &second() const noexcept {
+    return m_t2_val;
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair() = default;
+  constexpr impl_compressed_pair() = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair const &) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair &&) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair const &) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair &&) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  ~__compressed_pair() = default;
+  ~impl_compressed_pair() = default;
   template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
-      : __t1_val((_T1Like &&) __t1), __t2_val((_T2Like &&) __t2) {}
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
+      : m_t1_val((_T1Like &&) __t1), m_t2_val((_T2Like &&) __t2) {}
 };
 
 #if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 
 // First empty.
 template <class _T1, class _T2>
-struct __compressed_pair<
+struct impl_compressed_pair<
     _T1, _T2,
     std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, _T1) && !MDSPAN_IMPL_TRAIT(std::is_empty, _T2)>>
     : private _T1 {
-  _T2 __t2_val{};
+  _T2 m_t2_val{};
   MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &__first() noexcept {
     return *static_cast<_T1 *>(this);
   }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
     return *static_cast<_T1 const *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &__second() noexcept { return __t2_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &__second() noexcept { return m_t2_val; }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
-    return __t2_val;
+    return m_t2_val;
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair() = default;
+  constexpr impl_compressed_pair() = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair const &) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair &&) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair const &) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair &&) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  ~__compressed_pair() = default;
+  ~impl_compressed_pair() = default;
   template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
-      : _T1((_T1Like &&) __t1), __t2_val((_T2Like &&) __t2) {}
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
+      : _T1((_T1Like &&) __t1), m_t2_val((_T2Like &&) __t2) {}
 };
 
 // Second empty.
 template <class _T1, class _T2>
-struct __compressed_pair<
+struct impl_compressed_pair<
     _T1, _T2,
     std::enable_if_t<!MDSPAN_IMPL_TRAIT(std::is_empty, _T1) && MDSPAN_IMPL_TRAIT(std::is_empty, _T2)>>
     : private _T2 {
-  _T1 __t1_val{};
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &__first() noexcept { return __t1_val; }
+  _T1 m_t1_val{};
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &__first() noexcept { return m_t1_val; }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
-    return __t1_val;
+    return m_t1_val;
   }
   MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &__second() noexcept {
     return *static_cast<_T2 *>(this);
@@ -116,28 +116,28 @@ struct __compressed_pair<
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair() = default;
+  constexpr impl_compressed_pair() = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair const &) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair &&) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair const &) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair &&) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  ~__compressed_pair() = default;
+  ~impl_compressed_pair() = default;
 
   template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
-      : _T2((_T2Like &&) __t2), __t1_val((_T1Like &&) __t1) {}
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
+      : _T2((_T2Like &&) __t2), m_t1_val((_T1Like &&) __t1) {}
 };
 
 // Both empty.
 template <class _T1, class _T2>
-struct __compressed_pair<
+struct impl_compressed_pair<
     _T1, _T2,
     std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, _T1) && MDSPAN_IMPL_TRAIT(std::is_empty, _T2)>>
     // We need to use the __no_unique_address_emulation wrapper here to avoid
@@ -169,21 +169,21 @@ struct __compressed_pair<
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair() = default;
+  constexpr impl_compressed_pair() = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair const &) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __compressed_pair(__compressed_pair &&) = default;
+  constexpr impl_compressed_pair(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair const &) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair const &) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __compressed_pair &
-  operator=(__compressed_pair &&) = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED impl_compressed_pair &
+  operator=(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  ~__compressed_pair() = default;
+  ~impl_compressed_pair() = default;
   template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr __compressed_pair(_T1Like &&__t1, _T2Like &&__t2) noexcept
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2) noexcept
     : __first_base_t(_T1((_T1Like &&) __t1)),
       __second_base_t(_T2((_T2Like &&) __t2))
   { }

--- a/include/experimental/__p0009_bits/compressed_pair.hpp
+++ b/include/experimental/__p0009_bits/compressed_pair.hpp
@@ -27,15 +27,15 @@ namespace detail {
 
 // For no unique address emulation, this is the case taken when neither are empty.
 // For real `[[no_unique_address]]`, this case is always taken.
-template <class _T1, class _T2, class Enable = void> struct impl_compressed_pair {
-  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T1 m_t1_val{};
-  MDSPAN_IMPL_NO_UNIQUE_ADDRESS _T2 m_t2_val{};
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &first() noexcept { return m_t1_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &first() const noexcept {
+template <class T1, class T2, class Enable = void> struct impl_compressed_pair {
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS T1 m_t1_val{};
+  MDSPAN_IMPL_NO_UNIQUE_ADDRESS T2 m_t2_val{};
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &first() noexcept { return m_t1_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &first() const noexcept {
     return m_t1_val;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &second() noexcept { return m_t2_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &second() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &second() noexcept { return m_t2_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &second() const noexcept {
     return m_t2_val;
   }
 
@@ -53,28 +53,28 @@ template <class _T1, class _T2, class Enable = void> struct impl_compressed_pair
   operator=(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~impl_compressed_pair() = default;
-  template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
-      : m_t1_val((_T1Like &&) __t1), m_t2_val((_T2Like &&) __t2) {}
+  template <class T1Like, class T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(T1Like &&t1, T2Like &&t2)
+      : m_t1_val((T1Like &&) t1), m_t2_val((T2Like &&) t2) {}
 };
 
 #if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 
 // First empty.
-template <class _T1, class _T2>
+template <class T1, class T2>
 struct impl_compressed_pair<
-    _T1, _T2,
-    std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, _T1) && !MDSPAN_IMPL_TRAIT(std::is_empty, _T2)>>
-    : private _T1 {
-  _T2 m_t2_val{};
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &__first() noexcept {
-    return *static_cast<_T1 *>(this);
+    T1, T2,
+    std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, T1) && !MDSPAN_IMPL_TRAIT(std::is_empty, T2)>>
+    : private T1 {
+  T2 m_t2_val{};
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &__first() noexcept {
+    return *static_cast<T1 *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
-    return *static_cast<_T1 const *>(this);
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &__first() const noexcept {
+    return *static_cast<T1 const *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &__second() noexcept { return m_t2_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &__second() noexcept { return m_t2_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &__second() const noexcept {
     return m_t2_val;
   }
 
@@ -92,27 +92,27 @@ struct impl_compressed_pair<
   operator=(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~impl_compressed_pair() = default;
-  template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
-      : _T1((_T1Like &&) __t1), m_t2_val((_T2Like &&) __t2) {}
+  template <class T1Like, class T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(T1Like &&t1, T2Like &&t2)
+      : T1((T1Like &&) t1), m_t2_val((T2Like &&) t2) {}
 };
 
 // Second empty.
-template <class _T1, class _T2>
+template <class T1, class T2>
 struct impl_compressed_pair<
-    _T1, _T2,
-    std::enable_if_t<!MDSPAN_IMPL_TRAIT(std::is_empty, _T1) && MDSPAN_IMPL_TRAIT(std::is_empty, _T2)>>
-    : private _T2 {
-  _T1 m_t1_val{};
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &__first() noexcept { return m_t1_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
+    T1, T2,
+    std::enable_if_t<!MDSPAN_IMPL_TRAIT(std::is_empty, T1) && MDSPAN_IMPL_TRAIT(std::is_empty, T2)>>
+    : private T2 {
+  T1 m_t1_val{};
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &__first() noexcept { return m_t1_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &__first() const noexcept {
     return m_t1_val;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &__second() noexcept {
-    return *static_cast<_T2 *>(this);
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &__second() noexcept {
+    return *static_cast<T2 *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
-    return *static_cast<_T2 const *>(this);
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &__second() const noexcept {
+    return *static_cast<T2 const *>(this);
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
@@ -130,41 +130,41 @@ struct impl_compressed_pair<
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~impl_compressed_pair() = default;
 
-  template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2)
-      : _T2((_T2Like &&) __t2), m_t1_val((_T1Like &&) __t1) {}
+  template <class T1Like, class T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(T1Like &&t1, T2Like &&t2)
+      : T2((T2Like &&) t2), m_t1_val((T1Like &&) t1) {}
 };
 
 // Both empty.
-template <class _T1, class _T2>
+template <class T1, class T2>
 struct impl_compressed_pair<
-    _T1, _T2,
-    std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, _T1) && MDSPAN_IMPL_TRAIT(std::is_empty, _T2)>>
+    T1, T2,
+    std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, T1) && MDSPAN_IMPL_TRAIT(std::is_empty, T2)>>
     // We need to use the __no_unique_address_emulation wrapper here to avoid
     // base class ambiguities.
 #ifdef MDSPAN_IMPL_COMPILER_MSVC
 // MSVC doesn't allow you to access public static member functions of a type
 // when you *happen* to privately inherit from that type.
-    : protected __no_unique_address_emulation<_T1, 0>,
-      protected __no_unique_address_emulation<_T2, 1>
+    : protected __no_unique_address_emulation<T1, 0>,
+      protected __no_unique_address_emulation<T2, 1>
 #else
-    : private __no_unique_address_emulation<_T1, 0>,
-      private __no_unique_address_emulation<_T2, 1>
+    : private __no_unique_address_emulation<T1, 0>,
+      private __no_unique_address_emulation<T2, 1>
 #endif
 {
-  using __first_base_t = __no_unique_address_emulation<_T1, 0>;
-  using __second_base_t = __no_unique_address_emulation<_T2, 1>;
+  using __first_base_t = __no_unique_address_emulation<T1, 0>;
+  using __second_base_t = __no_unique_address_emulation<T2, 1>;
 
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T1 &__first() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &__first() noexcept {
     return this->__first_base_t::__ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T1 const &__first() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &__first() const noexcept {
     return this->__first_base_t::__ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T2 &__second() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &__second() noexcept {
     return this->__second_base_t::__ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T2 const &__second() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &__second() const noexcept {
     return this->__second_base_t::__ref();
   }
 
@@ -182,10 +182,10 @@ struct impl_compressed_pair<
   operator=(impl_compressed_pair &&) = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
   ~impl_compressed_pair() = default;
-  template <class _T1Like, class _T2Like>
-  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(_T1Like &&__t1, _T2Like &&__t2) noexcept
-    : __first_base_t(_T1((_T1Like &&) __t1)),
-      __second_base_t(_T2((_T2Like &&) __t2))
+  template <class T1Like, class T2Like>
+  MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(T1Like &&t1, T2Like &&t2) noexcept
+    : __first_base_t(T1((T1Like &&) t1)),
+      __second_base_t(T2((T2Like &&) t2))
   { }
 };
 

--- a/include/experimental/__p0009_bits/compressed_pair.hpp
+++ b/include/experimental/__p0009_bits/compressed_pair.hpp
@@ -140,32 +140,32 @@ template <class T1, class T2>
 struct impl_compressed_pair<
     T1, T2,
     std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, T1) && MDSPAN_IMPL_TRAIT(std::is_empty, T2)>>
-    // We need to use the __no_unique_address_emulation wrapper here to avoid
+    // We need to use the no_unique_address_emulation wrapper here to avoid
     // base class ambiguities.
 #ifdef MDSPAN_IMPL_COMPILER_MSVC
 // MSVC doesn't allow you to access public static member functions of a type
 // when you *happen* to privately inherit from that type.
-    : protected __no_unique_address_emulation<T1, 0>,
-      protected __no_unique_address_emulation<T2, 1>
+    : protected no_unique_address_emulation<T1, 0>,
+      protected no_unique_address_emulation<T2, 1>
 #else
-    : private __no_unique_address_emulation<T1, 0>,
-      private __no_unique_address_emulation<T2, 1>
+    : private no_unique_address_emulation<T1, 0>,
+      private no_unique_address_emulation<T2, 1>
 #endif
 {
-  using __first_base_t = __no_unique_address_emulation<T1, 0>;
-  using __second_base_t = __no_unique_address_emulation<T2, 1>;
+  using __first_base_t = no_unique_address_emulation<T1, 0>;
+  using __second_base_t = no_unique_address_emulation<T2, 1>;
 
   MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &__first() noexcept {
-    return this->__first_base_t::__ref();
+    return this->__first_base_t::ref();
   }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &__first() const noexcept {
-    return this->__first_base_t::__ref();
+    return this->__first_base_t::ref();
   }
   MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &__second() noexcept {
-    return this->__second_base_t::__ref();
+    return this->__second_base_t::ref();
   }
   MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &__second() const noexcept {
-    return this->__second_base_t::__ref();
+    return this->__second_base_t::ref();
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED

--- a/include/experimental/__p0009_bits/compressed_pair.hpp
+++ b/include/experimental/__p0009_bits/compressed_pair.hpp
@@ -67,14 +67,14 @@ struct impl_compressed_pair<
     std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, T1) && !MDSPAN_IMPL_TRAIT(std::is_empty, T2)>>
     : private T1 {
   T2 m_t2_val{};
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &__first() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &first() noexcept {
     return *static_cast<T1 *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &__first() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &first() const noexcept {
     return *static_cast<T1 const *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &__second() noexcept { return m_t2_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &__second() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &second() noexcept { return m_t2_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &second() const noexcept {
     return m_t2_val;
   }
 
@@ -104,14 +104,14 @@ struct impl_compressed_pair<
     std::enable_if_t<!MDSPAN_IMPL_TRAIT(std::is_empty, T1) && MDSPAN_IMPL_TRAIT(std::is_empty, T2)>>
     : private T2 {
   T1 m_t1_val{};
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &__first() noexcept { return m_t1_val; }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &__first() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &first() noexcept { return m_t1_val; }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &first() const noexcept {
     return m_t1_val;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &__second() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &second() noexcept {
     return *static_cast<T2 *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &__second() const noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &second() const noexcept {
     return *static_cast<T2 const *>(this);
   }
 
@@ -152,20 +152,20 @@ struct impl_compressed_pair<
       private no_unique_address_emulation<T2, 1>
 #endif
 {
-  using __first_base_t = no_unique_address_emulation<T1, 0>;
-  using __second_base_t = no_unique_address_emulation<T2, 1>;
+  using first_base_t = no_unique_address_emulation<T1, 0>;
+  using second_base_t = no_unique_address_emulation<T2, 1>;
 
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &__first() noexcept {
-    return this->__first_base_t::ref();
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T1 &first() noexcept {
+    return this->first_base_t::ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &__first() const noexcept {
-    return this->__first_base_t::ref();
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T1 const &first() const noexcept {
+    return this->first_base_t::ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &__second() noexcept {
-    return this->__second_base_t::ref();
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T2 &second() noexcept {
+    return this->second_base_t::ref();
   }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &__second() const noexcept {
-    return this->__second_base_t::ref();
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T2 const &second() const noexcept {
+    return this->second_base_t::ref();
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
@@ -184,8 +184,8 @@ struct impl_compressed_pair<
   ~impl_compressed_pair() = default;
   template <class T1Like, class T2Like>
   MDSPAN_INLINE_FUNCTION constexpr impl_compressed_pair(T1Like &&t1, T2Like &&t2) noexcept
-    : __first_base_t(T1((T1Like &&) t1)),
-      __second_base_t(T2((T2Like &&) t2))
+    : first_base_t(T1((T1Like &&) t1)),
+      second_base_t(T2((T2Like &&) t2))
   { }
 };
 

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -34,7 +34,7 @@ namespace detail {
 // can't be a private member function for some reason.
 template <size_t... Extents, size_t... OtherExtents>
 MDSPAN_INLINE_FUNCTION
-static constexpr std::integral_constant<bool, false> __check_compatible_extents(
+static constexpr std::integral_constant<bool, false> impl_check_compatible_extents(
     std::integral_constant<bool, false>,
     std::integer_sequence<size_t, Extents...>,
     std::integer_sequence<size_t, OtherExtents...>) noexcept {
@@ -43,7 +43,7 @@ static constexpr std::integral_constant<bool, false> __check_compatible_extents(
 
 // This helper prevents ICE's on MSVC.
 template <size_t Lhs, size_t Rhs>
-struct __compare_extent_compatible : std::integral_constant<bool,
+struct impl_compare_extent_compatible : std::integral_constant<bool,
      Lhs == dynamic_extent ||
      Rhs == dynamic_extent ||
      Lhs == Rhs>
@@ -52,8 +52,8 @@ struct __compare_extent_compatible : std::integral_constant<bool,
 template <size_t... Extents, size_t... OtherExtents>
 MDSPAN_INLINE_FUNCTION
 static constexpr std::integral_constant<
-    bool, MDSPAN_IMPL_FOLD_AND(__compare_extent_compatible<Extents, OtherExtents>::value)>
-__check_compatible_extents(
+    bool, MDSPAN_IMPL_FOLD_AND(impl_compare_extent_compatible<Extents, OtherExtents>::value)>
+impl_check_compatible_extents(
     std::integral_constant<bool, true>,
     std::integer_sequence<size_t, Extents...>,
     std::integer_sequence<size_t, OtherExtents...>) noexcept {
@@ -477,11 +477,11 @@ private:
       /* requires */ ((R < m_rank) && (static_extent(R) == dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
   constexpr
-  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
+  vals_t impl_construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
                                        std::integral_constant<size_t, R>,
                                        const OtherExtents &exts,
                                        DynamicValues... dynamic_values) noexcept {
-    return __construct_vals_from_extents(
+    return impl_construct_vals_from_extents(
         std::integral_constant<size_t, DynCount + 1>(),
         std::integral_constant<size_t, R + 1>(), exts, dynamic_values...,
         exts.extent(R));
@@ -492,11 +492,11 @@ private:
       /* requires */ ((R < m_rank) && (static_extent(R) != dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
   constexpr
-  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
+  vals_t impl_construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
                                        std::integral_constant<size_t, R>,
                                        const OtherExtents &exts,
                                        DynamicValues... dynamic_values) noexcept {
-    return __construct_vals_from_extents(
+    return impl_construct_vals_from_extents(
         std::integral_constant<size_t, DynCount>(),
         std::integral_constant<size_t, R + 1>(), exts, dynamic_values...);
   }
@@ -506,7 +506,7 @@ private:
       /* requires */ ((R == m_rank) && (DynCount == m_rank_dynamic)))
   MDSPAN_INLINE_FUNCTION
   constexpr
-  vals_t __construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
+  vals_t impl_construct_vals_from_extents(std::integral_constant<size_t, DynCount>,
                                        std::integral_constant<size_t, R>,
                                        const OtherExtents &,
                                        DynamicValues... dynamic_values) noexcept {
@@ -522,7 +522,7 @@ public:
         (
             /* multi-stage check to protect from invalid pack expansion when sizes
             don't match? */
-            decltype(detail::__check_compatible_extents(
+            decltype(detail::impl_check_compatible_extents(
               // using: sizeof...(Extents) == sizeof...(OtherExtents) as the second argument fails with MSVC+NVCC with some obscure expansion error
               // MSVC: 19.38.33133 NVCC: 12.0
               std::integral_constant<bool, extents<int, Extents...>::rank() == extents<int, OtherExtents...>::rank()>{},
@@ -537,7 +537,7 @@ public:
                               (std::numeric_limits<index_type>::max() <
                                std::numeric_limits<OtherIndexType>::max()))
   constexpr extents(const extents<OtherIndexType, OtherExtents...> &other) noexcept
-      : m_vals(__construct_vals_from_extents(
+      : m_vals(impl_construct_vals_from_extents(
             std::integral_constant<size_t, 0>(),
             std::integral_constant<size_t, 0>(), other)) {}
 
@@ -566,13 +566,13 @@ namespace detail {
 
 template <class IndexType, size_t Rank,
           class Extents = ::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<IndexType>>
-struct __make_dextents;
+struct impl_make_dextents;
 
 template <class IndexType, size_t Rank, size_t... ExtentsPack>
-struct __make_dextents<
+struct impl_make_dextents<
     IndexType, Rank, ::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<IndexType, ExtentsPack...>>
 {
-  using type = typename __make_dextents<
+  using type = typename impl_make_dextents<
       IndexType, Rank - 1,
       ::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<IndexType,
                                                 ::MDSPAN_IMPL_STANDARD_NAMESPACE::dynamic_extent,
@@ -580,7 +580,7 @@ struct __make_dextents<
 };
 
 template <class IndexType, size_t... ExtentsPack>
-struct __make_dextents<
+struct impl_make_dextents<
     IndexType, 0, ::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<IndexType, ExtentsPack...>>
 {
   using type = ::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<IndexType, ExtentsPack...>;
@@ -590,7 +590,7 @@ struct __make_dextents<
 
 // [mdspan.extents.dextents], alias template
 template <class IndexType, size_t Rank>
-using dextents = typename detail::__make_dextents<IndexType, Rank>::type;
+using dextents = typename detail::impl_make_dextents<IndexType, Rank>::type;
 
 // Deduction guide for extents
 #if defined(MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION)
@@ -603,10 +603,10 @@ extents(IndexTypes...)
 // Helper type traits for identifying a class as extents.
 namespace detail {
 
-template <class T> struct __is_extents : ::std::false_type {};
+template <class T> struct impl_is_extents : ::std::false_type {};
 
 template <class IndexType, size_t... ExtentsPack>
-struct __is_extents<::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<IndexType, ExtentsPack...>>
+struct impl_is_extents<::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<IndexType, ExtentsPack...>>
     : ::std::true_type {};
 
 template <class T>
@@ -615,7 +615,7 @@ inline
 #else
 static
 #endif
-constexpr bool __is_extents_v = __is_extents<T>::value;
+constexpr bool impl_is_extents_v = impl_is_extents<T>::value;
 
 template<class InputIndexType, class ExtentsIndexType>
 MDSPAN_INLINE_FUNCTION

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -294,7 +294,7 @@ public:
         m_dyn_vals[dyn_map_t::get(r)] = values[r];
       }
 // Precondition check
-#ifdef _MDSPAN_DEBUG
+#ifdef MDSPAN_DEBUG
       else {
         assert(values[r] == static_cast<TDynamic>(static_val));
       }
@@ -309,7 +309,7 @@ public:
   constexpr maybe_static_array(const std::array<T, N> &vals) {
     static_assert((N == m_size), "Invalid number of values.");
 // Precondition check
-#ifdef _MDSPAN_DEBUG
+#ifdef MDSPAN_DEBUG
     assert(N == m_size);
 #endif
     for (size_t r = 0; r < m_size; r++) {
@@ -318,7 +318,7 @@ public:
         m_dyn_vals[dyn_map_t::get(r)] = static_cast<TDynamic>(vals[r]);
       }
 // Precondition check
-#ifdef _MDSPAN_DEBUG
+#ifdef MDSPAN_DEBUG
       else {
         assert(static_cast<TDynamic>(vals[r]) ==
                static_cast<TDynamic>(static_val));
@@ -334,7 +334,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr maybe_static_array(const std::span<T, N> &vals) {
     static_assert((N == m_size) || (m_size == dynamic_extent));
-#ifdef _MDSPAN_DEBUG
+#ifdef MDSPAN_DEBUG
     assert(N == m_size);
 #endif
     for (size_t r = 0; r < m_size; r++) {
@@ -342,7 +342,7 @@ public:
       if (static_val == dyn_tag) {
         m_dyn_vals[dyn_map_t::get(r)] = static_cast<TDynamic>(vals[r]);
       }
-#ifdef _MDSPAN_DEBUG
+#ifdef MDSPAN_DEBUG
       else {
         assert(static_cast<TDynamic>(vals[r]) ==
                static_cast<TDynamic>(static_val));
@@ -625,7 +625,7 @@ check_lower_bound(InputIndexType user_index,
                   std::true_type /* is_signed */)
 {
   (void) user_index; // prevent unused variable warning
-#ifdef _MDSPAN_DEBUG
+#ifdef MDSPAN_DEBUG
   assert(static_cast<ExtentsIndexType>(user_index) >= 0);
 #endif
 }
@@ -646,7 +646,7 @@ check_upper_bound(InputIndexType user_index,
 {
   (void) user_index; // prevent unused variable warnings
   (void) current_extent;
-#ifdef _MDSPAN_DEBUG
+#ifdef MDSPAN_DEBUG
   assert(static_cast<ExtentsIndexType>(user_index) < current_extent);
 #endif
 }

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -54,7 +54,7 @@ class layout_left::mapping {
     constexpr index_type compute_offset(
       rank_count<r,Rank>, const I& i, Indices... idx) const {
       return compute_offset(rank_count<r+1,Rank>(), idx...) *
-                 __extents.extent(r) + i;
+                 m_extents.extent(r) + i;
     }
 
     template<class I>
@@ -76,7 +76,7 @@ class layout_left::mapping {
 
     MDSPAN_IMPL_HOST_DEVICE
     constexpr mapping(extents_type const& exts) noexcept
-      :__extents(exts)
+      :m_extents(exts)
     { }
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -88,7 +88,7 @@ class layout_left::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
@@ -106,7 +106,7 @@ class layout_left::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(layout_right::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
@@ -133,15 +133,15 @@ class layout_left::mapping {
     )
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename Mapping::extents_type, extents_type>))
     MDSPAN_INLINE_FUNCTION constexpr
-    mapping(const _Mapping& __other) noexcept
-      : __extents(__other.extents())
+    mapping(const Mapping& other) noexcept
+      : m_extents(other.extents())
     {
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_mandates<
             extents_type, Mapping>(detail::with_rank<extents_type::rank()>{});
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_preconditions<
-              extents_type>(detail::with_rank<extents_type::rank()>{}, __other);
+              extents_type>(detail::with_rank<extents_type::rank()>{}, other);
     }
 #endif
 
@@ -154,26 +154,26 @@ class layout_left::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(layout_stride::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
         * other.required_span_size() is a representable value of type index_type
         */
-       detail::validate_strides(detail::with_rank<extents_type::rank()>{}, layout_left{}, __extents, other);
+       detail::validate_strides(detail::with_rank<extents_type::rank()>{}, layout_left{}, m_extents, other);
     }
 
     MDSPAN_INLINE_FUNCTION_DEFAULTED MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED mapping& operator=(mapping const&) noexcept = default;
 
     MDSPAN_INLINE_FUNCTION
     constexpr const extents_type& extents() const noexcept {
-      return __extents;
+      return m_extents;
     }
 
     MDSPAN_INLINE_FUNCTION
     constexpr index_type required_span_size() const noexcept {
       index_type value = 1;
-      for(rank_type r=0; r<extents_type::rank(); r++) value*=__extents.extent(r);
+      for(rank_type r=0; r<extents_type::rank(); r++) value*=m_extents.extent(r);
       return value;
     }
 
@@ -211,7 +211,7 @@ class layout_left::mapping {
 #endif
     {
       index_type value = 1;
-      for(rank_type r=0; r<i; r++) value*=__extents.extent(r);
+      for(rank_type r=0; r<i; r++) value*=m_extents.extent(r);
       return value;
     }
 
@@ -239,17 +239,17 @@ class layout_left::mapping {
     // Not really public, but currently needed to implement fully constexpr useable submdspan:
     template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
     MDSPAN_INLINE_FUNCTION
-    constexpr index_type __get_stride(MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
-      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx<N? __extents.template __extent<Idx>():1),1);
+    constexpr index_type impl_get_stride(MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
+      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx<N? m_extents.template __extent<Idx>():1),1);
     }
     template<size_t N>
     MDSPAN_INLINE_FUNCTION
-    constexpr index_type __stride() const noexcept {
-      return __get_stride<N>(__extents, std::make_index_sequence<extents_type::rank()>());
+    constexpr index_type impl_stide() const noexcept {
+      return impl_get_stride<N>(m_extents, std::make_index_sequence<extents_type::rank()>());
     }
 
 private:
-   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type m_extents{};
 
    // [mdspan.submdspan.mapping], submdspan mapping specialization
    template<class... SliceSpecifiers>

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -47,25 +47,25 @@ class layout_left::mapping {
 
     // i0+(i1 + E(1)*(i2 + E(2)*i3))
     template <size_t r, size_t Rank>
-    struct __rank_count {};
+    struct rank_count {};
 
     template <size_t r, size_t Rank, class I, class... Indices>
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __compute_offset(
-      __rank_count<r,Rank>, const I& i, Indices... idx) const {
-      return __compute_offset(__rank_count<r+1,Rank>(), idx...) *
+    constexpr index_type compute_offset(
+      rank_count<r,Rank>, const I& i, Indices... idx) const {
+      return compute_offset(rank_count<r+1,Rank>(), idx...) *
                  __extents.extent(r) + i;
     }
 
     template<class I>
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __compute_offset(
-      __rank_count<extents_type::rank()-1,extents_type::rank()>, const I& i) const {
+    constexpr index_type compute_offset(
+      rank_count<extents_type::rank()-1,extents_type::rank()>, const I& i) const {
       return i;
     }
 
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __compute_offset(__rank_count<0,0>) const { return 0; }
+    constexpr index_type compute_offset(rank_count<0,0>) const { return 0; }
 
   public:
 
@@ -75,8 +75,8 @@ class layout_left::mapping {
     MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping(mapping const&) noexcept = default;
 
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr mapping(extents_type const& __exts) noexcept
-      :__extents(__exts)
+    constexpr mapping(extents_type const& exts) noexcept
+      :__extents(exts)
     { }
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -118,27 +118,27 @@ class layout_left::mapping {
     /**
      * Converting constructor from `layout_left_padded::mapping`.
      *
-     * This overload participates in overload resolution only if _Mapping is a layout_left_padded mapping and
-     * extents_type is constructible from _Mapping::extents_type.
+     * This overload participates in overload resolution only if Mapping is a layout_left_padded mapping and
+     * extents_type is constructible from Mapping::extents_type.
      *
      * \note There is currently a difference from p2642r2, where this function is specified as taking
      * `layout_left_padded< padding_value >::mapping< Extents>`. However, this makes `padding_value` non-deducible.
      */
     MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
+      class Mapping,
       /* requires */ (
-        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_left_padded_mapping<_Mapping>::value
-        && std::is_constructible_v<extents_type, typename _Mapping::extents_type>
+        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_left_padded_mapping<Mapping>::value
+        && std::is_constructible_v<extents_type, typename Mapping::extents_type>
       )
     )
-    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename Mapping::extents_type, extents_type>))
     MDSPAN_INLINE_FUNCTION constexpr
     mapping(const _Mapping& __other) noexcept
       : __extents(__other.extents())
     {
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_mandates<
-            extents_type, _Mapping>(detail::with_rank<extents_type::rank()>{});
+            extents_type, Mapping>(detail::with_rank<extents_type::rank()>{});
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_preconditions<
               extents_type>(detail::with_rank<extents_type::rank()>{}, __other);
@@ -191,7 +191,7 @@ class layout_left::mapping {
 #if ! defined(NDEBUG)
       detail::check_all_indices(this->extents(), idxs...);
 #endif // ! NDEBUG
-      return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
+      return compute_offset(rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 
 

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -240,7 +240,7 @@ class layout_left::mapping {
     template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
     MDSPAN_INLINE_FUNCTION
     constexpr index_type impl_get_stride(MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
-      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx<N? m_extents.template __extent<Idx>():1),1);
+      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx<N? m_extents.template extent<Idx>():1),1);
     }
     template<size_t N>
     MDSPAN_INLINE_FUNCTION

--- a/include/experimental/__p0009_bits/layout_left.hpp
+++ b/include/experimental/__p0009_bits/layout_left.hpp
@@ -39,7 +39,7 @@ class layout_left::mapping {
     using layout_type = layout_left;
   private:
 
-    static_assert(detail::__is_extents_v<extents_type>,
+    static_assert(detail::impl_is_extents_v<extents_type>,
                   MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::layout_left::mapping must be instantiated with a specialization of " MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::extents.");
 
     template <class>

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -51,7 +51,7 @@ class layout_right::mapping {
     MDSPAN_IMPL_HOST_DEVICE
     constexpr index_type compute_offset(
       index_type offset, rank_count<r,Rank>, const I& i, Indices... idx) const {
-      return compute_offset(offset * __extents.extent(r) + i,rank_count<r+1,Rank>(),  idx...);
+      return compute_offset(offset * m_extents.extent(r) + i,rank_count<r+1,Rank>(),  idx...);
     }
 
     template<class I, class ... Indices>
@@ -78,7 +78,7 @@ class layout_right::mapping {
 
     MDSPAN_IMPL_HOST_DEVICE
     constexpr mapping(extents_type const& exts) noexcept
-      :__extents(exts)
+      :m_extents(exts)
     { }
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -90,7 +90,7 @@ class layout_right::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
@@ -108,7 +108,7 @@ class layout_right::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(layout_left::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
@@ -133,15 +133,15 @@ class layout_right::mapping {
         && std::is_constructible_v<extents_type, typename Mapping::extents_type>))
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename Mapping::extents_type, extents_type>))
     MDSPAN_INLINE_FUNCTION constexpr
-    mapping(const _Mapping &__other) noexcept
-        : __extents(__other.extents())
+    mapping(const Mapping &other) noexcept
+        : m_extents(other.extents())
     {
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_mandates<
             extents_type, Mapping>(detail::with_rank<extents_type::rank()>{});
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_preconditions<
-            extents_type>(detail::with_rank<extents_type::rank()>{}, __other);
+            extents_type>(detail::with_rank<extents_type::rank()>{}, other);
     }
 #endif
 
@@ -154,26 +154,26 @@ class layout_right::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(layout_stride::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
         * other.required_span_size() is a representable value of type index_type
         */
-       detail::validate_strides(detail::with_rank<extents_type::rank()>{}, layout_right{}, __extents, other);
+       detail::validate_strides(detail::with_rank<extents_type::rank()>{}, layout_right{}, m_extents, other);
     }
 
     MDSPAN_INLINE_FUNCTION_DEFAULTED MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED mapping& operator=(mapping const&) noexcept = default;
 
     MDSPAN_INLINE_FUNCTION
     constexpr const extents_type& extents() const noexcept {
-      return __extents;
+      return m_extents;
     }
 
     MDSPAN_INLINE_FUNCTION
     constexpr index_type required_span_size() const noexcept {
       index_type value = 1;
-      for(rank_type r=0; r != extents_type::rank(); ++r) value*=__extents.extent(r);
+      for(rank_type r=0; r != extents_type::rank(); ++r) value*=m_extents.extent(r);
       return value;
     }
 
@@ -208,7 +208,7 @@ class layout_right::mapping {
 #endif
     {
       index_type value = 1;
-      for(rank_type r=extents_type::rank()-1; r>i; r--) value*=__extents.extent(r);
+      for(rank_type r=extents_type::rank()-1; r>i; r--) value*=m_extents.extent(r);
       return value;
     }
 
@@ -236,17 +236,17 @@ class layout_right::mapping {
     // Not really public, but currently needed to implement fully constexpr useable submdspan:
     template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
     MDSPAN_INLINE_FUNCTION
-    constexpr index_type __get_stride(MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
-      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx>N? __extents.template __extent<Idx>():1),1);
+    constexpr index_type impl_get_stride(MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
+      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx>N? m_extents.template __extent<Idx>():1),1);
     }
     template<size_t N>
     MDSPAN_INLINE_FUNCTION
-    constexpr index_type __stride() const noexcept {
-      return __get_stride<N>(__extents, std::make_index_sequence<extents_type::rank()>());
+    constexpr index_type impl_stide() const noexcept {
+      return impl_get_stride<N>(m_extents, std::make_index_sequence<extents_type::rank()>());
     }
 
 private:
-   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type m_extents{};
 
    // [mdspan.submdspan.mapping], submdspan mapping specialization
    template<class... SliceSpecifiers>

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -237,7 +237,7 @@ class layout_right::mapping {
     template<size_t N, class SizeType, size_t ... E, size_t ... Idx>
     MDSPAN_INLINE_FUNCTION
     constexpr index_type impl_get_stride(MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, E...>,std::integer_sequence<size_t, Idx...>) const {
-      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx>N? m_extents.template __extent<Idx>():1),1);
+      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((Idx>N? m_extents.template extent<Idx>():1),1);
     }
     template<size_t N>
     MDSPAN_INLINE_FUNCTION

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -45,29 +45,29 @@ class layout_right::mapping {
 
     // i0+(i1 + E(1)*(i2 + E(2)*i3))
     template <size_t r, size_t Rank>
-    struct __rank_count {};
+    struct rank_count {};
 
     template <size_t r, size_t Rank, class I, class... Indices>
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __compute_offset(
-      index_type offset, __rank_count<r,Rank>, const I& i, Indices... idx) const {
-      return __compute_offset(offset * __extents.extent(r) + i,__rank_count<r+1,Rank>(),  idx...);
+    constexpr index_type compute_offset(
+      index_type offset, rank_count<r,Rank>, const I& i, Indices... idx) const {
+      return compute_offset(offset * __extents.extent(r) + i,rank_count<r+1,Rank>(),  idx...);
     }
 
     template<class I, class ... Indices>
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __compute_offset(
-      __rank_count<0,extents_type::rank()>, const I& i, Indices... idx) const {
-      return __compute_offset(i,__rank_count<1,extents_type::rank()>(),idx...);
+    constexpr index_type compute_offset(
+      rank_count<0,extents_type::rank()>, const I& i, Indices... idx) const {
+      return compute_offset(i,rank_count<1,extents_type::rank()>(),idx...);
     }
 
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __compute_offset(size_t offset, __rank_count<extents_type::rank(), extents_type::rank()>) const {
+    constexpr index_type compute_offset(size_t offset, rank_count<extents_type::rank(), extents_type::rank()>) const {
       return static_cast<index_type>(offset);
     }
 
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __compute_offset(__rank_count<0,0>) const { return 0; }
+    constexpr index_type compute_offset(rank_count<0,0>) const { return 0; }
 
   public:
 
@@ -77,8 +77,8 @@ class layout_right::mapping {
     MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping(mapping const&) noexcept = default;
 
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr mapping(extents_type const& __exts) noexcept
-      :__extents(__exts)
+    constexpr mapping(extents_type const& exts) noexcept
+      :__extents(exts)
     { }
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -119,26 +119,26 @@ class layout_right::mapping {
     /**
      * Converting constructor from `layout_right_padded::mapping`.
      *
-     * This overload participates in overload resolution only if _Mapping is a layout_right_padded mapping and
-     * extents_type is constructible from _Mapping::extents_type.
+     * This overload participates in overload resolution only if Mapping is a layout_right_padded mapping and
+     * extents_type is constructible from Mapping::extents_type.
      *
      * \note There is currently a difference from p2642r2, where this function is specified as taking
      * `layout_right_padded< padding_value >::mapping< Extents>`. However, this makes `padding_value` non-deducible.
      */
 #if MDSPAN_HAS_CXX_17
     MDSPAN_TEMPLATE_REQUIRES(
-        class _Mapping,
+        class Mapping,
         /* requires */ (
-        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<_Mapping>::value
-        && std::is_constructible_v<extents_type, typename _Mapping::extents_type>))
-    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<Mapping>::value
+        && std::is_constructible_v<extents_type, typename Mapping::extents_type>))
+    MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible_v<typename Mapping::extents_type, extents_type>))
     MDSPAN_INLINE_FUNCTION constexpr
     mapping(const _Mapping &__other) noexcept
         : __extents(__other.extents())
     {
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_mandates<
-            extents_type, _Mapping>(detail::with_rank<extents_type::rank()>{});
+            extents_type, Mapping>(detail::with_rank<extents_type::rank()>{});
       MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::
           check_padded_layout_converting_constructor_preconditions<
             extents_type>(detail::with_rank<extents_type::rank()>{}, __other);
@@ -191,7 +191,7 @@ class layout_right::mapping {
 #if ! defined(NDEBUG)
       detail::check_all_indices(this->extents(), idxs...);
 #endif // ! NDEBUG
-      return __compute_offset(__rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
+      return compute_offset(rank_count<0, extents_type::rank()>(), static_cast<index_type>(idxs)...);
     }
 
     MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept { return true; }

--- a/include/experimental/__p0009_bits/layout_right.hpp
+++ b/include/experimental/__p0009_bits/layout_right.hpp
@@ -37,7 +37,7 @@ class layout_right::mapping {
     using layout_type = layout_right;
   private:
 
-    static_assert(detail::__is_extents_v<extents_type>,
+    static_assert(detail::impl_is_extents_v<extents_type>,
                   MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::layout_right::mapping must be instantiated with a specialization of " MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::extents.");
 
     template <class>

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -56,8 +56,8 @@ namespace detail {
 #  if !defined(__cpp_lib_concepts)
   namespace internal {
   namespace detail {
-  template <typename _Tp, typename _Up>
-  concept __same_as = std::is_same_v<_Tp, _Up>;
+  template <typename Tp, typename _Up>
+  concept __same_as = std::is_same_v<Tp, _Up>;
   } // namespace detail
   template <class T, class U>
   concept __same_as = detail::__same_as<T, U> && detail::__same_as<U, T>;

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -49,7 +49,7 @@ struct layout_right {
 
 namespace detail {
   template<class Layout, class Mapping>
-  constexpr bool __is_mapping_of =
+  constexpr bool is_mapping_of =
     std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
 
 #if defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
@@ -65,7 +65,7 @@ namespace detail {
 #  endif
 
   template<class M>
-  concept __layout_mapping_alike = requires {
+  concept layout_mapping_alike = requires {
     requires impl_is_extents<typename M::extents_type>::value;
 #if defined(__cpp_lib_concepts)
     { M::is_always_strided() } -> std::same_as<bool>;
@@ -112,35 +112,35 @@ struct layout_stride {
 
     //----------------------------------------------------------------------------
 
-    using __strides_storage_t = detail::possibly_empty_array<index_type, extents_type::rank()>;
-    using __member_pair_t = detail::impl_compressed_pair<extents_type, __strides_storage_t>;
+    using strides_storage_t = detail::possibly_empty_array<index_type, extents_type::rank()>;
+    using member_pair_t = detail::impl_compressed_pair<extents_type, strides_storage_t>;
 
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-    MDSPAN_IMPL_NO_UNIQUE_ADDRESS __member_pair_t __members;
+    MDSPAN_IMPL_NO_UNIQUE_ADDRESS member_pair_t m_members;
 #else
-    using __base_t = detail::__no_unique_address_emulation<__member_pair_t>;
+    using base_t = detail::__no_unique_address_emulation<member_pair_t>;
 #endif
 
-    MDSPAN_FORCE_INLINE_FUNCTION constexpr __strides_storage_t const&
-    __strides_storage() const noexcept {
+    MDSPAN_FORCE_INLINE_FUNCTION constexpr strides_storage_t const&
+    strides_storage() const noexcept {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      return __members.second();
+      return m_members.second();
 #else
-      return this->__base_t::__ref().second();
+      return this->base_t::__ref().second();
 #endif
     }
-    MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 __strides_storage_t&
-    __strides_storage() noexcept {
+    MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 strides_storage_t&
+    strides_storage() noexcept {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      return __members.second();
+      return m_members.second();
 #else
-      return this->__base_t::__ref().second();
+      return this->base_t::__ref().second();
 #endif
     }
 
     template<class SizeType, size_t ... Ep, size_t ... Idx>
     MDSPAN_IMPL_HOST_DEVICE
-    constexpr index_type __get_size(::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, Ep...>,std::integer_sequence<size_t, Idx...>) const {
+    constexpr index_type get_size(::MDSPAN_IMPL_STANDARD_NAMESPACE::extents<SizeType, Ep...>,std::integer_sequence<size_t, Idx...>) const {
       return MDSPAN_IMPL_FOLD_TIMES_RIGHT( static_cast<index_type>(extents().extent(Idx)), 1 );
     }
 
@@ -153,10 +153,10 @@ struct layout_stride {
 
     // Workaround for non-deducibility of the index sequence template parameter if it's given at the top level
     template <class>
-    struct __deduction_workaround;
+    struct deduction_workaround;
 
     template <size_t... Idxs>
-    struct __deduction_workaround<std::index_sequence<Idxs...>>
+    struct deduction_workaround<std::index_sequence<Idxs...>>
     {
       template <class OtherExtents>
       MDSPAN_INLINE_FUNCTION
@@ -182,23 +182,23 @@ struct layout_stride {
       MDSPAN_INLINE_FUNCTION
       static constexpr size_t _req_span_size_impl(mapping const& self) noexcept {
         // assumes no negative strides; not sure if I'm allowed to assume that or not
-        return __impl::_call_op_impl(self, (self.extents().template __extent<Idxs>() - 1)...) + 1;
+        return deduction_workaround_impl::_call_op_impl(self, (self.extents().template __extent<Idxs>() - 1)...) + 1;
       }
 
       template<class OtherMapping>
       MDSPAN_INLINE_FUNCTION
-      static constexpr const __strides_storage_t fill_strides(const OtherMapping& map) {
-        return __strides_storage_t{static_cast<index_type>(map.stride(Idxs))...};
+      static constexpr const strides_storage_t fill_strides(const OtherMapping& map) {
+        return strides_storage_t{static_cast<index_type>(map.stride(Idxs))...};
       }
 
       MDSPAN_INLINE_FUNCTION
-      static constexpr const __strides_storage_t& fill_strides(const __strides_storage_t& s) {
+      static constexpr const strides_storage_t& fill_strides(const strides_storage_t& s) {
         return s;
       }
 
       template<class IntegralType>
-      static constexpr const __strides_storage_t fill_strides(const std::array<IntegralType,extents_type::rank()>& s) {
-        return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
+      static constexpr const strides_storage_t fill_strides(const std::array<IntegralType,extents_type::rank()>& s) {
+        return strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 
       MDSPAN_TEMPLATE_REQUIRES(
@@ -207,44 +207,44 @@ struct layout_stride {
       )
       MDSPAN_INLINE_FUNCTION
       // Need to avoid zero length c-array
-      static constexpr const __strides_storage_t fill_strides(mdspan_non_standard_tag, const IntegralType (&s)[extents_type::rank()>0?extents_type::rank():1]) {
-        return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
+      static constexpr const strides_storage_t fill_strides(mdspan_non_standard_tag, const IntegralType (&s)[extents_type::rank()>0?extents_type::rank():1]) {
+        return strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 
 #ifdef __cpp_lib_span
       template<class IntegralType>
-      static constexpr const __strides_storage_t fill_strides(const std::span<IntegralType,extents_type::rank()>& s) {
-        return __strides_storage_t{static_cast<index_type>(s[Idxs])...};
+      static constexpr const strides_storage_t fill_strides(const std::span<IntegralType,extents_type::rank()>& s) {
+        return strides_storage_t{static_cast<index_type>(s[Idxs])...};
       }
 #endif
 
       MDSPAN_INLINE_FUNCTION
-      static constexpr std::array<index_type, extents_type::rank()> return_strides(const __strides_storage_t& s) {
+      static constexpr std::array<index_type, extents_type::rank()> return_strides(const strides_storage_t& s) {
         return std::array<index_type, extents_type::rank()>{s[Idxs]...};
       }
 
       template<size_t K>
       MDSPAN_INLINE_FUNCTION
-      static constexpr size_t __return_zero() { return 0; }
+      static constexpr size_t return_zero() { return 0; }
 
       template<class Mapping>
       MDSPAN_INLINE_FUNCTION
       static constexpr typename Mapping::index_type
-        __OFFSET(const Mapping& m) { return m(__return_zero<Idxs>()...); }
+        offset(const Mapping& m) { return m(return_zero<Idxs>()...); }
     };
 
-    // Can't use defaulted parameter in the __deduction_workaround template because of a bug in MSVC warning C4348.
-    using __impl = __deduction_workaround<std::make_index_sequence<Extents::rank()>>;
+    // Can't use defaulted parameter in the deduction_workaround template because of a bug in MSVC warning C4348.
+    using deduction_workaround_impl = deduction_workaround<std::make_index_sequence<Extents::rank()>>;
 
     MDSPAN_FUNCTION
-    static constexpr __strides_storage_t strides_storage(detail::with_rank<0>) {
+    static constexpr strides_storage_t strides_storage(detail::with_rank<0>) {
       return {};
     }
 
     template <std::size_t N>
     MDSPAN_FUNCTION
-    static constexpr __strides_storage_t strides_storage(detail::with_rank<N>) {
-      __strides_storage_t s{};
+    static constexpr strides_storage_t strides_storage(detail::with_rank<N>) {
+      strides_storage_t s{};
 
       extents_type e;
       index_type stride = 1;
@@ -260,10 +260,10 @@ struct layout_stride {
 
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     MDSPAN_INLINE_FUNCTION constexpr explicit
-    mapping(__member_pair_t&& __m) : __members(::std::move(__m)) {}
+    mapping(member_pair_t&& m) : m_members(::std::move(m)) {}
 #else
     MDSPAN_INLINE_FUNCTION constexpr explicit
-    mapping(__base_t&& __b) : __base_t(::std::move(__b)) {}
+    mapping(base_t&& __b) : base_t(::std::move(__b)) {}
 #endif
 
   public:
@@ -272,12 +272,12 @@ struct layout_stride {
 
     MDSPAN_INLINE_FUNCTION constexpr mapping() noexcept
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      : __members{
+      : m_members{
 #else
-      : __base_t(__base_t{__member_pair_t(
+      : base_t(base_t{member_pair_t(
 #endif
           extents_type(),
-          __strides_storage_t(strides_storage(detail::with_rank<extents_type::rank()>{}))
+          strides_storage_t(strides_storage(detail::with_rank<extents_type::rank()>{}))
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -302,11 +302,11 @@ struct layout_stride {
       std::array<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      : __members{
+      : m_members{
 #else
-      : __base_t(__base_t{__member_pair_t(
+      : base_t(base_t{member_pair_t(
 #endif
-          e, __strides_storage_t(__impl::fill_strides(s))
+          e, strides_storage_t(deduction_workaround_impl::fill_strides(s))
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -341,11 +341,11 @@ struct layout_stride {
       const IntegralTypes (&s)[extents_type::rank()>0?extents_type::rank():1]
     ) noexcept
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      : __members{
+      : m_members{
 #else
-      : __base_t(__base_t{__member_pair_t(
+      : base_t(base_t{member_pair_t(
 #endif
-          e, __strides_storage_t(__impl::fill_strides(mdspan_non_standard, s))
+          e, strides_storage_t(deduction_workaround_impl::fill_strides(mdspan_non_standard, s))
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -378,11 +378,11 @@ struct layout_stride {
       std::span<IntegralTypes, extents_type::rank()> const& s
     ) noexcept
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      : __members{
+      : m_members{
 #else
-      : __base_t(__base_t{__member_pair_t(
+      : base_t(base_t{member_pair_t(
 #endif
-          e, __strides_storage_t(__impl::fill_strides(s))
+          e, strides_storage_t(deduction_workaround_impl::fill_strides(s))
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -405,7 +405,7 @@ struct layout_stride {
       class StridedLayoutMapping,
       /* requires */ (
         MDSPAN_IMPL_TRAIT(std::is_constructible, extents_type, typename StridedLayoutMapping::extents_type) &&
-        detail::__is_mapping_of<typename StridedLayoutMapping::layout_type, StridedLayoutMapping> &&
+        detail::is_mapping_of<typename StridedLayoutMapping::layout_type, StridedLayoutMapping> &&
         StridedLayoutMapping::is_always_unique() &&
         StridedLayoutMapping::is_always_strided()
       )
@@ -413,7 +413,7 @@ struct layout_stride {
 #else
     template<class StridedLayoutMapping>
     requires(
-         detail::__layout_mapping_alike<StridedLayoutMapping> &&
+         detail::layout_mapping_alike<StridedLayoutMapping> &&
          MDSPAN_IMPL_TRAIT(std::is_constructible, extents_type, typename StridedLayoutMapping::extents_type) &&
          StridedLayoutMapping::is_always_unique() &&
          StridedLayoutMapping::is_always_strided()
@@ -421,18 +421,18 @@ struct layout_stride {
 #endif
     MDSPAN_CONDITIONAL_EXPLICIT(
       !(std::is_convertible<typename StridedLayoutMapping::extents_type, extents_type>::value &&
-       (detail::__is_mapping_of<layout_left, StridedLayoutMapping> ||
-        detail::__is_mapping_of<layout_right, StridedLayoutMapping> ||
-        detail::__is_mapping_of<layout_stride, StridedLayoutMapping>))
+       (detail::is_mapping_of<layout_left, StridedLayoutMapping> ||
+        detail::is_mapping_of<layout_right, StridedLayoutMapping> ||
+        detail::is_mapping_of<layout_stride, StridedLayoutMapping>))
     ) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(StridedLayoutMapping const& other) noexcept // NOLINT(google-explicit-constructor)
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      : __members{
+      : m_members{
 #else
-      : __base_t(__base_t{__member_pair_t(
+      : base_t(base_t{member_pair_t(
 #endif
-          other.extents(), __strides_storage_t(__impl::fill_strides(other))
+          other.extents(), strides_storage_t(deduction_workaround_impl::fill_strides(other))
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else
@@ -454,15 +454,15 @@ struct layout_stride {
 
     MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      return __members.first();
+      return m_members.first();
 #else
-      return this->__base_t::__ref().first();
+      return this->base_t::__ref().first();
 #endif
     };
 
     MDSPAN_INLINE_FUNCTION
     constexpr std::array< index_type, extents_type::rank() > strides() const noexcept {
-      return __impl::return_strides(__strides_storage());
+      return deduction_workaround_impl::return_strides(strides_storage());
     }
 
     MDSPAN_INLINE_FUNCTION
@@ -472,7 +472,7 @@ struct layout_stride {
       for(int r = 0; r < static_cast<int>(extents_type::rank()); r++) {
         // Return early if any of the extents are zero
         if(extents().extent(r)==0) return 0;
-        span_size += ( static_cast<index_type>(extents().extent(r) - 1 ) * __strides_storage()[r]);
+        span_size += ( static_cast<index_type>(extents().extent(r) - 1 ) * strides_storage()[r]);
       }
       return span_size;
     }
@@ -490,7 +490,7 @@ struct layout_stride {
 #if ! defined(NDEBUG)
       detail::check_all_indices(this->extents(), idxs...);
 #endif // ! NDEBUG
-      return static_cast<index_type>(__impl::_call_op_impl(*this, static_cast<index_type>(idxs)...));
+      return static_cast<index_type>(deduction_workaround_impl::_call_op_impl(*this, static_cast<index_type>(idxs)...));
     }
 
     MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept { return true; }
@@ -505,7 +505,7 @@ struct layout_stride {
     MDSPAN_INLINE_FUNCTION
     constexpr bool exhaustive_for_nonzero_span_size() const
     {
-      return required_span_size() == __get_size(extents(), std::make_index_sequence<extents_type::rank()>());
+      return required_span_size() == get_size(extents(), std::make_index_sequence<extents_type::rank()>());
     }
 
     MDSPAN_INLINE_FUNCTION
@@ -552,14 +552,14 @@ struct layout_stride {
 
     MDSPAN_INLINE_FUNCTION
     constexpr index_type stride(rank_type r) const noexcept {
-      return __strides_storage()[r];
+      return strides_storage()[r];
     }
 
 #if !(defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20)
     MDSPAN_TEMPLATE_REQUIRES(
       class StridedLayoutMapping,
       /* requires */ (
-        detail::__is_mapping_of<typename StridedLayoutMapping::layout_type, StridedLayoutMapping> &&
+        detail::is_mapping_of<typename StridedLayoutMapping::layout_type, StridedLayoutMapping> &&
         (extents_type::rank() == StridedLayoutMapping::extents_type::rank()) &&
         StridedLayoutMapping::is_always_strided()
       )
@@ -567,7 +567,7 @@ struct layout_stride {
 #else
     template<class StridedLayoutMapping>
     requires(
-         detail::__layout_mapping_alike<StridedLayoutMapping> &&
+         detail::layout_mapping_alike<StridedLayoutMapping> &&
          (extents_type::rank() == StridedLayoutMapping::extents_type::rank()) &&
          StridedLayoutMapping::is_always_strided()
     )
@@ -575,7 +575,7 @@ struct layout_stride {
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator==(const mapping& x, const StridedLayoutMapping& y) noexcept {
       return (x.extents() == y.extents()) &&
-             (__impl::__OFFSET(y) == static_cast<typename StridedLayoutMapping::index_type>(0)) &&
+             (deduction_workaround_impl::offset(y) == static_cast<typename StridedLayoutMapping::index_type>(0)) &&
              detail::rankwise_equal(detail::with_rank<extents_type::rank()>{}, x, y, detail::stride);
     }
 
@@ -588,14 +588,14 @@ struct layout_stride {
     )
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator==(mapping const& lhs, mapping<OtherExtents> const& rhs) noexcept {
-      return __impl::_eq_impl(lhs, rhs);
+      return deduction_workaround_impl::_eq_impl(lhs, rhs);
     }
 
 #if !MDSPAN_HAS_CXX_20
     MDSPAN_TEMPLATE_REQUIRES(
       class StridedLayoutMapping,
       /* requires */ (
-        detail::__is_mapping_of<typename StridedLayoutMapping::layout_type, StridedLayoutMapping> &&
+        detail::is_mapping_of<typename StridedLayoutMapping::layout_type, StridedLayoutMapping> &&
         (extents_type::rank() == StridedLayoutMapping::extents_type::rank()) &&
         StridedLayoutMapping::is_always_strided()
       )
@@ -613,7 +613,7 @@ struct layout_stride {
     )
     MDSPAN_INLINE_FUNCTION
     friend constexpr bool operator!=(mapping const& lhs, mapping<OtherExtents> const& rhs) noexcept {
-      return __impl::_not_eq_impl(lhs, rhs);
+      return deduction_workaround_impl::_not_eq_impl(lhs, rhs);
     }
 #endif
 

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -57,10 +57,10 @@ namespace detail {
   namespace internal {
   namespace detail {
   template <typename Tp, typename _Up>
-  concept __same_as = std::is_same_v<Tp, _Up>;
+  concept same_as = std::is_same_v<Tp, _Up>;
   } // namespace detail
   template <class T, class U>
-  concept __same_as = detail::__same_as<T, U> && detail::__same_as<U, T>;
+  concept same_as = detail::same_as<T, U> && detail::same_as<U, T>;
   } // namespace internal
 #  endif
 
@@ -72,9 +72,9 @@ namespace detail {
     { M::is_always_exhaustive() } -> std::same_as<bool>;
     { M::is_always_unique() } -> std::same_as<bool>;
 #else
-    { M::is_always_strided() } -> internal::__same_as<bool>;
-    { M::is_always_exhaustive() } -> internal::__same_as<bool>;
-    { M::is_always_unique() } -> internal::__same_as<bool>;
+    { M::is_always_strided() } -> internal::same_as<bool>;
+    { M::is_always_exhaustive() } -> internal::_ame_as<bool>;
+    { M::is_always_unique() } -> internal::same_as<bool>;
 #endif
     std::bool_constant<M::is_always_strided()>::value;
     std::bool_constant<M::is_always_exhaustive()>::value;
@@ -182,7 +182,7 @@ struct layout_stride {
       MDSPAN_INLINE_FUNCTION
       static constexpr size_t _req_span_size_impl(mapping const& self) noexcept {
         // assumes no negative strides; not sure if I'm allowed to assume that or not
-        return deduction_workaround_impl::_call_op_impl(self, (self.extents().template __extent<Idxs>() - 1)...) + 1;
+        return deduction_workaround_impl::_call_op_impl(self, (self.extents().template extent<Idxs>() - 1)...) + 1;
       }
 
       template<class OtherMapping>

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -66,7 +66,7 @@ namespace detail {
 
   template<class M>
   concept __layout_mapping_alike = requires {
-    requires __is_extents<typename M::extents_type>::value;
+    requires impl_is_extents<typename M::extents_type>::value;
 #if defined(__cpp_lib_concepts)
     { M::is_always_strided() } -> std::same_as<bool>;
     { M::is_always_exhaustive() } -> std::same_as<bool>;
@@ -89,7 +89,7 @@ struct layout_stride {
   class mapping
 #if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     : private detail::__no_unique_address_emulation<
-        detail::__compressed_pair<
+        detail::impl_compressed_pair<
           Extents,
           detail::possibly_empty_array<typename Extents::index_type, Extents::rank()>
         >
@@ -104,7 +104,7 @@ struct layout_stride {
     using layout_type = layout_stride;
 
     // This could be a `requires`, but I think it's better and clearer as a `static_assert`.
-    static_assert(detail::__is_extents_v<Extents>,
+    static_assert(detail::impl_is_extents_v<Extents>,
                   MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::layout_stride::mapping must be instantiated with a specialization of " MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::extents.");
 
 
@@ -113,7 +113,7 @@ struct layout_stride {
     //----------------------------------------------------------------------------
 
     using __strides_storage_t = detail::possibly_empty_array<index_type, extents_type::rank()>;
-    using __member_pair_t = detail::__compressed_pair<extents_type, __strides_storage_t>;
+    using __member_pair_t = detail::impl_compressed_pair<extents_type, __strides_storage_t>;
 
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     MDSPAN_IMPL_NO_UNIQUE_ADDRESS __member_pair_t __members;
@@ -124,17 +124,17 @@ struct layout_stride {
     MDSPAN_FORCE_INLINE_FUNCTION constexpr __strides_storage_t const&
     __strides_storage() const noexcept {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      return __members.__second();
+      return __members.second();
 #else
-      return this->__base_t::__ref().__second();
+      return this->__base_t::__ref().second();
 #endif
     }
     MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 __strides_storage_t&
     __strides_storage() noexcept {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      return __members.__second();
+      return __members.second();
 #else
-      return this->__base_t::__ref().__second();
+      return this->__base_t::__ref().second();
 #endif
     }
 
@@ -454,9 +454,9 @@ struct layout_stride {
 
     MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-      return __members.__first();
+      return __members.first();
 #else
-      return this->__base_t::__ref().__first();
+      return this->__base_t::__ref().first();
 #endif
     };
 

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -88,7 +88,7 @@ struct layout_stride {
   template <class Extents>
   class mapping
 #if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
-    : private detail::__no_unique_address_emulation<
+    : private detail::no_unique_address_emulation<
         detail::impl_compressed_pair<
           Extents,
           detail::possibly_empty_array<typename Extents::index_type, Extents::rank()>
@@ -118,7 +118,7 @@ struct layout_stride {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
     MDSPAN_IMPL_NO_UNIQUE_ADDRESS member_pair_t m_members;
 #else
-    using base_t = detail::__no_unique_address_emulation<member_pair_t>;
+    using base_t = detail::no_unique_address_emulation<member_pair_t>;
 #endif
 
     MDSPAN_FORCE_INLINE_FUNCTION constexpr strides_storage_t const&
@@ -126,7 +126,7 @@ struct layout_stride {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return m_members.second();
 #else
-      return this->base_t::__ref().second();
+      return this->base_t::ref().second();
 #endif
     }
     MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 strides_storage_t&
@@ -134,7 +134,7 @@ struct layout_stride {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return m_members.second();
 #else
-      return this->base_t::__ref().second();
+      return this->base_t::ref().second();
 #endif
     }
 
@@ -456,7 +456,7 @@ struct layout_stride {
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
       return m_members.first();
 #else
-      return this->base_t::__ref().first();
+      return this->base_t::ref().first();
 #endif
     };
 

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -339,7 +339,7 @@ MDSPAN_FUNCTION constexpr void precondition(const char* cond, const char* file, 
 //==============================================================================
 // <editor-fold desc="fold expressions"> {{{1
 
-struct mdspan_enable_fold_comma { };
+struct enable_fold_comma { };
 
 #ifdef MDSPAN_IMPL_USE_FOLD_EXPRESSIONS
 #  define MDSPAN_IMPL_FOLD_AND(...) ((__VA_ARGS__) && ...)
@@ -648,7 +648,7 @@ fold_left_assign_impl(Args&&... args) {
 
 
 template <class... Args>
-constexpr mdspan_enable_fold_comma fold_comma_impl(Args&&...) noexcept { return { }; }
+constexpr enable_fold_comma fold_comma_impl(Args&&...) noexcept { return { }; }
 
 template <bool... Bs>
 struct fold_bools;

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -32,7 +32,7 @@ template <
 class mdspan
 {
 private:
-  static_assert(detail::__is_extents_v<Extents>,
+  static_assert(detail::impl_is_extents_v<Extents>,
                 MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::mdspan's Extents template parameter must be a specialization of " MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::extents.");
   static_assert(std::is_same<ElementType, typename AccessorPolicy::element_type>::value,
                 MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::mdspan's ElementType template parameter must be the same as its AccessorPolicy::element_type.");
@@ -93,7 +93,7 @@ private:
   // Can't use defaulted parameter in the __deduction_workaround template because of a bug in MSVC warning C4348.
   using __impl = __deduction_workaround<std::make_index_sequence<extents_type::rank()>>;
 
-  using __map_acc_pair_t = detail::__compressed_pair<mapping_type, accessor_type>;
+  using __map_acc_pair_t = detail::impl_compressed_pair<mapping_type, accessor_type>;
 
 public:
 
@@ -368,14 +368,14 @@ public:
 
 private:
 
-  detail::__compressed_pair<data_handle_type, __map_acc_pair_t> __members{};
+  detail::impl_compressed_pair<data_handle_type, __map_acc_pair_t> __members{};
 
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 data_handle_type& __ptr_ref() noexcept { return __members.__first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr data_handle_type const& __ptr_ref() const noexcept { return __members.__first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 mapping_type& __mapping_ref() noexcept { return __members.__second().__first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr mapping_type const& __mapping_ref() const noexcept { return __members.__second().__first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 accessor_type& __accessor_ref() noexcept { return __members.__second().__second(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr accessor_type const& __accessor_ref() const noexcept { return __members.__second().__second(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 data_handle_type& __ptr_ref() noexcept { return __members.first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr data_handle_type const& __ptr_ref() const noexcept { return __members.first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 mapping_type& __mapping_ref() noexcept { return __members.second().first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr mapping_type const& __mapping_ref() const noexcept { return __members.second().first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 accessor_type& __accessor_ref() noexcept { return __members.second().second(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr accessor_type const& __accessor_ref() const noexcept { return __members.second().second(); }
 
   template <class, class, class, class>
   friend class mdspan;

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -45,23 +45,23 @@ private:
   struct deduction_workaround<std::index_sequence<Idxs...>>
   {
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
-    size_t __size(mdspan const& __self) noexcept {
-      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((__self.__mapping_ref().extents().extent(Idxs)), /* * ... * */ size_t(1));
+    size_t size(mdspan const& self) noexcept {
+      return MDSPAN_IMPL_FOLD_TIMES_RIGHT((self.mapping_ref().extents().extent(Idxs)), /* * ... * */ size_t(1));
     }
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
-    bool __empty(mdspan const& __self) noexcept {
-      return (__self.rank()>0) && MDSPAN_IMPL_FOLD_OR((__self.__mapping_ref().extents().extent(Idxs)==index_type(0)));
+    bool empty(mdspan const& self) noexcept {
+      return (self.rank()>0) && MDSPAN_IMPL_FOLD_OR((self.mapping_ref().extents().extent(Idxs)==index_type(0)));
     }
     template <class ReferenceType, class SizeType, size_t N>
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
-    ReferenceType __callop(mdspan const& __self, const std::array<SizeType, N>& indices) noexcept {
-      return __self.__accessor_ref().access(__self.__ptr_ref(), __self.__mapping_ref()(indices[Idxs]...));
+    ReferenceType callop(mdspan const& self, const std::array<SizeType, N>& indices) noexcept {
+      return self.accessor_ref().access(self.ptr_ref(), self.mapping_ref()(indices[Idxs]...));
     }
 #ifdef __cpp_lib_span
     template <class ReferenceType, class SizeType, size_t N>
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
-    ReferenceType __callop(mdspan const& __self, const std::span<SizeType, N>& indices) noexcept {
-      return __self.__accessor_ref().access(__self.__ptr_ref(), __self.__mapping_ref()(indices[Idxs]...));
+    ReferenceType callop(mdspan const& self, const std::span<SizeType, N>& indices) noexcept {
+      return self.accessor_ref().access(self.ptr_ref(), self.mapping_ref()(indices[Idxs]...));
     }
 #endif
   };
@@ -86,14 +86,14 @@ public:
   MDSPAN_INLINE_FUNCTION static constexpr size_t rank() noexcept { return extents_type::rank(); }
   MDSPAN_INLINE_FUNCTION static constexpr size_t rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
   MDSPAN_INLINE_FUNCTION static constexpr size_t static_extent(size_t r) noexcept { return extents_type::static_extent(r); }
-  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return __mapping_ref().extents().extent(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return mapping_ref().extents().extent(r); };
 
 private:
 
   // Can't use defaulted parameter in the deduction_workaround template because of a bug in MSVC warning C4348.
-  using __impl = deduction_workaround<std::make_index_sequence<extents_type::rank()>>;
+  using deduction_workaround_impl = deduction_workaround<std::make_index_sequence<extents_type::rank()>>;
 
-  using __map_acc_pair_t = detail::impl_compressed_pair<mapping_type, accessor_type>;
+  using map_acc_pair_t = detail::impl_compressed_pair<mapping_type, accessor_type>;
 
 public:
 
@@ -127,7 +127,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   explicit constexpr mdspan(data_handle_type p, SizeTypes... dynamic_extents)
     // TODO @proposal-bug shouldn't I be allowed to do `move(p)` here?
-    : m_members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(static_cast<index_type>(std::move(dynamic_extents))...)), accessor_type()))
+    : m_members(std::move(p), map_acc_pair_t(mapping_type(extents_type(static_cast<index_type>(std::move(dynamic_extents))...)), accessor_type()))
   { }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -143,7 +143,7 @@ public:
   MDSPAN_CONDITIONAL_EXPLICIT(N != rank_dynamic())
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(data_handle_type p, const std::array<SizeType, N>& dynamic_extents)
-    : m_members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(dynamic_extents)), accessor_type()))
+    : m_members(std::move(p), map_acc_pair_t(mapping_type(extents_type(dynamic_extents)), accessor_type()))
   { }
 
 #ifdef __cpp_lib_span
@@ -160,7 +160,7 @@ public:
   MDSPAN_CONDITIONAL_EXPLICIT(N != rank_dynamic())
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(data_handle_type p, std::span<SizeType, N> dynamic_extents)
-    : m_members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(as_const(dynamic_extents))), accessor_type()))
+    : m_members(std::move(p), map_acc_pair_t(mapping_type(extents_type(as_const(dynamic_extents))), accessor_type()))
   { }
 #endif
 
@@ -169,19 +169,19 @@ public:
     mdspan, (data_handle_type p, const extents_type& exts), ,
     /* requires */ (MDSPAN_IMPL_TRAIT(std::is_default_constructible, accessor_type) &&
                     MDSPAN_IMPL_TRAIT(std::is_constructible, mapping_type, const extents_type&))
-  ) : m_members(std::move(p), __map_acc_pair_t(mapping_type(exts), accessor_type()))
+  ) : m_members(std::move(p), map_acc_pair_t(mapping_type(exts), accessor_type()))
   { }
 
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdspan, (data_handle_type p, const mapping_type& m), ,
     /* requires */ (MDSPAN_IMPL_TRAIT(std::is_default_constructible, accessor_type))
-  ) : m_members(std::move(p), __map_acc_pair_t(m, accessor_type()))
+  ) : m_members(std::move(p), map_acc_pair_t(m, accessor_type()))
   { }
 
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(data_handle_type p, const mapping_type& m, const accessor_type& a)
-    : m_members(std::move(p), __map_acc_pair_t(m, a))
+    : m_members(std::move(p), map_acc_pair_t(m, a))
   { }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -197,7 +197,7 @@ public:
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other)
-    : m_members(other.__ptr_ref(), __map_acc_pair_t(other.__mapping_ref(), other.__accessor_ref()))
+    : m_members(other.ptr_ref(), map_acc_pair_t(other.mapping_ref(), other.accessor_ref()))
   {
       static_assert(MDSPAN_IMPL_TRAIT(std::is_constructible, data_handle_type, typename OtherAccessor::data_handle_type),"Incompatible data_handle_type for mdspan construction");
       static_assert(MDSPAN_IMPL_TRAIT(std::is_constructible, extents_type, OtherExtents),"Incompatible extents for mdspan construction");
@@ -231,7 +231,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](SizeTypes... indices) const
   {
-    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(static_cast<index_type>(std::move(indices))...));
+    return accessor_ref().access(ptr_ref(), mapping_ref()(static_cast<index_type>(std::move(indices))...));
   }
   #endif
 
@@ -245,7 +245,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](const std::array< SizeType, rank()>& indices) const
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return deduction_workaround_impl::template callop<reference>(*this, indices);
   }
 
   #ifdef __cpp_lib_span
@@ -259,7 +259,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](std::span<SizeType, rank()> indices) const
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return deduction_workaround_impl::template callop<reference>(*this, indices);
   }
   #endif // __cpp_lib_span
 
@@ -275,7 +275,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](Index idx) const
   {
-    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(static_cast<index_type>(std::move(idx))));
+    return accessor_ref().access(ptr_ref(), mapping_ref()(static_cast<index_type>(std::move(idx))));
   }
   #endif
 
@@ -290,7 +290,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(SizeTypes... indices) const
   {
-    return __accessor_ref().access(__ptr_ref(), __mapping_ref()(static_cast<index_type>(std::move(indices))...));
+    return accessor_ref().access(ptr_ref(), mapping_ref()(static_cast<index_type>(std::move(indices))...));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -303,7 +303,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(const std::array<SizeType, rank()>& indices) const
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return deduction_workaround_impl::template callop<reference>(*this, indices);
   }
 
   #ifdef __cpp_lib_span
@@ -317,17 +317,17 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(std::span<SizeType, rank()> indices) const
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return deduction_workaround_impl::template callop<reference>(*this, indices);
   }
   #endif // __cpp_lib_span
   #endif // MDSPAN_USE_PAREN_OPERATOR
 
   MDSPAN_INLINE_FUNCTION constexpr size_type size() const noexcept {
-    return static_cast<size_type>(__impl::__size(*this));
+    return static_cast<size_type>(deduction_workaround_impl::size(*this));
   };
 
   MDSPAN_INLINE_FUNCTION constexpr bool empty() const noexcept {
-    return __impl::__empty(*this);
+    return deduction_workaround_impl::empty(*this);
   };
 
   MDSPAN_INLINE_FUNCTION
@@ -335,9 +335,9 @@ public:
     // can't call the std::swap inside on HIP
     #if !defined(MDSPAN_IMPL_HAS_HIP) && !defined(MDSPAN_IMPL_HAS_CUDA)
     using std::swap;
-    swap(x.__ptr_ref(), y.__ptr_ref());
-    swap(x.__mapping_ref(), y.__mapping_ref());
-    swap(x.__accessor_ref(), y.__accessor_ref());
+    swap(x.ptr_ref(), y.ptr_ref());
+    swap(x.mapping_ref(), y.mapping_ref());
+    swap(x.accessor_ref(), y.accessor_ref());
     #else
     mdspan tmp = y;
     y = x;
@@ -349,10 +349,10 @@ public:
   // [mdspan.basic.domobs], mdspan observers of the domain multidimensional index space
 
 
-  MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return __mapping_ref().extents(); };
-  MDSPAN_INLINE_FUNCTION constexpr const data_handle_type& data_handle() const noexcept { return __ptr_ref(); };
-  MDSPAN_INLINE_FUNCTION constexpr const mapping_type& mapping() const noexcept { return __mapping_ref(); };
-  MDSPAN_INLINE_FUNCTION constexpr const accessor_type& accessor() const noexcept { return __accessor_ref(); };
+  MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return mapping_ref().extents(); };
+  MDSPAN_INLINE_FUNCTION constexpr const data_handle_type& data_handle() const noexcept { return ptr_ref(); };
+  MDSPAN_INLINE_FUNCTION constexpr const mapping_type& mapping() const noexcept { return mapping_ref(); };
+  MDSPAN_INLINE_FUNCTION constexpr const accessor_type& accessor() const noexcept { return accessor_ref(); };
 
   //--------------------------------------------------------------------------------
   // [mdspan.basic.obs], mdspan observers of the mapping
@@ -361,21 +361,21 @@ public:
   MDSPAN_INLINE_FUNCTION static constexpr bool is_always_exhaustive() { return mapping_type::is_always_exhaustive(); };
   MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() { return mapping_type::is_always_strided(); };
 
-  MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const { return __mapping_ref().is_unique(); };
-  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const { return __mapping_ref().is_exhaustive(); };
-  MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const { return __mapping_ref().is_strided(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return __mapping_ref().stride(r); };
+  MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const { return mapping_ref().is_unique(); };
+  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const { return mapping_ref().is_exhaustive(); };
+  MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const { return mapping_ref().is_strided(); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return mapping_ref().stride(r); };
 
 private:
 
-  detail::impl_compressed_pair<data_handle_type, __map_acc_pair_t> m_members{};
+  detail::impl_compressed_pair<data_handle_type, map_acc_pair_t> m_members{};
 
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 data_handle_type& __ptr_ref() noexcept { return m_members.first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr data_handle_type const& __ptr_ref() const noexcept { return m_members.first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 mapping_type& __mapping_ref() noexcept { return m_members.second().first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr mapping_type const& __mapping_ref() const noexcept { return m_members.second().first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 accessor_type& __accessor_ref() noexcept { return m_members.second().second(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr accessor_type const& __accessor_ref() const noexcept { return m_members.second().second(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 data_handle_type& ptr_ref() noexcept { return m_members.first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr data_handle_type const& ptr_ref() const noexcept { return m_members.first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 mapping_type& mapping_ref() noexcept { return m_members.second().first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr mapping_type const& mapping_ref() const noexcept { return m_members.second().first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 accessor_type& accessor_ref() noexcept { return m_members.second().second(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr accessor_type const& accessor_ref() const noexcept { return m_members.second().second(); }
 
   template <class, class, class, class>
   friend class mdspan;

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -39,10 +39,10 @@ private:
 
   // Workaround for non-deducibility of the index sequence template parameter if it's given at the top level
   template <class>
-  struct __deduction_workaround;
+  struct deduction_workaround;
 
   template <size_t... Idxs>
-  struct __deduction_workaround<std::index_sequence<Idxs...>>
+  struct deduction_workaround<std::index_sequence<Idxs...>>
   {
     MDSPAN_FORCE_INLINE_FUNCTION static constexpr
     size_t __size(mdspan const& __self) noexcept {
@@ -90,8 +90,8 @@ public:
 
 private:
 
-  // Can't use defaulted parameter in the __deduction_workaround template because of a bug in MSVC warning C4348.
-  using __impl = __deduction_workaround<std::make_index_sequence<extents_type::rank()>>;
+  // Can't use defaulted parameter in the deduction_workaround template because of a bug in MSVC warning C4348.
+  using __impl = deduction_workaround<std::make_index_sequence<extents_type::rank()>>;
 
   using __map_acc_pair_t = detail::impl_compressed_pair<mapping_type, accessor_type>;
 
@@ -127,7 +127,7 @@ public:
   MDSPAN_INLINE_FUNCTION
   explicit constexpr mdspan(data_handle_type p, SizeTypes... dynamic_extents)
     // TODO @proposal-bug shouldn't I be allowed to do `move(p)` here?
-    : __members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(static_cast<index_type>(std::move(dynamic_extents))...)), accessor_type()))
+    : m_members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(static_cast<index_type>(std::move(dynamic_extents))...)), accessor_type()))
   { }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -143,7 +143,7 @@ public:
   MDSPAN_CONDITIONAL_EXPLICIT(N != rank_dynamic())
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(data_handle_type p, const std::array<SizeType, N>& dynamic_extents)
-    : __members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(dynamic_extents)), accessor_type()))
+    : m_members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(dynamic_extents)), accessor_type()))
   { }
 
 #ifdef __cpp_lib_span
@@ -160,7 +160,7 @@ public:
   MDSPAN_CONDITIONAL_EXPLICIT(N != rank_dynamic())
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(data_handle_type p, std::span<SizeType, N> dynamic_extents)
-    : __members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(as_const(dynamic_extents))), accessor_type()))
+    : m_members(std::move(p), __map_acc_pair_t(mapping_type(extents_type(as_const(dynamic_extents))), accessor_type()))
   { }
 #endif
 
@@ -169,19 +169,19 @@ public:
     mdspan, (data_handle_type p, const extents_type& exts), ,
     /* requires */ (MDSPAN_IMPL_TRAIT(std::is_default_constructible, accessor_type) &&
                     MDSPAN_IMPL_TRAIT(std::is_constructible, mapping_type, const extents_type&))
-  ) : __members(std::move(p), __map_acc_pair_t(mapping_type(exts), accessor_type()))
+  ) : m_members(std::move(p), __map_acc_pair_t(mapping_type(exts), accessor_type()))
   { }
 
   MDSPAN_FUNCTION_REQUIRES(
     (MDSPAN_INLINE_FUNCTION constexpr),
     mdspan, (data_handle_type p, const mapping_type& m), ,
     /* requires */ (MDSPAN_IMPL_TRAIT(std::is_default_constructible, accessor_type))
-  ) : __members(std::move(p), __map_acc_pair_t(m, accessor_type()))
+  ) : m_members(std::move(p), __map_acc_pair_t(m, accessor_type()))
   { }
 
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(data_handle_type p, const mapping_type& m, const accessor_type& a)
-    : __members(std::move(p), __map_acc_pair_t(m, a))
+    : m_members(std::move(p), __map_acc_pair_t(m, a))
   { }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -197,7 +197,7 @@ public:
   )
   MDSPAN_INLINE_FUNCTION
   constexpr mdspan(const mdspan<OtherElementType, OtherExtents, OtherLayoutPolicy, OtherAccessor>& other)
-    : __members(other.__ptr_ref(), __map_acc_pair_t(other.__mapping_ref(), other.__accessor_ref()))
+    : m_members(other.__ptr_ref(), __map_acc_pair_t(other.__mapping_ref(), other.__accessor_ref()))
   {
       static_assert(MDSPAN_IMPL_TRAIT(std::is_constructible, data_handle_type, typename OtherAccessor::data_handle_type),"Incompatible data_handle_type for mdspan construction");
       static_assert(MDSPAN_IMPL_TRAIT(std::is_constructible, extents_type, OtherExtents),"Incompatible extents for mdspan construction");
@@ -368,14 +368,14 @@ public:
 
 private:
 
-  detail::impl_compressed_pair<data_handle_type, __map_acc_pair_t> __members{};
+  detail::impl_compressed_pair<data_handle_type, __map_acc_pair_t> m_members{};
 
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 data_handle_type& __ptr_ref() noexcept { return __members.first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr data_handle_type const& __ptr_ref() const noexcept { return __members.first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 mapping_type& __mapping_ref() noexcept { return __members.second().first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr mapping_type const& __mapping_ref() const noexcept { return __members.second().first(); }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 accessor_type& __accessor_ref() noexcept { return __members.second().second(); }
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr accessor_type const& __accessor_ref() const noexcept { return __members.second().second(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 data_handle_type& __ptr_ref() noexcept { return m_members.first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr data_handle_type const& __ptr_ref() const noexcept { return m_members.first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 mapping_type& __mapping_ref() noexcept { return m_members.second().first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr mapping_type const& __mapping_ref() const noexcept { return m_members.second().first(); }
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 accessor_type& __accessor_ref() noexcept { return m_members.second().second(); }
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr accessor_type const& __accessor_ref() const noexcept { return m_members.second().second(); }
 
   template <class, class, class, class>
   friend class mdspan;

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -23,24 +23,24 @@ namespace detail {
 
 //==============================================================================
 
-template <class T, size_t _Disambiguator = 0, class _Enable = void>
-struct __no_unique_address_emulation {
-  using __stored_type = T;
-  T __v;
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T const &__ref() const noexcept {
-    return __v;
+template <class T, size_t Disambiguator = 0, class Enable = void>
+struct no_unique_address_emulation {
+  using stored_type = T;
+  T m_v;
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T const &ref() const noexcept {
+    return m_v;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T &__ref() noexcept {
-    return __v;
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T &ref() noexcept {
+    return m_v;
   }
 };
 
 // Empty case
 // This doesn't work if T is final, of course, but we're not using anything
 // like that currently. That kind of thing could be added pretty easily though
-template <class T, size_t _Disambiguator>
-struct __no_unique_address_emulation<
-    T, _Disambiguator,
+template <class T, size_t Disambiguator>
+struct no_unique_address_emulation<
+    T, Disambiguator,
     std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, T) &&
                 // If the type isn't trivially destructible, its destructor
                 // won't be called at the right time, so don't use this
@@ -52,43 +52,43 @@ struct __no_unique_address_emulation<
     protected
 #else
     // But we still want this to be private if possible so that we don't accidentally
-    // access members of T directly rather than calling __ref() first, which wouldn't
+    // access members of T directly rather than calling ref() first, which wouldn't
     // work if T happens to be stateful and thus we're using the unspecialized definition
-    // of __no_unique_address_emulation above.
+    // of no_unique_address_emulation above.
     private
 #endif
     T {
-  using __stored_type = T;
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr T const &__ref() const noexcept {
+  using stored_type = T;
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T const &ref() const noexcept {
     return *static_cast<T const *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T &__ref() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T &ref() noexcept {
     return *static_cast<T *>(this);
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __no_unique_address_emulation() noexcept = default;
+  constexpr no_unique_address_emulation() noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __no_unique_address_emulation(
-      __no_unique_address_emulation const &) noexcept = default;
+  constexpr no_unique_address_emulation(
+      no_unique_address_emulation const &) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  constexpr __no_unique_address_emulation(
-      __no_unique_address_emulation &&) noexcept = default;
+  constexpr no_unique_address_emulation(
+      no_unique_address_emulation &&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __no_unique_address_emulation &
-  operator=(__no_unique_address_emulation const &) noexcept = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED no_unique_address_emulation &
+  operator=(no_unique_address_emulation const &) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED __no_unique_address_emulation &
-  operator=(__no_unique_address_emulation &&) noexcept = default;
+  MDSPAN_IMPL_CONSTEXPR_14_DEFAULTED no_unique_address_emulation &
+  operator=(no_unique_address_emulation &&) noexcept = default;
   MDSPAN_INLINE_FUNCTION_DEFAULTED
-  ~__no_unique_address_emulation() noexcept = default;
+  ~no_unique_address_emulation() noexcept = default;
 
   // Explicitly make this not a reference so that the copy or move
   // constructor still gets called.
   MDSPAN_INLINE_FUNCTION
-  explicit constexpr __no_unique_address_emulation(T const& __v) noexcept : T(__v) {}
+  explicit constexpr no_unique_address_emulation(T const& v) noexcept : T(v) {}
   MDSPAN_INLINE_FUNCTION
-  explicit constexpr __no_unique_address_emulation(T&& __v) noexcept : T(::std::move(__v)) {}
+  explicit constexpr no_unique_address_emulation(T&& v) noexcept : T(::std::move(v)) {}
 };
 
 //==============================================================================

--- a/include/experimental/__p0009_bits/no_unique_address.hpp
+++ b/include/experimental/__p0009_bits/no_unique_address.hpp
@@ -23,47 +23,47 @@ namespace detail {
 
 //==============================================================================
 
-template <class _T, size_t _Disambiguator = 0, class _Enable = void>
+template <class T, size_t _Disambiguator = 0, class _Enable = void>
 struct __no_unique_address_emulation {
-  using __stored_type = _T;
-  _T __v;
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T const &__ref() const noexcept {
+  using __stored_type = T;
+  T __v;
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T const &__ref() const noexcept {
     return __v;
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T &__ref() noexcept {
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T &__ref() noexcept {
     return __v;
   }
 };
 
 // Empty case
-// This doesn't work if _T is final, of course, but we're not using anything
+// This doesn't work if T is final, of course, but we're not using anything
 // like that currently. That kind of thing could be added pretty easily though
-template <class _T, size_t _Disambiguator>
+template <class T, size_t _Disambiguator>
 struct __no_unique_address_emulation<
-    _T, _Disambiguator,
-    std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, _T) &&
+    T, _Disambiguator,
+    std::enable_if_t<MDSPAN_IMPL_TRAIT(std::is_empty, T) &&
                 // If the type isn't trivially destructible, its destructor
                 // won't be called at the right time, so don't use this
                 // specialization
-                MDSPAN_IMPL_TRAIT(std::is_trivially_destructible, _T)>> :
+                MDSPAN_IMPL_TRAIT(std::is_trivially_destructible, T)>> :
 #ifdef MDSPAN_IMPL_COMPILER_MSVC
     // MSVC doesn't allow you to access public static member functions of a type
     // when you *happen* to privately inherit from that type.
     protected
 #else
     // But we still want this to be private if possible so that we don't accidentally
-    // access members of _T directly rather than calling __ref() first, which wouldn't
-    // work if _T happens to be stateful and thus we're using the unspecialized definition
+    // access members of T directly rather than calling __ref() first, which wouldn't
+    // work if T happens to be stateful and thus we're using the unspecialized definition
     // of __no_unique_address_emulation above.
     private
 #endif
-    _T {
-  using __stored_type = _T;
-  MDSPAN_FORCE_INLINE_FUNCTION constexpr _T const &__ref() const noexcept {
-    return *static_cast<_T const *>(this);
+    T {
+  using __stored_type = T;
+  MDSPAN_FORCE_INLINE_FUNCTION constexpr T const &__ref() const noexcept {
+    return *static_cast<T const *>(this);
   }
-  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 _T &__ref() noexcept {
-    return *static_cast<_T *>(this);
+  MDSPAN_FORCE_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14 T &__ref() noexcept {
+    return *static_cast<T *>(this);
   }
 
   MDSPAN_INLINE_FUNCTION_DEFAULTED
@@ -86,9 +86,9 @@ struct __no_unique_address_emulation<
   // Explicitly make this not a reference so that the copy or move
   // constructor still gets called.
   MDSPAN_INLINE_FUNCTION
-  explicit constexpr __no_unique_address_emulation(_T const& __v) noexcept : _T(__v) {}
+  explicit constexpr __no_unique_address_emulation(T const& __v) noexcept : T(__v) {}
   MDSPAN_INLINE_FUNCTION
-  explicit constexpr __no_unique_address_emulation(_T&& __v) noexcept : _T(::std::move(__v)) {}
+  explicit constexpr __no_unique_address_emulation(T&& __v) noexcept : T(::std::move(__v)) {}
 };
 
 //==============================================================================

--- a/include/experimental/__p0009_bits/trait_backports.hpp
+++ b/include/experimental/__p0009_bits/trait_backports.hpp
@@ -30,19 +30,19 @@
 #if MDSPAN_IMPL_USE_VARIABLE_TEMPLATES
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
-#define _MDSPAN_BACKPORT_TRAIT(TRAIT) \
+#define MDSPAN_IMPL_BACKPORT_TRAIT(TRAIT) \
   template <class... Args> MDSPAN_IMPL_INLINE_VARIABLE constexpr auto TRAIT##_v = TRAIT<Args...>::value;
 
-_MDSPAN_BACKPORT_TRAIT(is_assignable)
-_MDSPAN_BACKPORT_TRAIT(is_constructible)
-_MDSPAN_BACKPORT_TRAIT(is_convertible)
-_MDSPAN_BACKPORT_TRAIT(is_default_constructible)
-_MDSPAN_BACKPORT_TRAIT(is_trivially_destructible)
-_MDSPAN_BACKPORT_TRAIT(is_same)
-_MDSPAN_BACKPORT_TRAIT(is_empty)
-_MDSPAN_BACKPORT_TRAIT(is_void)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_assignable)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_constructible)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_convertible)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_default_constructible)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_trivially_destructible)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_same)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_empty)
+MDSPAN_IMPL_BACKPORT_TRAIT(is_void)
 
-#undef _MDSPAN_BACKPORT_TRAIT
+#undef MDSPAN_IMPL_BACKPORT_TRAIT
 
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 
@@ -111,16 +111,16 @@ using index_sequence_for = make_index_sequence<sizeof...(T)>;
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
-#define _MDSPAN_BACKPORT_TRAIT_ALIAS(TRAIT) \
+#define MDSPAN_IMPL_BACKPORT_TRAIT_ALIAS(TRAIT) \
   template <class... Args> using TRAIT##_t = typename TRAIT<Args...>::type;
 
-_MDSPAN_BACKPORT_TRAIT_ALIAS(remove_cv)
-_MDSPAN_BACKPORT_TRAIT_ALIAS(remove_reference)
+MDSPAN_IMPL_BACKPORT_TRAIT_ALIAS(remove_cv)
+MDSPAN_IMPL_BACKPORT_TRAIT_ALIAS(remove_reference)
 
 template <bool _B, class _T=void>
 using enable_if_t = typename enable_if<_B, _T>::type;
 
-#undef _MDSPAN_BACKPORT_TRAIT_ALIAS
+#undef MDSPAN_IMPL_BACKPORT_TRAIT_ALIAS
 
 } // end namespace MDSPAN_IMPL_STANDARD_NAMESPACE
 

--- a/include/experimental/__p0009_bits/trait_backports.hpp
+++ b/include/experimental/__p0009_bits/trait_backports.hpp
@@ -117,8 +117,8 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 MDSPAN_IMPL_BACKPORT_TRAIT_ALIAS(remove_cv)
 MDSPAN_IMPL_BACKPORT_TRAIT_ALIAS(remove_reference)
 
-template <bool _B, class _T=void>
-using enable_if_t = typename enable_if<_B, _T>::type;
+template <bool _B, class T=void>
+using enable_if_t = typename enable_if<_B, T>::type;
 
 #undef MDSPAN_IMPL_BACKPORT_TRAIT_ALIAS
 

--- a/include/experimental/__p0009_bits/type_list.hpp
+++ b/include/experimental/__p0009_bits/type_list.hpp
@@ -23,59 +23,59 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
 namespace detail {
 
-template <class... _Ts> struct __type_list { static constexpr auto __size = sizeof...(_Ts); };
+template <class... Ts> struct __type_list { static constexpr auto __size = sizeof...(Ts); };
 
 // Implementation of type_list at() that's heavily optimized for small typelists
 template <size_t, class> struct __type_at;
 template <size_t, class _Seq, class=std::make_index_sequence<_Seq::__size>> struct __type_at_large_impl;
 
-template <size_t _I, size_t _Idx, class _T>
+template <size_t _I, size_t _Idx, class T>
 struct __type_at_entry { };
 
 template <class _Result>
 struct __type_at_assign_op_ignore_rest {
-  template <class _T>
-  __type_at_assign_op_ignore_rest<_Result> operator=(_T&&);
+  template <class T>
+  __type_at_assign_op_ignore_rest<_Result> operator=(T&&);
   using type = _Result;
 };
 
 struct __type_at_assign_op_impl {
-  template <size_t _I, size_t _Idx, class _T>
-  __type_at_assign_op_impl operator=(__type_at_entry<_I, _Idx, _T>&&);
-  template <size_t _I, class _T>
-  __type_at_assign_op_ignore_rest<_T> operator=(__type_at_entry<_I, _I, _T>&&);
+  template <size_t _I, size_t _Idx, class T>
+  __type_at_assign_op_impl operator=(__type_at_entry<_I, _Idx, T>&&);
+  template <size_t _I, class T>
+  __type_at_assign_op_ignore_rest<T> operator=(__type_at_entry<_I, _I, T>&&);
 };
 
-template <size_t _I, class... _Ts, size_t... _Idxs>
-struct __type_at_large_impl<_I, __type_list<_Ts...>, std::integer_sequence<size_t, _Idxs...>>
+template <size_t _I, class... Ts, size_t... _Idxs>
+struct __type_at_large_impl<_I, __type_list<Ts...>, std::integer_sequence<size_t, _Idxs...>>
   : decltype(
-      MDSPAN_IMPL_FOLD_ASSIGN_LEFT(__type_at_assign_op_impl{}, /* = ... = */ __type_at_entry<_I, _Idxs, _Ts>{})
+      MDSPAN_IMPL_FOLD_ASSIGN_LEFT(__type_at_assign_op_impl{}, /* = ... = */ __type_at_entry<_I, _Idxs, Ts>{})
     )
 { };
 
-template <size_t _I, class... _Ts>
-struct __type_at<_I, __type_list<_Ts...>>
-    : __type_at_large_impl<_I, __type_list<_Ts...>>
+template <size_t _I, class... Ts>
+struct __type_at<_I, __type_list<Ts...>>
+    : __type_at_large_impl<_I, __type_list<Ts...>>
 { };
 
-template <class _T0, class... _Ts>
-struct __type_at<0, __type_list<_T0, _Ts...>> {
-  using type = _T0;
+template <class T0, class... Ts>
+struct __type_at<0, __type_list<T0, Ts...>> {
+  using type = T0;
 };
 
-template <class _T0, class _T1, class... _Ts>
-struct __type_at<1, __type_list<_T0, _T1, _Ts...>> {
-  using type = _T1;
+template <class T0, class T1, class... Ts>
+struct __type_at<1, __type_list<T0, T1, Ts...>> {
+  using type = T1;
 };
 
-template <class _T0, class _T1, class _T2, class... _Ts>
-struct __type_at<2, __type_list<_T0, _T1, _T2, _Ts...>> {
-  using type = _T2;
+template <class T0, class T1, class T2, class... Ts>
+struct __type_at<2, __type_list<T0, T1, T2, Ts...>> {
+  using type = T2;
 };
 
-template <class _T0, class _T1, class _T2, class _T3, class... _Ts>
-struct __type_at<3, __type_list<_T0, _T1, _T2, _T3, _Ts...>> {
-  using type = _T3;
+template <class T0, class T1, class T2, class T3, class... Ts>
+struct __type_at<3, __type_list<T0, T1, T2, T3, Ts...>> {
+  using type = T3;
 };
 
 

--- a/include/experimental/__p0009_bits/type_list.hpp
+++ b/include/experimental/__p0009_bits/type_list.hpp
@@ -23,58 +23,58 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
 namespace detail {
 
-template <class... Ts> struct __type_list { static constexpr auto __size = sizeof...(Ts); };
+template <class... Ts> struct type_list { static constexpr auto size = sizeof...(Ts); };
 
 // Implementation of type_list at() that's heavily optimized for small typelists
-template <size_t, class> struct __type_at;
-template <size_t, class _Seq, class=std::make_index_sequence<_Seq::__size>> struct __type_at_large_impl;
+template <size_t, class> struct type_at;
+template <size_t, class Seq, class=std::make_index_sequence<Seq::size>> struct type_at_large_impl;
 
-template <size_t _I, size_t _Idx, class T>
-struct __type_at_entry { };
+template <size_t I, size_t Idx, class T>
+struct type_at_entry { };
 
-template <class _Result>
-struct __type_at_assign_op_ignore_rest {
+template <class Result>
+struct type_at_assign_op_ignore_rest {
   template <class T>
-  __type_at_assign_op_ignore_rest<_Result> operator=(T&&);
-  using type = _Result;
+  type_at_assign_op_ignore_rest<Result> operator=(T&&);
+  using type = Result;
 };
 
-struct __type_at_assign_op_impl {
-  template <size_t _I, size_t _Idx, class T>
-  __type_at_assign_op_impl operator=(__type_at_entry<_I, _Idx, T>&&);
-  template <size_t _I, class T>
-  __type_at_assign_op_ignore_rest<T> operator=(__type_at_entry<_I, _I, T>&&);
+struct type_at_assign_op_impl {
+  template <size_t I, size_t Idx, class T>
+  type_at_assign_op_impl operator=(type_at_entry<I, Idx, T>&&);
+  template <size_t I, class T>
+  type_at_assign_op_ignore_rest<T> operator=(type_at_entry<I, I, T>&&);
 };
 
-template <size_t _I, class... Ts, size_t... _Idxs>
-struct __type_at_large_impl<_I, __type_list<Ts...>, std::integer_sequence<size_t, _Idxs...>>
+template <size_t I, class... Ts, size_t... Idxs>
+struct type_at_large_impl<I, type_list<Ts...>, std::integer_sequence<size_t, Idxs...>>
   : decltype(
-      MDSPAN_IMPL_FOLD_ASSIGN_LEFT(__type_at_assign_op_impl{}, /* = ... = */ __type_at_entry<_I, _Idxs, Ts>{})
+      MDSPAN_IMPL_FOLD_ASSIGN_LEFT(type_at_assign_op_impl{}, /* = ... = */ type_at_entry<I, Idxs, Ts>{})
     )
 { };
 
-template <size_t _I, class... Ts>
-struct __type_at<_I, __type_list<Ts...>>
-    : __type_at_large_impl<_I, __type_list<Ts...>>
+template <size_t I, class... Ts>
+struct type_at<I, type_list<Ts...>>
+    : type_at_large_impl<I, type_list<Ts...>>
 { };
 
 template <class T0, class... Ts>
-struct __type_at<0, __type_list<T0, Ts...>> {
+struct type_at<0, type_list<T0, Ts...>> {
   using type = T0;
 };
 
 template <class T0, class T1, class... Ts>
-struct __type_at<1, __type_list<T0, T1, Ts...>> {
+struct type_at<1, type_list<T0, T1, Ts...>> {
   using type = T1;
 };
 
 template <class T0, class T1, class T2, class... Ts>
-struct __type_at<2, __type_list<T0, T1, T2, Ts...>> {
+struct type_at<2, type_list<T0, T1, T2, Ts...>> {
   using type = T2;
 };
 
 template <class T0, class T1, class T2, class T3, class... Ts>
-struct __type_at<3, __type_list<T0, T1, T2, T3, Ts...>> {
+struct type_at<3, type_list<T0, T1, T2, T3, Ts...>> {
   using type = T3;
 };
 

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -4,6 +4,7 @@
 #include <type_traits>
 #include <array>
 #include <utility>
+#include "macros.hpp"
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 namespace detail {

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -59,7 +59,7 @@ template <
 >
 class mdarray {
 private:
-  static_assert(::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::__is_extents_v<Extents>,
+  static_assert(::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::impl_is_extents_v<Extents>,
                 MDSPAN_IMPL_PROPOSED_NAMESPACE_STRING "::mdspan's Extents template parameter must be a specialization of " MDSPAN_IMPL_STANDARD_NAMESPACE_STRING "::extents.");
 
 public:

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -290,7 +290,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr const_reference operator[](const std::array<SizeType, N>& indices) const noexcept
   {
-    return __impl::template callop<reference>(*this, indices);
+    return impl::template callop<reference>(*this, indices);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -303,7 +303,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](const std::array<SizeType, N>& indices) noexcept
   {
-    return __impl::template callop<reference>(*this, indices);
+    return impl::template callop<reference>(*this, indices);
   }
 #endif
 
@@ -345,7 +345,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr const_reference operator()(const std::array<SizeType, N>& indices) const noexcept
   {
-    return __impl::template callop<reference>(*this, indices);
+    return impl::template callop<reference>(*this, indices);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -358,7 +358,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(const std::array<SizeType, N>& indices) noexcept
   {
-    return __impl::template callop<reference>(*this, indices);
+    return impl::template callop<reference>(*this, indices);
   }
 #endif
   #endif
@@ -378,7 +378,7 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return map_.extents(); };
   MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return map_.extents().extent(r); };
   MDSPAN_INLINE_FUNCTION constexpr index_type size() const noexcept {
-//    return __impl::size(*this);
+//    return impl::size(*this);
     return ctr_.size();
   };
 

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -290,7 +290,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr const_reference operator[](const std::array<SizeType, N>& indices) const noexcept
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return __impl::template callop<reference>(*this, indices);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -303,7 +303,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator[](const std::array<SizeType, N>& indices) noexcept
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return __impl::template callop<reference>(*this, indices);
   }
 #endif
 
@@ -345,7 +345,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr const_reference operator()(const std::array<SizeType, N>& indices) const noexcept
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return __impl::template callop<reference>(*this, indices);
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -358,7 +358,7 @@ public:
   MDSPAN_FORCE_INLINE_FUNCTION
   constexpr reference operator()(const std::array<SizeType, N>& indices) noexcept
   {
-    return __impl::template __callop<reference>(*this, indices);
+    return __impl::template callop<reference>(*this, indices);
   }
 #endif
   #endif

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -378,7 +378,7 @@ public:
   MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return map_.extents(); };
   MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return map_.extents().extent(r); };
   MDSPAN_INLINE_FUNCTION constexpr index_type size() const noexcept {
-//    return __impl::__size(*this);
+//    return __impl::size(*this);
     return ctr_.size();
   };
 

--- a/include/experimental/__p2630_bits/strided_slice.hpp
+++ b/include/experimental/__p2630_bits/strided_slice.hpp
@@ -23,10 +23,10 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
 namespace {
   template<class T>
-  struct __mdspan_is_integral_constant: std::false_type {};
+  struct mdspan_is_integral_constant: std::false_type {};
 
   template<class T, T val>
-  struct __mdspan_is_integral_constant<std::integral_constant<T,val>>: std::true_type {};
+  struct mdspan_is_integral_constant<std::integral_constant<T,val>>: std::true_type {};
 }
 
 // Slice Specifier allowing for strides and compile time extent
@@ -40,9 +40,9 @@ struct strided_slice {
   MDSPAN_IMPL_NO_UNIQUE_ADDRESS ExtentType extent{};
   MDSPAN_IMPL_NO_UNIQUE_ADDRESS StrideType stride{};
 
-  static_assert(std::is_integral_v<OffsetType> || __mdspan_is_integral_constant<OffsetType>::value);
-  static_assert(std::is_integral_v<ExtentType> || __mdspan_is_integral_constant<ExtentType>::value);
-  static_assert(std::is_integral_v<StrideType> || __mdspan_is_integral_constant<StrideType>::value);
+  static_assert(std::is_integral_v<OffsetType> || mdspan_is_integral_constant<OffsetType>::value);
+  static_assert(std::is_integral_v<ExtentType> || mdspan_is_integral_constant<ExtentType>::value);
+  static_assert(std::is_integral_v<StrideType> || mdspan_is_integral_constant<StrideType>::value);
 };
 
 } // MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -41,22 +41,22 @@ find_next_multiple(T alignment, T offset)
   }
 }
 
-template <class _ExtentsType, size_t _PaddingValue, size_t _ExtentToPadIdx>
+template <class ExtentsType, size_t PaddingValue, size_t ExtentToPadIdx>
 MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
-  constexpr auto rank = _ExtentsType::rank();
+  constexpr auto rank = ExtentsType::rank();
 
-  if constexpr (rank <= typename _ExtentsType::rank_type(1)) {
+  if constexpr (rank <= typename ExtentsType::rank_type(1)) {
     return 0;
-  } else if constexpr (_PaddingValue != dynamic_extent &&
-                       _ExtentsType::static_extent(_ExtentToPadIdx) !=
+  } else if constexpr (PaddingValue != dynamic_extent &&
+                       ExtentsType::static_extent(ExtentToPadIdx) !=
                            dynamic_extent) {
     static_assert(
-        (_PaddingValue != 0) ||
-            (_ExtentsType::static_extent(_ExtentToPadIdx) == 0),
+        (PaddingValue != 0) ||
+            (ExtentsType::static_extent(ExtentToPadIdx) == 0),
         "padding stride can be 0 only if "
         "extents_type::static_extent(extent-to-pad) is 0 or dynamic_extent");
-    return find_next_multiple(_PaddingValue,
-                                _ExtentsType::static_extent(_ExtentToPadIdx));
+    return find_next_multiple(PaddingValue,
+                                ExtentsType::static_extent(ExtentToPadIdx));
   } else {
     return dynamic_extent;
   }
@@ -66,44 +66,44 @@ MDSPAN_INLINE_FUNCTION constexpr size_t get_actual_static_padding_value() {
 #endif
 }
 
-template <size_t _PaddingValue, typename _Extents, size_t _ExtentToPadIdx, size_t _Rank, typename Enabled = void>
+template <size_t PaddingValue, typename Extents, size_t ExtentToPadIdx, size_t Rank, typename Enabled = void>
 struct static_array_type_for_padded_extent
 {
-  static constexpr size_t padding_value = _PaddingValue;
-  using index_type = typename _Extents::index_type;
-  using extents_type = _Extents;
+  static constexpr size_t padding_value = PaddingValue;
+  using index_type = typename Extents::index_type;
+  using extents_type = Extents;
   using type = ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::maybe_static_array<
       index_type, size_t, dynamic_extent,
-      ::MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::get_actual_static_padding_value<extents_type, _PaddingValue,
-                                                _ExtentToPadIdx>()>;
+      ::MDSPAN_IMPL_STANDARD_NAMESPACE::MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::get_actual_static_padding_value<extents_type, PaddingValue,
+                                                ExtentToPadIdx>()>;
 };
 
-template <size_t _PaddingValue, typename _Extents, size_t _ExtentToPadIdx, size_t Rank>
-struct static_array_type_for_padded_extent<_PaddingValue, _Extents,
-                                             _ExtentToPadIdx, Rank, std::enable_if_t<Rank <= 1>> {
-  using index_type = typename _Extents::index_type;
-  using extents_type = _Extents;
+template <size_t PaddingValue, typename Extents, size_t ExtentToPadIdx, size_t Rank>
+struct static_array_type_for_padded_extent<PaddingValue, Extents,
+                                             ExtentToPadIdx, Rank, std::enable_if_t<Rank <= 1>> {
+  using index_type = typename Extents::index_type;
+  using extents_type = Extents;
   using type =
       ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::maybe_static_array<
           index_type, size_t, dynamic_extent, 0>;
 };
 
-template <size_t _PaddingValue, typename _Extents, size_t _ExtentToPadIdx>
+template <size_t PaddingValue, typename Extents, size_t ExtentToPadIdx>
 struct padded_extent {
-  static constexpr size_t padding_value = _PaddingValue;
-  using index_type = typename _Extents::index_type;
-  using extents_type = _Extents;
+  static constexpr size_t padding_value = PaddingValue;
+  using index_type = typename Extents::index_type;
+  using extents_type = Extents;
   using static_array_type = typename static_array_type_for_padded_extent<
-      padding_value, _Extents, _ExtentToPadIdx, _Extents::rank()>::type;
+      padding_value, Extents, ExtentToPadIdx, Extents::rank()>::type;
 
   MDSPAN_INLINE_FUNCTION
   static constexpr auto static_value() { return static_array_type::static_value(0); }
 
   MDSPAN_INLINE_FUNCTION
   static constexpr static_array_type
-  init_padding(const _Extents &exts) {
-    if constexpr ((_Extents::rank() > 1) && (padding_value == dynamic_extent)) {
-      return {exts.extent(_ExtentToPadIdx)};
+  init_padding(const Extents &exts) {
+    if constexpr ((Extents::rank() > 1) && (padding_value == dynamic_extent)) {
+      return {exts.extent(ExtentToPadIdx)};
     } else {
       return init_padding(exts, padding_value);
     }
@@ -114,11 +114,11 @@ struct padded_extent {
   }
 
   MDSPAN_INLINE_FUNCTION static constexpr static_array_type
-  init_padding([[maybe_unused]] const _Extents &exts,
+  init_padding([[maybe_unused]] const Extents &exts,
                [[maybe_unused]] index_type pv) {
-    if constexpr (_Extents::rank() > 1) {
+    if constexpr (Extents::rank() > 1) {
       return {find_next_multiple(pv,
-                                   exts.extent(_ExtentToPadIdx))};
+                                   exts.extent(ExtentToPadIdx))};
     } else {
       return {};
     }
@@ -128,12 +128,12 @@ struct padded_extent {
 #endif
   }
 
-  template <typename Mapping, size_t _PaddingStrideIdx>
+  template <typename Mapping, size_t PaddingStrideIdx>
   MDSPAN_INLINE_FUNCTION static constexpr static_array_type
   init_padding([[maybe_unused]] const Mapping &other_mapping,
-                      std::integral_constant<size_t, _PaddingStrideIdx>) {
-    if constexpr (_Extents::rank() > 1) {
-      return {other_mapping.stride(_PaddingStrideIdx)};
+                      std::integral_constant<size_t, PaddingStrideIdx>) {
+    if constexpr (Extents::rank() > 1) {
+      return {other_mapping.stride(PaddingStrideIdx)};
     } else {
       return {};
     }
@@ -245,14 +245,14 @@ public:
    * \param padding_value the padding value
    */
   MDSPAN_TEMPLATE_REQUIRES(
-    class _Size,
+    class Size,
     /* requires */ (
-      std::is_convertible_v<_Size, index_type>
-      && std::is_nothrow_constructible_v<index_type, _Size>
+      std::is_convertible_v<Size, index_type>
+      && std::is_nothrow_constructible_v<index_type, Size>
     )
   )
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const extents_type &ext, _Size dynamic_padding_value)
+  constexpr mapping(const extents_type &ext, Size dynamic_padding_value)
       : padded_stride(padded_stride_type::init_padding(ext, dynamic_padding_value)), exts(ext)
   {
     assert((padding_value == dynamic_extent) || (static_cast<index_type>(padding_value) == static_cast<index_type>(dynamic_padding_value)));
@@ -269,22 +269,22 @@ public:
    * `padding_value` greater than or equal to `extents_type::static_extent(0)`
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _OtherExtents,
-      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
+      class OtherExtents,
+      /* requires */ (std::is_constructible_v<extents_type, OtherExtents>))
   MDSPAN_CONDITIONAL_EXPLICIT(
-      (!std::is_convertible_v<_OtherExtents, extents_type>))
+      (!std::is_convertible_v<OtherExtents, extents_type>))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const layout_left::mapping<_OtherExtents> &other_mapping)
+  constexpr mapping(const layout_left::mapping<OtherExtents> &other_mapping)
       : padded_stride(padded_stride_type::init_padding(
             other_mapping,
             std::integral_constant<size_t, padded_stride_idx>{})),
         exts(other_mapping.extents()) {
     static_assert(
-        (_OtherExtents::rank() > 1) ||
+        (OtherExtents::rank() > 1) ||
         (static_padding_stride != dynamic_extent) ||
-        (_OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent) ||
+        (OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent) ||
         (static_padding_stride ==
-         _OtherExtents::static_extent(extent_to_pad_idx)));
+         OtherExtents::static_extent(extent_to_pad_idx)));
   }
 
   /**
@@ -294,11 +294,11 @@ public:
    * `is_constructible_v<extents_type, OtherExtents>` is true
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _OtherExtents,
-      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
+      class OtherExtents,
+      /* requires */ (std::is_constructible_v<extents_type, OtherExtents>))
   MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const layout_stride::mapping<_OtherExtents> &other_mapping)
+  constexpr mapping(const layout_stride::mapping<OtherExtents> &other_mapping)
       : padded_stride(padded_stride_type::init_padding(
             other_mapping,
             std::integral_constant<size_t, padded_stride_idx>{})),
@@ -403,17 +403,17 @@ public:
    * - (is_nothrow_constructible_v<index_type, Indices> && ...) is true.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class... _Indices,
-      /* requires */ (sizeof...(_Indices) == extents_type::rank() &&
+      class... Indices,
+      /* requires */ (sizeof...(Indices) == extents_type::rank() &&
                       (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::
-                           are_valid_indices<index_type, _Indices...>())))
+                           are_valid_indices<index_type, Indices...>())))
   MDSPAN_INLINE_FUNCTION constexpr size_t
-  operator()(_Indices... idxs) const noexcept {
+  operator()(Indices... idxs) const noexcept {
 #if !defined(NDEBUG)
     ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::check_all_indices(this->extents(),
                                                                 idxs...);
 #endif // ! NDEBUG
-    return compute_offset(std::index_sequence_for<_Indices...>{}, idxs...);
+    return compute_offset(std::index_sequence_for<Indices...>{}, idxs...);
   }
 
   MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept {
@@ -607,14 +607,14 @@ public:
    * \param padding_value the padding value
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Size,
+      class Size,
       /* requires */ (
-          std::is_convertible_v<_Size, index_type>
-              && std::is_nothrow_constructible_v<index_type, _Size>
+          std::is_convertible_v<Size, index_type>
+              && std::is_nothrow_constructible_v<index_type, Size>
           )
       )
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const extents_type &ext, _Size dynamic_padding_value)
+  constexpr mapping(const extents_type &ext, Size dynamic_padding_value)
       : padded_stride(padded_stride_type::init_padding(ext, static_cast<index_type>(dynamic_padding_value))),
         exts(ext) {
     assert((padding_value == dynamic_extent) ||
@@ -629,22 +629,22 @@ public:
    * otherwise, `OtherExtents::static_extent(0)` must be equal to the least multiple of `padding_value` greater than or equal to `extents_type::static_extent(0)`
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _OtherExtents,
-      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
+      class OtherExtents,
+      /* requires */ (std::is_constructible_v<extents_type, OtherExtents>))
   MDSPAN_CONDITIONAL_EXPLICIT(
-      (!std::is_convertible_v<_OtherExtents, extents_type>))
+      (!std::is_convertible_v<OtherExtents, extents_type>))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const layout_right::mapping<_OtherExtents> &other_mapping)
+  constexpr mapping(const layout_right::mapping<OtherExtents> &other_mapping)
       : padded_stride(padded_stride_type::init_padding(
             other_mapping,
             std::integral_constant<size_t, padded_stride_idx>{})),
         exts(other_mapping.extents()) {
     static_assert(
-        (_OtherExtents::rank() > 1) ||
+        (OtherExtents::rank() > 1) ||
         (padded_stride_type::static_value() != dynamic_extent) ||
-        (_OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent) ||
+        (OtherExtents::static_extent(extent_to_pad_idx) != dynamic_extent) ||
         (padded_stride_type::static_value() ==
-         _OtherExtents::static_extent(extent_to_pad_idx)));
+         OtherExtents::static_extent(extent_to_pad_idx)));
   }
 
   /**
@@ -654,11 +654,11 @@ public:
    * `is_constructible_v<extents_type, OtherExtents>` is true
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _OtherExtents,
-      /* requires */ (std::is_constructible_v<extents_type, _OtherExtents>))
+      class OtherExtents,
+      /* requires */ (std::is_constructible_v<extents_type, OtherExtents>))
   MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const layout_stride::mapping<_OtherExtents> &other_mapping)
+  constexpr mapping(const layout_stride::mapping<OtherExtents> &other_mapping)
       : padded_stride(padded_stride_type::init_padding(
             other_mapping,
             std::integral_constant<size_t, padded_stride_idx>{})),
@@ -762,13 +762,13 @@ public:
    * - (is_nothrow_constructible_v<index_type, Indices> && ...) is true.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class... _Indices,
-      /* requires */ (sizeof...(_Indices) == extents_type::rank() &&
+      class... Indices,
+      /* requires */ (sizeof...(Indices) == extents_type::rank() &&
                       (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::
-                           are_valid_indices<index_type, _Indices...>())))
+                           are_valid_indices<index_type, Indices...>())))
   MDSPAN_INLINE_FUNCTION constexpr size_t
-  operator()(_Indices... idxs) const noexcept {
-    return compute_offset(std::index_sequence_for<_Indices...>{}, idxs...);
+  operator()(Indices... idxs) const noexcept {
+    return compute_offset(std::index_sequence_for<Indices...>{}, idxs...);
   }
 
   MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept {

--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -29,13 +29,13 @@ namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 
 namespace detail {
-template<class _T>
+template<class T>
 MDSPAN_INLINE_FUNCTION
-constexpr _T
-find_next_multiple(_T alignment, _T offset)
+constexpr T
+find_next_multiple(T alignment, T offset)
 {
   if ( alignment == 0 ) {
-    return _T(0);
+    return T(0);
   } else {
     return ( ( offset + alignment - 1 ) / alignment) * alignment;
   }
@@ -128,9 +128,9 @@ struct padded_extent {
 #endif
   }
 
-  template <typename _Mapping, size_t _PaddingStrideIdx>
+  template <typename Mapping, size_t _PaddingStrideIdx>
   MDSPAN_INLINE_FUNCTION static constexpr static_array_type
-  init_padding([[maybe_unused]] const _Mapping &other_mapping,
+  init_padding([[maybe_unused]] const Mapping &other_mapping,
                       std::integral_constant<size_t, _PaddingStrideIdx>) {
     if constexpr (_Extents::rank() > 1) {
       return {other_mapping.stride(_PaddingStrideIdx)};
@@ -313,22 +313,22 @@ public:
    * `padding_value == OtherPaddingStride`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value
+      class Mapping,
+      /* requires */ (detail::is_layout_left_padded_mapping<Mapping>::value
                           &&std::is_constructible_v<
-                              extents_type, typename _Mapping::extents_type>))
+                              extents_type, typename Mapping::extents_type>))
   MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 1 &&
                                (padding_value == dynamic_extent ||
-                                _Mapping::padding_value == dynamic_extent)))
+                                Mapping::padding_value == dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const _Mapping &other_mapping)
+  constexpr mapping(const Mapping &other_mapping)
       : padded_stride(padded_stride_type::init_padding(
             other_mapping,
             std::integral_constant<size_t, padded_stride_idx>{})),
         exts(other_mapping.extents()) {
     static_assert(padding_value == dynamic_extent ||
-                  _Mapping::padding_value == dynamic_extent ||
-                  padding_value == _Mapping::padding_value);
+                  Mapping::padding_value == dynamic_extent ||
+                  padding_value == Mapping::padding_value);
   }
 
   /**
@@ -339,15 +339,15 @@ public:
    * OtherExtents>` is `true`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value
+      class Mapping,
+      /* requires */ (detail::is_layout_right_padded_mapping<Mapping>::value
                               &&extents_type::rank() <= 1 &&
                       std::is_constructible_v<extents_type,
-                                              typename _Mapping::extents_type>))
+                                              typename Mapping::extents_type>))
   MDSPAN_CONDITIONAL_EXPLICIT(
-      (!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+      (!std::is_convertible_v<typename Mapping::extents_type, extents_type>))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const _Mapping &other_mapping) noexcept
+  constexpr mapping(const Mapping &other_mapping) noexcept
       : padded_stride(padded_stride_type::init_padding(
             static_cast<extents_type>(other_mapping.extents()),
             other_mapping.extents().extent(extent_to_pad_idx))),
@@ -464,11 +464,11 @@ public:
    * Extents>`. However, this makes `padding_value` non-deducible.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value &&
-                      (_Mapping::extents_type::rank() == extents_type::rank())))
+      class Mapping,
+      /* requires */ (detail::is_layout_left_padded_mapping<Mapping>::value &&
+                      (Mapping::extents_type::rank() == extents_type::rank())))
   MDSPAN_INLINE_FUNCTION friend constexpr bool
-  operator==(const mapping &left, const _Mapping &right) noexcept {
+  operator==(const mapping &left, const Mapping &right) noexcept {
     // Workaround for some compilers not short-circuiting properly with
     // compile-time checks i.e. we can't access stride(_padding_stride_idx) of a
     // rank 0 mapping
@@ -488,11 +488,11 @@ public:
    * `OtherExtents::rank() == extents_type::rank()`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value &&
-                      (_Mapping::extents_type::rank() == extents_type::rank())))
+      class Mapping,
+      /* requires */ (detail::is_layout_left_padded_mapping<Mapping>::value &&
+                      (Mapping::extents_type::rank() == extents_type::rank())))
   MDSPAN_INLINE_FUNCTION friend constexpr bool
-  operator!=(const mapping &left, const _Mapping &right) noexcept {
+  operator!=(const mapping &left, const Mapping &right) noexcept {
     return !(left == right);
   }
 #endif
@@ -673,22 +673,22 @@ public:
    * `padding_value == OtherPaddingStride`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value
+      class Mapping,
+      /* requires */ (detail::is_layout_right_padded_mapping<Mapping>::value
                           &&std::is_constructible_v<
-                              extents_type, typename _Mapping::extents_type>))
+                              extents_type, typename Mapping::extents_type>))
   MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 1 &&
                                (padding_value == dynamic_extent ||
-                                _Mapping::padding_value == dynamic_extent)))
+                                Mapping::padding_value == dynamic_extent)))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const _Mapping &other_mapping)
+  constexpr mapping(const Mapping &other_mapping)
       : padded_stride(padded_stride_type::init_padding(
             other_mapping,
             std::integral_constant<size_t, padded_stride_idx>{})),
         exts(other_mapping.extents()) {
     static_assert(padding_value == dynamic_extent ||
-                  _Mapping::padding_value == dynamic_extent ||
-                  padding_value == _Mapping::padding_value);
+                  Mapping::padding_value == dynamic_extent ||
+                  padding_value == Mapping::padding_value);
   }
 
   /**
@@ -699,15 +699,15 @@ public:
    * OtherExtents>` is `true`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_left_padded_mapping<_Mapping>::value
+      class Mapping,
+      /* requires */ (detail::is_layout_left_padded_mapping<Mapping>::value
                               &&extents_type::rank() <= 1 &&
                       std::is_constructible_v<extents_type,
-                                              typename _Mapping::extents_type>))
+                                              typename Mapping::extents_type>))
   MDSPAN_CONDITIONAL_EXPLICIT(
-      (!std::is_convertible_v<typename _Mapping::extents_type, extents_type>))
+      (!std::is_convertible_v<typename Mapping::extents_type, extents_type>))
   MDSPAN_INLINE_FUNCTION
-  constexpr mapping(const _Mapping &other_mapping) noexcept
+  constexpr mapping(const Mapping &other_mapping) noexcept
       : padded_stride(padded_stride_type::init_padding(
             static_cast<extents_type>(other_mapping.extents()),
             other_mapping.extents().extent(extent_to_pad_idx))),
@@ -819,11 +819,11 @@ public:
    * Extents>`. However, this makes `padding_value` non-deducible.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value &&
-                      (_Mapping::extents_type::rank() == extents_type::rank())))
+      class Mapping,
+      /* requires */ (detail::is_layout_right_padded_mapping<Mapping>::value &&
+                      (Mapping::extents_type::rank() == extents_type::rank())))
   MDSPAN_INLINE_FUNCTION friend constexpr bool
-  operator==(const mapping &left, const _Mapping &right) noexcept {
+  operator==(const mapping &left, const Mapping &right) noexcept {
     // Workaround for some compilers not short-circuiting properly with
     // compile-time checks i.e. we can't access stride(_padding_stride_idx) of a
     // rank 0 mapping
@@ -843,11 +843,11 @@ public:
    * `OtherExtents::rank() == extents_type::rank()`.
    */
   MDSPAN_TEMPLATE_REQUIRES(
-      class _Mapping,
-      /* requires */ (detail::is_layout_right_padded_mapping<_Mapping>::value &&
-                      (_Mapping::extents_type::rank() == extents_type::rank())))
+      class Mapping,
+      /* requires */ (detail::is_layout_right_padded_mapping<Mapping>::value &&
+                      (Mapping::extents_type::rank() == extents_type::rank())))
   MDSPAN_INLINE_FUNCTION friend constexpr bool
-  operator!=(const mapping &left, const _Mapping &right) noexcept {
+  operator!=(const mapping &left, const Mapping &right) noexcept {
     return !(left == right);
   }
 #endif

--- a/include/experimental/__p2642_bits/layout_padded_fwd.hpp
+++ b/include/experimental/__p2642_bits/layout_padded_fwd.hpp
@@ -61,12 +61,12 @@ struct is_layout_left_padded : std::false_type {};
 template <size_t _PaddingStride>
 struct is_layout_left_padded<layout_left_padded<_PaddingStride>> : std::true_type {};
 
-template <class _Mapping, class _Enabled = void>
+template <class Mapping, class _Enabled = void>
 struct is_layout_left_padded_mapping : std::false_type {};
 
-template <class _Mapping>
-struct is_layout_left_padded_mapping<_Mapping,
-  std::enable_if_t<std::is_same<_Mapping, typename layout_left_padded<_Mapping::padding_value>::template mapping<typename _Mapping::extents_type>>::value>>
+template <class Mapping>
+struct is_layout_left_padded_mapping<Mapping,
+  std::enable_if_t<std::is_same<Mapping, typename layout_left_padded<Mapping::padding_value>::template mapping<typename Mapping::extents_type>>::value>>
     : std::true_type {};
 
 template <class _Layout>
@@ -75,12 +75,12 @@ struct is_layout_right_padded : std::false_type {};
 template <size_t _PaddingStride>
 struct is_layout_right_padded<layout_right_padded<_PaddingStride>> : std::true_type {};
 
-template <class _Mapping, class _Enabled = void>
+template <class Mapping, class _Enabled = void>
 struct is_layout_right_padded_mapping : std::false_type {};
 
-template <class _Mapping>
-struct is_layout_right_padded_mapping<_Mapping,
-  std::enable_if_t<std::is_same<_Mapping, typename layout_right_padded<_Mapping::padding_value>::template mapping<typename _Mapping::extents_type>>::value>>
+template <class Mapping>
+struct is_layout_right_padded_mapping<Mapping,
+  std::enable_if_t<std::is_same<Mapping, typename layout_right_padded<Mapping::padding_value>::template mapping<typename Mapping::extents_type>>::value>>
     : std::true_type {};
 
 

--- a/include/experimental/__p2642_bits/layout_padded_fwd.hpp
+++ b/include/experimental/__p2642_bits/layout_padded_fwd.hpp
@@ -24,44 +24,44 @@ namespace MDSPAN_IMPL_PROPOSED_NAMESPACE {
 
 template <size_t padding_value = dynamic_extent>
 struct layout_left_padded {
-  template <class _Extents>
+  template <class Extents>
   class mapping;
 };
 
 template <size_t padding_value = dynamic_extent>
 struct layout_right_padded {
-  template <class _Extents>
+  template <class Extents>
   class mapping;
 };
 
 namespace detail {
 // The layout_padded_constants structs are only useful if rank > 1, otherwise they may wrap
-template <class _Layout, class _ExtentsType>
+template <class Layout, class ExtentsType>
 struct layout_padded_constants;
 
-template <class _ExtentsType, size_t _PaddingStride>
-struct layout_padded_constants<layout_left_padded<_PaddingStride>, _ExtentsType>
+template <class ExtentsType, size_t PaddingStride>
+struct layout_padded_constants<layout_left_padded<PaddingStride>, ExtentsType>
 {
-  using rank_type = typename _ExtentsType::rank_type;
+  using rank_type = typename ExtentsType::rank_type;
   static constexpr rank_type padded_stride_idx = 1;
   static constexpr rank_type extent_to_pad_idx = 0;
 };
 
-template <class _ExtentsType, size_t _PaddingStride>
-struct layout_padded_constants<layout_right_padded<_PaddingStride>, _ExtentsType>
+template <class ExtentsType, size_t PaddingStride>
+struct layout_padded_constants<layout_right_padded<PaddingStride>, ExtentsType>
 {
-  using rank_type = typename _ExtentsType::rank_type;
-  static constexpr rank_type padded_stride_idx = _ExtentsType::rank() - 2;
-  static constexpr rank_type extent_to_pad_idx = _ExtentsType::rank() - 1;
+  using rank_type = typename ExtentsType::rank_type;
+  static constexpr rank_type padded_stride_idx = ExtentsType::rank() - 2;
+  static constexpr rank_type extent_to_pad_idx = ExtentsType::rank() - 1;
 };
 
-template <class _Layout>
+template <class Layout>
 struct is_layout_left_padded : std::false_type {};
 
-template <size_t _PaddingStride>
-struct is_layout_left_padded<layout_left_padded<_PaddingStride>> : std::true_type {};
+template <size_t PaddingStride>
+struct is_layout_left_padded<layout_left_padded<PaddingStride>> : std::true_type {};
 
-template <class Mapping, class _Enabled = void>
+template <class Mapping, class Enabled = void>
 struct is_layout_left_padded_mapping : std::false_type {};
 
 template <class Mapping>
@@ -69,13 +69,13 @@ struct is_layout_left_padded_mapping<Mapping,
   std::enable_if_t<std::is_same<Mapping, typename layout_left_padded<Mapping::padding_value>::template mapping<typename Mapping::extents_type>>::value>>
     : std::true_type {};
 
-template <class _Layout>
+template <class Layout>
 struct is_layout_right_padded : std::false_type {};
 
-template <size_t _PaddingStride>
-struct is_layout_right_padded<layout_right_padded<_PaddingStride>> : std::true_type {};
+template <size_t PaddingStride>
+struct is_layout_right_padded<layout_right_padded<PaddingStride>> : std::true_type {};
 
-template <class Mapping, class _Enabled = void>
+template <class Mapping, class Enabled = void>
 struct is_layout_right_padded_mapping : std::false_type {};
 
 template <class Mapping>
@@ -84,50 +84,50 @@ struct is_layout_right_padded_mapping<Mapping,
     : std::true_type {};
 
 
-template <class _LayoutExtentsType, class _PaddedLayoutMappingType>
+template <class LayoutExtentsType, class PaddedLayoutMappingType>
 MDSPAN_INLINE_FUNCTION
 constexpr void check_padded_layout_converting_constructor_mandates(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<0>) {}
 
-template <class _LayoutExtentsType, class _PaddedLayoutMappingType>
+template <class LayoutExtentsType, class PaddedLayoutMappingType>
 MDSPAN_INLINE_FUNCTION
 constexpr void check_padded_layout_converting_constructor_mandates(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<1>) {}
 
-template <class _LayoutExtentsType, class _PaddedLayoutMappingType, std::size_t N>
+template <class LayoutExtentsType, class PaddedLayoutMappingType, std::size_t N>
 MDSPAN_INLINE_FUNCTION
 constexpr void check_padded_layout_converting_constructor_mandates(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<N>)
 {
-  using extents_type = typename _PaddedLayoutMappingType::extents_type;
-  constexpr auto padding_value = _PaddedLayoutMappingType::padding_value;
-  constexpr auto idx = layout_padded_constants<typename _PaddedLayoutMappingType::layout_type, _LayoutExtentsType >::extent_to_pad_idx;
+  using extents_type = typename PaddedLayoutMappingType::extents_type;
+  constexpr auto padding_value = PaddedLayoutMappingType::padding_value;
+  constexpr auto idx = layout_padded_constants<typename PaddedLayoutMappingType::layout_type, LayoutExtentsType >::extent_to_pad_idx;
 
   constexpr auto statically_determinable =
-    (_LayoutExtentsType::static_extent(idx) != dynamic_extent) &&
+    (LayoutExtentsType::static_extent(idx) != dynamic_extent) &&
     (extents_type::static_extent(idx) != dynamic_extent) &&
     (padding_value != dynamic_extent);
 
   static_assert(!statically_determinable ||
                 (padding_value == 0
-                 ? _LayoutExtentsType::static_extent(idx) == 0
-                 : _LayoutExtentsType::static_extent(idx) % padding_value == 0),
+                 ? LayoutExtentsType::static_extent(idx) == 0
+                 : LayoutExtentsType::static_extent(idx) % padding_value == 0),
                 "");
 }
 
-template <typename _ExtentsType, typename _OtherMapping>
+template <typename ExtentsType, typename OtherMapping>
 MDSPAN_INLINE_FUNCTION
 constexpr void check_padded_layout_converting_constructor_preconditions(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<0>,
-                                                                        const _OtherMapping&) {}
-template <typename _ExtentsType, typename _OtherMapping>
+                                                                        const OtherMapping&) {}
+template <typename ExtentsType, typename OtherMapping>
 MDSPAN_INLINE_FUNCTION
 constexpr void check_padded_layout_converting_constructor_preconditions(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<1>,
-                                                                        const _OtherMapping&) {}
-template <typename _ExtentsType, typename _OtherMapping, std::size_t N>
+                                                                        const OtherMapping&) {}
+template <typename ExtentsType, typename OtherMapping, std::size_t N>
 MDSPAN_INLINE_FUNCTION
 constexpr void check_padded_layout_converting_constructor_preconditions(MDSPAN_IMPL_STANDARD_NAMESPACE::detail::with_rank<N>,
-                                                                        const _OtherMapping &other_mapping) {
+                                                                        const OtherMapping &other_mapping) {
   constexpr auto padded_stride_idx =
-    layout_padded_constants<typename _OtherMapping::layout_type,
-                            _ExtentsType>::padded_stride_idx;
-  constexpr auto extent_to_pad_idx = layout_padded_constants<typename _OtherMapping::layout_type, _ExtentsType>::extent_to_pad_idx;
+    layout_padded_constants<typename OtherMapping::layout_type,
+                            ExtentsType>::padded_stride_idx;
+  constexpr auto extent_to_pad_idx = layout_padded_constants<typename OtherMapping::layout_type, ExtentsType>::extent_to_pad_idx;
   MDSPAN_IMPL_PRECONDITION(other_mapping.stride(padded_stride_idx) == other_mapping.extents().extent(extent_to_pad_idx));
 }
 

--- a/make_single_header.py
+++ b/make_single_header.py
@@ -73,10 +73,10 @@ if __name__ == "__main__":
             # We use an include guard instead of `#pragma once` because Godbolt will
             # cause complaints about `#pragma once` when they are used in URL includes.
             [
-                "#ifndef _MDSPAN_SINGLE_HEADER_INCLUDE_GUARD_\n",
-                "#define _MDSPAN_SINGLE_HEADER_INCLUDE_GUARD_\n",
+                "#ifndef MDSPAN_SINGLE_HEADER_INCLUDE_GUARD_\n",
+                "#define MDSPAN_SINGLE_HEADER_INCLUDE_GUARD_\n",
             ],
-            ["#endif // _MDSPAN_SINGLE_HEADER_INCLUDE_GUARD_\n"],
+            ["#endif // MDSPAN_SINGLE_HEADER_INCLUDE_GUARD_\n"],
             [str(Path(sys.argv[1]).resolve())],
         )
     )

--- a/tests/foo_customizations.hpp
+++ b/tests/foo_customizations.hpp
@@ -94,8 +94,8 @@ class layout_foo::mapping {
     MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping() noexcept = default;
     MDSPAN_INLINE_FUNCTION_DEFAULTED constexpr mapping(mapping const&) noexcept = default;
 
-    constexpr mapping(extents_type const& __exts) noexcept
-      :__extents(__exts)
+    constexpr mapping(extents_type const& exts) noexcept
+      :m_extents(exts)
     { }
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -107,7 +107,7 @@ class layout_foo::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
@@ -124,7 +124,7 @@ class layout_foo::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(Kokkos::layout_right::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {}
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -137,7 +137,7 @@ class layout_foo::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((!std::is_convertible<OtherExtents, extents_type>::value)) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(Kokkos::layout_left::mapping<OtherExtents> const& other) noexcept // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {}
 
     MDSPAN_TEMPLATE_REQUIRES(
@@ -149,7 +149,7 @@ class layout_foo::mapping {
     MDSPAN_CONDITIONAL_EXPLICIT((extents_type::rank() > 0))
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(Kokkos::layout_stride::mapping<OtherExtents> const& other) // NOLINT(google-explicit-constructor)
-      :__extents(other.extents())
+      :m_extents(other.extents())
     {
        /*
         * TODO: check precondition
@@ -157,10 +157,10 @@ class layout_foo::mapping {
         */
        #ifndef __CUDA_ARCH__
        size_t stride = 1;
-       for(rank_type r=__extents.rank(); r>0; r--) {
+       for(rank_type r=m_extents.rank(); r>0; r--) {
          if(stride != other.stride(r-1))
            throw std::runtime_error("Assigning layout_stride to layout_foo with invalid strides.");
-         stride *= __extents.extent(r-1);
+         stride *= m_extents.extent(r-1);
        }
        #endif
     }
@@ -169,13 +169,13 @@ class layout_foo::mapping {
 
     MDSPAN_INLINE_FUNCTION
     constexpr const extents_type& extents() const noexcept {
-      return __extents;
+      return m_extents;
     }
 
     MDSPAN_INLINE_FUNCTION
     constexpr index_type required_span_size() const noexcept {
       index_type value = 1;
-      for(rank_type r=0; r != extents_type::rank(); ++r) value*=__extents.extent(r);
+      for(rank_type r=0; r != extents_type::rank(); ++r) value*=m_extents.extent(r);
       return value;
     }
 
@@ -193,7 +193,7 @@ class layout_foo::mapping {
     template<class Indx0, class Indx1>
     MDSPAN_INLINE_FUNCTION
     constexpr index_type operator()(Indx0 idx0, Indx1 idx1) const noexcept {
-      return static_cast<index_type>(idx0 * __extents.extent(1) + idx1);
+      return static_cast<index_type>(idx0 * m_extents.extent(1) + idx1);
     }
 
     MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept { return true; }
@@ -206,7 +206,7 @@ class layout_foo::mapping {
     MDSPAN_INLINE_FUNCTION
     constexpr index_type stride(rank_type i) const noexcept {
       index_type value = 1;
-      for(rank_type r=extents_type::rank()-1; r>i; r--) value*=__extents.extent(r);
+      for(rank_type r=extents_type::rank()-1; r>i; r--) value*=m_extents.extent(r);
       return value;
     }
 
@@ -245,7 +245,7 @@ class layout_foo::mapping {
 #endif
 
 private:
-   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type __extents{};
+   MDSPAN_IMPL_NO_UNIQUE_ADDRESS extents_type m_extents{};
 
 };
 

--- a/tests/foo_customizations.hpp
+++ b/tests/foo_customizations.hpp
@@ -80,7 +80,7 @@ class layout_foo::mapping {
     using layout_type = layout_foo;
   private:
 
-    static_assert(Kokkos::detail::__is_extents_v<extents_type>,
+    static_assert(Kokkos::detail::impl_is_extents_v<extents_type>,
                   "layout_foo::mapping must be instantiated with a specialization of Kokkos::extents.");
     static_assert(extents_type::rank() < 3, "layout_foo only supports 0D, 1D and 2D");
 

--- a/tests/libcxx-backports/layout_left/layout_left.static_requirements.pass.cpp
+++ b/tests/libcxx-backports/layout_left/layout_left.static_requirements.pass.cpp
@@ -87,7 +87,7 @@
 template <class M, size_t... Idxs>
 void test_mapping_requirements(std::index_sequence<Idxs...>) {
   using E = typename M::extents_type;
-  // static_assert(std::__mdspan_detail::__is_extents_v<E>); // FIXME
+  // static_assert(std::__mdspan_detail::impl_is_extents_v<E>); // FIXME
   static_assert(std::is_copy_constructible_v<M>);
   static_assert(std::is_nothrow_move_constructible_v<M>);
   static_assert(std::is_nothrow_move_assignable_v<M>);

--- a/tests/libcxx-backports/layout_right/layout_right.static_requirements.pass.cpp
+++ b/tests/libcxx-backports/layout_right/layout_right.static_requirements.pass.cpp
@@ -87,7 +87,7 @@
 template <class M, size_t... Idxs>
 void test_mapping_requirements(std::index_sequence<Idxs...>) {
   using E = typename M::extents_type;
-  //static_assert(std::__mdspan_detail::__is_extents_v<E>); //FIXME
+  //static_assert(std::__mdspan_detail::impl_is_extents_v<E>); //FIXME
   static_assert(std::is_copy_constructible_v<M>);
   static_assert(std::is_nothrow_move_constructible_v<M>);
   static_assert(std::is_nothrow_move_assignable_v<M>);

--- a/tests/libcxx-backports/layout_stride/layout_stride.static_requirements.pass.cpp
+++ b/tests/libcxx-backports/layout_stride/layout_stride.static_requirements.pass.cpp
@@ -87,7 +87,7 @@
 template <class M, size_t... Idxs>
 void test_mapping_requirements(std::index_sequence<Idxs...>) {
   using E = typename M::extents_type;
-  //static_assert(std::__mdspan_detail::__is_extents_v<E>); //FIXME
+  //static_assert(std::__mdspan_detail::impl_is_extents_v<E>); //FIXME
   static_assert(std::is_copy_constructible_v<M>);
   static_assert(std::is_nothrow_move_constructible_v<M>);
   static_assert(std::is_nothrow_move_assignable_v<M>);

--- a/tests/offload_utils.hpp
+++ b/tests/offload_utils.hpp
@@ -29,13 +29,13 @@ namespace {
 bool dispatch_host = true;
 
 #ifdef MDSPAN_IMPL_HAS_SYCL
-#define __MDSPAN_DEVICE_ASSERT_EQ(LHS, RHS) \
+#define MDSPAN_IMPL_DEVICE_ASSERT_EQ(LHS, RHS) \
 if (!(LHS == RHS)) { \
   sycl::ext::oneapi::experimental::printf("expected equality of %s and %s\n", #LHS, #RHS); \
   errors[0]++; \
 }
 #else
- #define __MDSPAN_DEVICE_ASSERT_EQ(LHS, RHS) \
+ #define MDSPAN_IMPL_DEVICE_ASSERT_EQ(LHS, RHS) \
  if (!(LHS == RHS)) { \
   printf("expected equality of %s and %s\n", #LHS, #RHS); \
   errors[0]++; \
@@ -93,13 +93,13 @@ void free_array(T* ptr) {
     freeManaged(ptr);
 }
 
-#define __MDSPAN_TESTS_RUN_TEST(A) \
+#define MDSPAN_IMPL_TESTS_RUN_TEST(A) \
  dispatch_host = true; \
  A; \
  dispatch_host = false; \
  A;
 
-#define __MDSPAN_TESTS_DISPATCH_DEFINED
+#define MDSPAN_IMPL_TESTS_DISPATCH_DEFINED
 #endif // MDSPAN_IMPL_HAS_CUDA
 
 #ifdef MDSPAN_IMPL_HAS_SYCL
@@ -147,16 +147,16 @@ void free_array(T* ptr) {
   }
 }
 
-#define __MDSPAN_TESTS_RUN_TEST(A) \
+#define MDSPAN_IMPL_TESTS_RUN_TEST(A) \
  dispatch_host = true; \
  A; \
  dispatch_host = false; \
  A;
 
-#define __MDSPAN_TESTS_DISPATCH_DEFINED
+#define MDSPAN_IMPL_TESTS_DISPATCH_DEFINED
 #endif // MDSPAN_IMPL_HAS_SYCL
 
-#ifndef __MDSPAN_TESTS_DISPATCH_DEFINED
+#ifndef MDSPAN_IMPL_TESTS_DISPATCH_DEFINED
 template<class LAMBDA>
 void dispatch(LAMBDA&& f) {
   static_cast<LAMBDA&&>(f)();
@@ -173,7 +173,7 @@ void free_array(T* ptr) {
   delete [] ptr;
 }
 
-#define __MDSPAN_TESTS_RUN_TEST(A) \
+#define MDSPAN_IMPL_TESTS_RUN_TEST(A) \
  dispatch_host = true; \
  A;
 #endif

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -306,7 +306,7 @@ struct ImplicitConversionToExts<Extents,false> {
 };
 
 
-#ifdef _MDSPAN_USE_CONDITIONAL_EXPLICIT
+#ifdef MDSPAN_HAS_CXX_20
 TYPED_TEST(TestExtentsCompatCtors, implicit_construct_1) {
   bool exts1_convertible_exts2 =
     std::is_convertible<typename TestFixture::extents_type1,

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -46,13 +46,13 @@ struct TestExtents<
     size_t* result = allocate_array<size_t>(2);
 
     dispatch([=] MDSPAN_IMPL_HOST_DEVICE () {
-      extents_type _exts(DynamicSizes...);
+      extents_type exts(DynamicSizes...);
       // Silencing an unused warning in nvc++ the condition will never be true
-      size_t dyn_val = _exts.rank()>0?static_cast<size_t>(_exts.extent(0)):1;
-      result[0] = dyn_val > 1e9 ? dyn_val : _exts.rank();
-      result[1] = _exts.rank_dynamic();
-      // Some compilers warn about unused _exts since the functions are all static constexpr
-      (void) _exts;
+      size_t dyn_val = exts.rank()>0?static_cast<size_t>(exts.extent(0)):1;
+      result[0] = dyn_val > 1e9 ? dyn_val : exts.rank();
+      result[1] = exts.rank_dynamic();
+      // Some compilers warn about unused exts since the functions are all static constexpr
+      (void) exts;
     });
     EXPECT_EQ(result[0], static_sizes.size());
     EXPECT_EQ(result[1], dyn_sizes.size());
@@ -64,14 +64,14 @@ struct TestExtents<
     size_t* result = allocate_array<size_t>(extents_type::rank());
 
     dispatch([=] MDSPAN_IMPL_HOST_DEVICE () {
-      extents_type _exts(DynamicSizes...);
-      for(size_t r=0; r<_exts.rank(); r++) {
+      extents_type exts(DynamicSizes...);
+      for(size_t r=0; r<exts.rank(); r++) {
         // Silencing an unused warning in nvc++ the condition will never be true
-        size_t dyn_val = static_cast<size_t>(_exts.extent(r));
-        result[r] = dyn_val > 1e9 ? dyn_val : _exts.static_extent(r);
+        size_t dyn_val = static_cast<size_t>(exts.extent(r));
+        result[r] = dyn_val > 1e9 ? dyn_val : exts.static_extent(r);
       }
-      // Some compilers warn about unused _exts since the functions are all static constexpr
-      (void) _exts;
+      // Some compilers warn about unused exts since the functions are all static constexpr
+      (void) exts;
     });
     for(size_t r=0; r<extents_type::rank(); r++) {
       EXPECT_EQ(result[r], static_sizes[r]);
@@ -84,11 +84,11 @@ struct TestExtents<
     size_t* result = allocate_array<size_t>(extents_type::rank());
 
     dispatch([=] MDSPAN_IMPL_HOST_DEVICE () {
-      extents_type _exts(DynamicSizes...);
-      for(size_t r=0; r<_exts.rank(); r++ )
-        result[r] = _exts.extent(r);
+      extents_type exts(DynamicSizes...);
+      for(size_t r=0; r<exts.rank(); r++ )
+        result[r] = exts.extent(r);
       // Some compilers warn about unused _exts since the functions are all static constexpr
-      (void) _exts;
+      (void) exts;
     });
     int dyn_count = 0;
     for(size_t r=0; r<extents_type::rank(); r++) {
@@ -102,18 +102,18 @@ struct TestExtents<
 };
 
 template <size_t... Ds>
-using _sizes = std::integer_sequence<size_t, Ds...>;
+using sizes = std::integer_sequence<size_t, Ds...>;
 template <size_t... Ds>
-using _exts = Kokkos::extents<size_t,Ds...>;
+using exts = Kokkos::extents<size_t,Ds...>;
 
 using extents_test_types =
   ::testing::Types<
-    std::tuple<_exts<10>, _sizes<>>,
-    std::tuple<_exts<Kokkos::dynamic_extent>, _sizes<10>>,
-    std::tuple<_exts<10, 3>, _sizes<>>,
-    std::tuple<_exts<Kokkos::dynamic_extent, 3>, _sizes<10>>,
-    std::tuple<_exts<10, Kokkos::dynamic_extent>, _sizes<3>>,
-    std::tuple<_exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, _sizes<10, 3>>
+    std::tuple<exts<10>, sizes<>>,
+    std::tuple<exts<Kokkos::dynamic_extent>, sizes<10>>,
+    std::tuple<exts<10, 3>, sizes<>>,
+    std::tuple<exts<Kokkos::dynamic_extent, 3>, sizes<10>>,
+    std::tuple<exts<10, Kokkos::dynamic_extent>, sizes<3>>,
+    std::tuple<exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, sizes<10, 3>>
   >;
 
 TYPED_TEST_SUITE(TestExtents, extents_test_types);
@@ -159,7 +159,7 @@ TYPED_TEST(TestExtents, copy_assign) {
 // Only types can be part of the gtest type iteration
 // so i need this wrapper to wrap around true/false values
 template<bool Val1, bool Val2>
-struct _BoolPairDeducer {
+struct BoolPairDeducer {
   static constexpr bool val1 = Val1;
   static constexpr bool val2 = Val2;
 };
@@ -172,7 +172,7 @@ struct TestExtentsCompatCtors<std::tuple<
   std::integer_sequence<size_t, DynamicSizes...>,
   Kokkos::extents<size_t,Extents2...>,
   std::integer_sequence<size_t, DynamicSizes2...>,
-  _BoolPairDeducer<ImplicitExts1ToExts2,ImplicitExts2ToExts1>
+  BoolPairDeducer<ImplicitExts1ToExts2,ImplicitExts2ToExts1>
 >> : public ::testing::Test {
   using extents_type1 = Kokkos::extents<size_t,Extents...>;
   using extents_type2 = Kokkos::extents<size_t,Extents2...>;
@@ -232,19 +232,19 @@ struct TestExtentsCompatCtors<std::tuple<
 
 using compatible_extents_test_types =
   ::testing::Types<
-    std::tuple<_exts<Kokkos::dynamic_extent>, _sizes<5>, _exts<5>, _sizes<>, _BoolPairDeducer<false,true>>,
-    std::tuple<_exts<5>, _sizes<>, _exts<Kokkos::dynamic_extent>, _sizes<5>, _BoolPairDeducer<true,false>>,
+    std::tuple<exts<Kokkos::dynamic_extent>, sizes<5>, exts<5>, sizes<>, BoolPairDeducer<false,true>>,
+    std::tuple<exts<5>, sizes<>, exts<Kokkos::dynamic_extent>, sizes<5>, BoolPairDeducer<true,false>>,
     //--------------------
-    std::tuple<_exts<Kokkos::dynamic_extent, 10>, _sizes<5>, _exts<5, Kokkos::dynamic_extent>, _sizes<10>,  _BoolPairDeducer<false, false>>,
-    std::tuple<_exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, _sizes<5, 10>, _exts<5, Kokkos::dynamic_extent>, _sizes<10>,  _BoolPairDeducer<false, true>>,
-    std::tuple<_exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, _sizes<5, 10>, _exts<Kokkos::dynamic_extent, 10>, _sizes<5>,  _BoolPairDeducer<false, true>>,
-    std::tuple<_exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, _sizes<5, 10>, _exts<5, 10>, _sizes<>,  _BoolPairDeducer<false, true>>,
-    std::tuple<_exts<5, 10>, _sizes<>, _exts<5, Kokkos::dynamic_extent>, _sizes<10>,  _BoolPairDeducer<true, false>>,
-    std::tuple<_exts<5, 10>, _sizes<>, _exts<Kokkos::dynamic_extent, 10>, _sizes<5>,  _BoolPairDeducer<true, false>>,
+    std::tuple<exts<Kokkos::dynamic_extent, 10>, sizes<5>, exts<5, Kokkos::dynamic_extent>, sizes<10>,  BoolPairDeducer<false, false>>,
+    std::tuple<exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, sizes<5, 10>, exts<5, Kokkos::dynamic_extent>, sizes<10>,  BoolPairDeducer<false, true>>,
+    std::tuple<exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, sizes<5, 10>, exts<Kokkos::dynamic_extent, 10>, sizes<5>,  BoolPairDeducer<false, true>>,
+    std::tuple<exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent>, sizes<5, 10>, exts<5, 10>, sizes<>,  BoolPairDeducer<false, true>>,
+    std::tuple<exts<5, 10>, sizes<>, exts<5, Kokkos::dynamic_extent>, sizes<10>,  BoolPairDeducer<true, false>>,
+    std::tuple<exts<5, 10>, sizes<>, exts<Kokkos::dynamic_extent, 10>, sizes<5>,  BoolPairDeducer<true, false>>,
     //--------------------
-    std::tuple<_exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent, 15>, _sizes<5, 10>, _exts<5, Kokkos::dynamic_extent, 15>, _sizes<10>,  _BoolPairDeducer<false, true>>,
-    std::tuple<_exts<5, 10, 15>, _sizes<>, _exts<5, Kokkos::dynamic_extent, 15>, _sizes<10>,  _BoolPairDeducer<true, false>>,
-    std::tuple<_exts<5, 10, 15>, _sizes<>, _exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent, Kokkos::dynamic_extent>, _sizes<5, 10, 15>,  _BoolPairDeducer<true, false>>
+    std::tuple<exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent, 15>, sizes<5, 10>, exts<5, Kokkos::dynamic_extent, 15>, sizes<10>,  BoolPairDeducer<false, true>>,
+    std::tuple<exts<5, 10, 15>, sizes<>, exts<5, Kokkos::dynamic_extent, 15>, sizes<10>,  BoolPairDeducer<true, false>>,
+    std::tuple<exts<5, 10, 15>, sizes<>, exts<Kokkos::dynamic_extent, Kokkos::dynamic_extent, Kokkos::dynamic_extent>, sizes<5, 10, 15>,  BoolPairDeducer<true, false>>
   >;
 
 TYPED_TEST_SUITE(TestExtentsCompatCtors, compatible_extents_test_types);

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -119,15 +119,15 @@ using extents_test_types =
 TYPED_TEST_SUITE(TestExtents, extents_test_types);
 
 TYPED_TEST(TestExtents, rank) {
-  __MDSPAN_TESTS_RUN_TEST(this->test_rank())
+  MDSPAN_IMPL_TESTS_RUN_TEST(this->test_rank())
 }
 
 TYPED_TEST(TestExtents, static_extent) {
-  __MDSPAN_TESTS_RUN_TEST(this->test_static_extent())
+  MDSPAN_IMPL_TESTS_RUN_TEST(this->test_static_extent())
 }
 
 TYPED_TEST(TestExtents, extent) {
-  __MDSPAN_TESTS_RUN_TEST(this->test_extent())
+  MDSPAN_IMPL_TESTS_RUN_TEST(this->test_extent())
 }
 
 TYPED_TEST(TestExtents, default_ctor) {

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -306,7 +306,7 @@ struct ImplicitConversionToExts<Extents,false> {
 };
 
 
-#ifdef MDSPAN_HAS_CXX_20
+#if MDSPAN_HAS_CXX_20
 TYPED_TEST(TestExtentsCompatCtors, implicit_construct_1) {
   bool exts1_convertible_exts2 =
     std::is_convertible<typename TestFixture::extents_type1,

--- a/tests/test_layout_ctors.cpp
+++ b/tests/test_layout_ctors.cpp
@@ -97,25 +97,25 @@ using test_right_type_compatible = std::tuple<
   typename Kokkos::layout_right::template mapping<E2>, S2
 >;
 template <size_t... Ds>
-using _sizes = std::integer_sequence<size_t, Ds...>;
+using sizes = std::integer_sequence<size_t, Ds...>;
 template <size_t... Ds>
-using _exts = Kokkos::extents<size_t,Ds...>;
+using exts = Kokkos::extents<size_t,Ds...>;
 
-template <template <class, class, class, class> class _test_case_type>
+template <template <class, class, class, class> class test_case_type>
 using compatible_layout_test_types =
   ::testing::Types<
-    _test_case_type<_exts<dyn>, _sizes<10>, _exts<10>, _sizes<>>,
+    test_case_type<exts<dyn>, sizes<10>, exts<10>, sizes<>>,
     //--------------------
-    _test_case_type<_exts<dyn, 10>, _sizes<5>, _exts<5, dyn>, _sizes<10>>,
-    _test_case_type<_exts<dyn, dyn>, _sizes<5, 10>, _exts<5, dyn>, _sizes<10>>,
-    _test_case_type<_exts<dyn, dyn>, _sizes<5, 10>, _exts<dyn, 10>, _sizes<5>>,
-    _test_case_type<_exts<dyn, dyn>, _sizes<5, 10>, _exts<5, 10>, _sizes<>>,
-    _test_case_type<_exts<5, 10>, _sizes<>, _exts<5, dyn>, _sizes<10>>,
-    _test_case_type<_exts<5, 10>, _sizes<>, _exts<dyn, 10>, _sizes<5>>,
+    test_case_type<exts<dyn, 10>, sizes<5>, exts<5, dyn>, sizes<10>>,
+    test_case_type<exts<dyn, dyn>, sizes<5, 10>, exts<5, dyn>, sizes<10>>,
+    test_case_type<exts<dyn, dyn>, sizes<5, 10>, exts<dyn, 10>, sizes<5>>,
+    test_case_type<exts<dyn, dyn>, sizes<5, 10>, exts<5, 10>, sizes<>>,
+    test_case_type<exts<5, 10>, sizes<>, exts<5, dyn>, sizes<10>>,
+    test_case_type<exts<5, 10>, sizes<>, exts<dyn, 10>, sizes<5>>,
     //--------------------
-    _test_case_type<_exts<dyn, dyn, 15>, _sizes<5, 10>, _exts<5, dyn, 15>, _sizes<10>>,
-    _test_case_type<_exts<5, 10, 15>, _sizes<>, _exts<5, dyn, 15>, _sizes<10>>,
-    _test_case_type<_exts<5, 10, 15>, _sizes<>, _exts<dyn, dyn, dyn>, _sizes<5, 10, 15>>
+    test_case_type<exts<dyn, dyn, 15>, sizes<5, 10>, exts<5, dyn, 15>, sizes<10>>,
+    test_case_type<exts<5, 10, 15>, sizes<>, exts<5, dyn, 15>, sizes<10>>,
+    test_case_type<exts<5, 10, 15>, sizes<>, exts<dyn, dyn, dyn>, sizes<5, 10, 15>>
   >;
 
 using left_compatible_test_types = compatible_layout_test_types<test_left_type_compatible>;

--- a/tests/test_layout_padded_left.cpp
+++ b/tests/test_layout_padded_left.cpp
@@ -1,5 +1,5 @@
 #define MDSPAN_INTERNAL_TEST
-#define _MDSPAN_DEBUG
+#define MDSPAN_DEBUG
 #include <cassert>
 
 #include <mdspan/mdspan.hpp>

--- a/tests/test_layout_padded_right.cpp
+++ b/tests/test_layout_padded_right.cpp
@@ -1,5 +1,5 @@
 #define MDSPAN_INTERNAL_TEST
-#define _MDSPAN_DEBUG
+#define MDSPAN_DEBUG
 #include <cassert>
 
 #include <mdspan/mdspan.hpp>

--- a/tests/test_layout_stride.cpp
+++ b/tests/test_layout_stride.cpp
@@ -33,9 +33,9 @@ struct TestLayoutStride<std::tuple<
 };
 
 template <size_t... Extents>
-using _exts = Kokkos::extents<size_t,Extents...>;
+using exts = Kokkos::extents<size_t,Extents...>;
 template <size_t... Vals>
-using _ints = std::integer_sequence<size_t, Vals...>;
+using ints = std::integer_sequence<size_t, Vals...>;
 template <class E, class DSz, class SStr, class DStr>
 using layout_stride_case_t =
   std::tuple<E, DSz, SStr, DStr>;
@@ -45,9 +45,9 @@ using extents_3dyn5_t = Kokkos::extents<size_t,3, dyn, 5>;
 using extents_ddd_t = Kokkos::extents<size_t,dyn, dyn, dyn>;
 using zero_stride_maps =
   ::testing::Types<
-    layout_stride_case_t<extents_345_t, _ints<>, _ints<dyn, dyn, dyn>, _ints<0, 0, 0>>,
-    layout_stride_case_t<extents_3dyn5_t, _ints<4>, _ints<dyn, dyn, dyn>, _ints<0, 0, 0>>,
-    layout_stride_case_t<extents_ddd_t, _ints<3, 4, 5>, _ints<dyn, dyn, dyn>, _ints<0, 0, 0>>
+    layout_stride_case_t<extents_345_t, ints<>, ints<dyn, dyn, dyn>, ints<0, 0, 0>>,
+    layout_stride_case_t<extents_3dyn5_t, ints<4>, ints<dyn, dyn, dyn>, ints<0, 0, 0>>,
+    layout_stride_case_t<extents_ddd_t, ints<3, 4, 5>, ints<dyn, dyn, dyn>, ints<0, 0, 0>>
   >;
 
 template <class T>
@@ -130,17 +130,17 @@ using test_stride_equality = std::tuple<
   Equal
 >;
 template <size_t... Ds>
-using _sizes = std::integer_sequence<size_t, Ds...>;
+using sizes = std::integer_sequence<size_t, Ds...>;
 template <size_t... Ds>
-using _exts = Kokkos::extents<size_t,Ds...>;
+using exts = Kokkos::extents<size_t,Ds...>;
 
-template <template <class, class, class, class, class> class _test_case_type>
+template <template <class, class, class, class, class> class test_case_type>
 using equality_test_types =
   ::testing::Types<
-    _test_case_type<_exts<16, 32>, _sizes<1, 16>, _exts<16, 32>, _sizes<1, 16>, std:: true_type>,
-    _test_case_type<_exts<16, 32>, _sizes<1, 16>, _exts<16, 32>, _sizes<1, 17>, std::false_type>,
-    _test_case_type<_exts<16, 32>, _sizes<1, 16>, _exts<16, 64>, _sizes<1, 16>, std::false_type>,
-    _test_case_type<_exts<16, 32>, _sizes<1, 16>, _exts<16, 64>, _sizes<1, 17>, std::false_type>
+    test_case_type<exts<16, 32>, sizes<1, 16>, exts<16, 32>, sizes<1, 16>, std:: true_type>,
+    test_case_type<exts<16, 32>, sizes<1, 16>, exts<16, 32>, sizes<1, 17>, std::false_type>,
+    test_case_type<exts<16, 32>, sizes<1, 16>, exts<16, 64>, sizes<1, 16>, std::false_type>,
+    test_case_type<exts<16, 32>, sizes<1, 16>, exts<16, 64>, sizes<1, 17>, std::false_type>
   >;
 
 using layout_stride_equality_test_types = equality_test_types<test_stride_equality>;

--- a/tests/test_mdarray_ctors.cpp
+++ b/tests/test_mdarray_ctors.cpp
@@ -174,22 +174,22 @@ void test_mdarray_ctor_data_carray() {
 
   dispatch([=] MDSPAN_IMPL_HOST_DEVICE () {
     KokkosEx::mdarray<int, Kokkos::extents<size_t,1>, Kokkos::layout_right, std::array<int, 1>> m(Kokkos::extents<int,1>{});
-    __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.stride(0), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.rank(), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.extent(0), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.stride(0), 1);
     m.data()[0] = {42};
     auto val = MDSPAN_IMPL_OP(m,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val, 42);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val, 42);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
   });
   ASSERT_EQ(errors[0], 0);
   free_array(errors);
 }
 
 TEST(TestMdarrayCtorDataCArray, test_mdarray_ctor_data_carray) {
-  __MDSPAN_TESTS_RUN_TEST(test_mdarray_ctor_data_carray())
+  MDSPAN_IMPL_TESTS_RUN_TEST(test_mdarray_ctor_data_carray())
 }
 
 // Construct from extents only

--- a/tests/test_mdarray_ctors.cpp
+++ b/tests/test_mdarray_ctors.cpp
@@ -589,16 +589,8 @@ TEST(TestMdarrayCTAD, ctad_carray) {
   KokkosEx::mdarray m(data);
   static_assert(std::is_same<decltype(m)::element_type,int>::value);
   ASSERT_EQ(m.data(), &data[0]);
-  #ifdef  _MDSPAN_USE_P2554
-  ASSERT_EQ(m.rank(), 1);
-  ASSERT_EQ(m.rank_dynamic(), 0);
-  ASSERT_EQ(m.static_extent(0), 5);
-  ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(MDSPAN_IMPL_OP(m, 2), 3);
-  #else
   ASSERT_EQ(m.rank(), 0);
   ASSERT_EQ(m.rank_dynamic(), 0);
-  #endif
   ASSERT_TRUE(m.is_exhaustive());
 
 
@@ -617,16 +609,8 @@ TEST(TestMdarrayCTAD, ctad_const_carray) {
   KokkosEx::mdarray m(data);
   static_assert(std::is_same<decltype(m)::element_type,const int>::value);
   ASSERT_EQ(m.data(), &data[0]);
-  #ifdef  _MDSPAN_USE_P2554
-  ASSERT_EQ(m.rank(), 1);
-  ASSERT_EQ(m.rank_dynamic(), 0);
-  ASSERT_EQ(m.static_extent(0), 5);
-  ASSERT_EQ(m.extent(0), 5);
-  ASSERT_EQ(MDSPAN_IMPL_OP(m, 2), 3);
-  #else
   ASSERT_EQ(m.rank(), 0);
   ASSERT_EQ(m.rank_dynamic(), 0);
-  #endif
   ASSERT_TRUE(m.is_exhaustive());
 }
 

--- a/tests/test_mdspan_ctors.cpp
+++ b/tests/test_mdspan_ctors.cpp
@@ -28,22 +28,22 @@ void test_mdspan_ctor_default() {
 
   dispatch([=] MDSPAN_IMPL_HOST_DEVICE () {
     Kokkos::mdspan<int, Kokkos::dextents<size_t,1>> m;
-    __MDSPAN_DEVICE_ASSERT_EQ(m.data_handle(), nullptr);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), 0);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), dyn);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.stride(0), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.size(), 0);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.empty(), true);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.data_handle(), nullptr);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.rank(), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.rank_dynamic(), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.extent(0), 0);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.static_extent(0), dyn);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.stride(0), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.size(), 0);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.empty(), true);
   });
   ASSERT_EQ(errors[0], 0);
   free_array(errors);
 }
 
 TEST(TestMdspanCtorDataCArray, test_mdspan_ctor_default) {
-  __MDSPAN_TESTS_RUN_TEST(test_mdspan_ctor_default())
+  MDSPAN_IMPL_TESTS_RUN_TEST(test_mdspan_ctor_default())
 }
 
 void test_mdspan_ctor_data_carray() {
@@ -53,24 +53,24 @@ void test_mdspan_ctor_data_carray() {
   dispatch([=] MDSPAN_IMPL_HOST_DEVICE () {
     int data[1] = {42};
     Kokkos::mdspan<int, Kokkos::extents<size_t,1>> m(data);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.data_handle(), data);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.rank(), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.extent(0), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.stride(0), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.data_handle(), data);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.rank(), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.rank_dynamic(), 0);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.extent(0), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.static_extent(0), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.stride(0), 1);
     auto val = MDSPAN_IMPL_OP(m,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val, 42);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.size(), 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m.empty(), false);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val, 42);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.is_exhaustive(), true);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.size(), 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m.empty(), false);
   });
   ASSERT_EQ(errors[0], 0);
   free_array(errors);
 }
 
 TEST(TestMdspanCtorDataCArray, test_mdspan_ctor_data_carray) {
-  __MDSPAN_TESTS_RUN_TEST(test_mdspan_ctor_data_carray())
+  MDSPAN_IMPL_TESTS_RUN_TEST(test_mdspan_ctor_data_carray())
 }
 
 TEST(TestMdspanCtorDataStdArray, test_mdspan_ctor_data_carray) {

--- a/tests/test_mdspan_swap.cpp
+++ b/tests/test_mdspan_swap.cpp
@@ -35,30 +35,30 @@ void test_mdspan_std_swap_static_extents() {
     Kokkos::layout_right::mapping<Kokkos::extents<size_t, 3, 4>> map1(exts1);
     Kokkos::extents<size_t,3,4> exts2;
     Kokkos::layout_right::mapping<Kokkos::extents<size_t, 3, 4>> map2(exts2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.mapping(), map1);
     auto val1 = MDSPAN_IMPL_OP(m1,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val1, 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.mapping(), map2);
     auto val2 = MDSPAN_IMPL_OP(m2,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.mapping(), map2);
     val1 = MDSPAN_IMPL_OP(m1,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val1, 21);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.mapping(), map1);
     val2 = MDSPAN_IMPL_OP(m2,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val2, 1);
   });
   ASSERT_EQ(errors[0], 0);
   free_array(errors);
 }
 
 TEST(TestMDSpanSwap, std_swap_static_extents) {
-  __MDSPAN_TESTS_RUN_TEST(test_mdspan_std_swap_static_extents())
+  MDSPAN_IMPL_TESTS_RUN_TEST(test_mdspan_std_swap_static_extents())
 }
 
 
@@ -75,30 +75,30 @@ void test_mdspan_std_swap_dynamic_extents() {
     Kokkos::layout_right::mapping<Kokkos::dextents<size_t,2>> map1(exts1);
     Kokkos::dextents<size_t,2> exts2(4,3);
     Kokkos::layout_right::mapping<Kokkos::dextents<size_t,2>> map2(exts2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.data_handle(), data1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.mapping(), map1);
     auto val1 = MDSPAN_IMPL_OP(m1,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val1, 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.data_handle(), data2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.mapping(), map2);
     auto val2 = MDSPAN_IMPL_OP(m2,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.data_handle(), data2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.mapping(), map2);
     val1 = MDSPAN_IMPL_OP(m1,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val1, 21);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.data_handle(), data1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.mapping(), map1);
     val2 = MDSPAN_IMPL_OP(m2,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val2, 1);
   });
   ASSERT_EQ(errors[0], 0);
   free_array(errors);
 }
 
 TEST(TestMDSpanSwap, std_swap_dynamic_extents) {
-  __MDSPAN_TESTS_RUN_TEST(test_mdspan_std_swap_dynamic_extents())
+  MDSPAN_IMPL_TESTS_RUN_TEST(test_mdspan_std_swap_dynamic_extents())
 }
 
 // On HIP/CUDA we actually don't call through to swap via ADL
@@ -127,36 +127,36 @@ void test_mdspan_foo_swap_dynamic_extents() {
     acc_t acc2(&flag2);
     Kokkos::mdspan<int, Kokkos::dextents<size_t,2>,
                   Foo::layout_foo, acc_t> m2(Foo::foo_ptr<int>{data2}, map2, acc2);
-    __MDSPAN_DEVICE_ASSERT_EQ((map1==map2), false);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle().data, data1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 9);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ((map1==map2), false);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.data_handle().data, data1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.mapping(), map1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 9);
     auto val1 = MDSPAN_IMPL_OP(m1,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val1, 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle().data, data2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 7);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val1, 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.data_handle().data, data2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.mapping(), map2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 7);
     auto val2 = MDSPAN_IMPL_OP(m2,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val2, 21);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val2, 21);
     swap(m1,m2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.data_handle().data, data2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.mapping(), map2);
-    __MDSPAN_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 77);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.data_handle().data, data2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.mapping(), map2);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m1.accessor().flag[0], 77);
     val1 = MDSPAN_IMPL_OP(m1,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val1, 21);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.data_handle().data, data1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.mapping(), map1);
-    __MDSPAN_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 99);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val1, 21);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.data_handle().data, data1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.mapping(), map1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(m2.accessor().flag[0], 99);
     val2 = MDSPAN_IMPL_OP(m2,0,0);
-    __MDSPAN_DEVICE_ASSERT_EQ(val2, 1);
-    __MDSPAN_DEVICE_ASSERT_EQ(flag1, 99);
-    __MDSPAN_DEVICE_ASSERT_EQ(flag2, 77);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(val2, 1);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(flag1, 99);
+    MDSPAN_IMPL_DEVICE_ASSERT_EQ(flag2, 77);
   });
   ASSERT_EQ(errors[0], 0);
   free_array(errors);
 }
 
 TEST(TestMDSpanSwap, foo_swap_dynamic_extents) {
-  __MDSPAN_TESTS_RUN_TEST(test_mdspan_foo_swap_dynamic_extents())
+  MDSPAN_IMPL_TESTS_RUN_TEST(test_mdspan_foo_swap_dynamic_extents())
 }
 #endif

--- a/tests/test_submdspan.cpp
+++ b/tests/test_submdspan.cpp
@@ -377,7 +377,7 @@ TYPED_TEST(TestSubMDSpan, submdspan_return_type) {
   static_assert(std::is_same<typename TestFixture::mds_sub_t,
                              typename TestFixture::mds_sub_deduced_t>::value,
                 "SubMDSpan: wrong return type");
-  __MDSPAN_TESTS_RUN_TEST(TestFixture::run());
+  MDSPAN_IMPL_TESTS_RUN_TEST(TestFixture::run());
 }
 
 #ifdef MDSPAN_IMPL_USE_CLASS_TEMPLATE_ARGUMENT_DEDUCTION


### PR DESCRIPTION
This makes clang-tidy run clean with the following parameters, and is (hopefully) the last part of my cleanup PRs:

```sh
clang-tidy -p cmake-build-debug --checks="-*,bugprone-reserved-identifier" -warnings-as-errors="*" --header-filter="include/*" include/mdspan/*.hpp
```