### PR TITLE
Exclude fetchcontent googletest and google bench from all

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -20,8 +20,13 @@ else()
       GIT_REPOSITORY https://github.com/google/benchmark.git
       GIT_TAG v1.9.1
   )
-  
-  fetchcontent_makeavailable(benchmark)
+
+  # TODO CMake 3.28, we can pass EXCLUDE_FROM_ALL directly to fetchcontent_makeavailable(benchmark)
+  fetchcontent_getproperties(benchmarkgoogletest)
+  if (NOT benchmark_POPULATED)
+    fetchcontent_populate(benchmark)
+    add_subdirectory(${benchmark_SOURCE_DIR} ${benchmark_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
 endif()
 
 function(mdspan_add_cuda_benchmark EXENAME)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,12 @@ else()
       GIT_TAG v1.16.0
   )
   
-  fetchcontent_makeavailable(googletest)
+  # TODO CMake 3.28, we can pass EXCLUDE_FROM_ALL directly to fetchcontent_makeavailable
+  fetchcontent_getproperties(googletest)
+  if (NOT googletest_POPULATED)
+    fetchcontent_populate(googletest)
+    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
   
   add_library(GTest::gtest_main ALIAS gtest_main)
 endif()


### PR DESCRIPTION
This stops those libraries from being installed, as generally a user wouldn't want that.

Unfortunately because we are using a rather old version of CMake we have to do things a bit manually. CMake 3.28 allows you to pass `EXCLUDE_FROM_ALL` directly to `fetchcontent_makeavailable`