### PR TITLE
Avoid static variables and functions in header files

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -34,7 +34,7 @@ namespace detail {
 // can't be a private member function for some reason.
 template <size_t... Extents, size_t... OtherExtents>
 MDSPAN_INLINE_FUNCTION
-static constexpr std::integral_constant<bool, false> impl_check_compatible_extents(
+constexpr std::integral_constant<bool, false> impl_check_compatible_extents(
     std::integral_constant<bool, false>,
     std::integer_sequence<size_t, Extents...>,
     std::integer_sequence<size_t, OtherExtents...>) noexcept {
@@ -51,7 +51,7 @@ struct impl_compare_extent_compatible : std::integral_constant<bool,
 
 template <size_t... Extents, size_t... OtherExtents>
 MDSPAN_INLINE_FUNCTION
-static constexpr std::integral_constant<
+constexpr std::integral_constant<
     bool, MDSPAN_IMPL_FOLD_AND(impl_compare_extent_compatible<Extents, OtherExtents>::value)>
 impl_check_compatible_extents(
     std::integral_constant<bool, true>,
@@ -62,7 +62,7 @@ impl_check_compatible_extents(
 
 template<class IndexType, class ... Arguments>
 MDSPAN_INLINE_FUNCTION
-static constexpr bool are_valid_indices() {
+constexpr bool are_valid_indices() {
     return
       MDSPAN_IMPL_FOLD_AND(std::is_convertible<Arguments, IndexType>::value) &&
       MDSPAN_IMPL_FOLD_AND(std::is_nothrow_constructible<IndexType, Arguments>::value);

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -47,7 +47,10 @@ constexpr bool rankwise_equal(with_rank<N>, const T1& x, const T2& y, F func)
   return match;
 }
 
-inline constexpr struct
+#if MDSPAN_HAS_CXX_17
+inline
+#endif
+constexpr struct
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -57,7 +60,10 @@ inline constexpr struct
   }
 } extent;
 
-inline constexpr struct
+#if MDSPAN_HAS_CXX_17
+inline
+#endif
+constexpr struct
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -167,7 +173,10 @@ tuple(Elements ...) -> tuple<Elements...>;
 #endif
 } // namespace detail
 
-inline constexpr struct mdspan_non_standard_tag {
+#if MDSPAN_HAS_CXX_17
+inline
+#endif
+constexpr struct mdspan_non_standard_tag {
 } mdspan_non_standard;
 
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -47,7 +47,7 @@ constexpr bool rankwise_equal(with_rank<N>, const T1& x, const T2& y, F func)
   return match;
 }
 
-constexpr struct
+inline constexpr struct
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -57,7 +57,7 @@ constexpr struct
   }
 } extent;
 
-constexpr struct
+inline constexpr struct
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -167,7 +167,7 @@ tuple(Elements ...) -> tuple<Elements...>;
 #endif
 } // namespace detail
 
-constexpr struct mdspan_non_standard_tag {
+inline constexpr struct mdspan_non_standard_tag {
 } mdspan_non_standard;
 
 } // namespace MDSPAN_IMPL_STANDARD_NAMESPACE


### PR DESCRIPTION
Extracted from https://github.com/kokkos/kokkos/pull/8071. As discussed there (and in https://github.com/kokkos/kokkos/pull/7898) `static` global variables and functions are problematic when building C++20 modules.