### PR TITLE
precondition checks in extents constructors

### DIFF
--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -439,7 +439,10 @@ public:
            sizeof...(OtherIndexTypes) == m_rank_dynamic)))
   MDSPAN_INLINE_FUNCTION
   constexpr explicit extents(OtherIndexTypes... dynvals) noexcept
-      : m_vals(static_cast<index_type>(dynvals)...) {}
+      : m_vals(static_cast<index_type>(dynvals)...) {
+    MDSPAN_IMPL_PRECONDITION(
+        detail::all_values_are_nonnegative_and_representable<index_type>(dynvals...));
+  }
 
   MDSPAN_TEMPLATE_REQUIRES(
       class OtherIndexType, size_t N,
@@ -452,7 +455,11 @@ public:
   MDSPAN_INLINE_FUNCTION
   MDSPAN_CONDITIONAL_EXPLICIT(N != m_rank_dynamic)
   constexpr extents(const std::array<OtherIndexType, N> &exts) noexcept
-      : m_vals(std::move(exts)) {}
+      : m_vals(std::move(exts)) {
+    MDSPAN_IMPL_PRECONDITION(
+        detail::range_is_nonnegative_and_representable<index_type>(
+            std::begin(exts), std::end(exts)));
+  }
 
 #ifdef __cpp_lib_span
   MDSPAN_TEMPLATE_REQUIRES(
@@ -464,7 +471,11 @@ public:
   MDSPAN_INLINE_FUNCTION
   MDSPAN_CONDITIONAL_EXPLICIT(N != m_rank_dynamic)
   constexpr extents(const std::span<OtherIndexType, N> &exts) noexcept
-      : m_vals(std::move(exts)) {}
+      : m_vals(std::move(exts)) {
+    MDSPAN_IMPL_PRECONDITION(
+        detail::range_is_nonnegative_and_representable<index_type>(
+            std::begin(exts), std::end(exts)));
+  }
 #endif
 
 private:
@@ -536,10 +547,14 @@ public:
                                ...) ||
                               (std::numeric_limits<index_type>::max() <
                                std::numeric_limits<OtherIndexType>::max()))
-  constexpr extents(const extents<OtherIndexType, OtherExtents...> &other) noexcept
+  constexpr extents(
+      const extents<OtherIndexType, OtherExtents...> &other) noexcept
       : m_vals(impl_construct_vals_from_extents(
             std::integral_constant<size_t, 0>(),
-            std::integral_constant<size_t, 0>(), other)) {}
+            std::integral_constant<size_t, 0>(), other)) {
+    MDSPAN_IMPL_PRECONDITION(
+        detail::extent_is_representable<index_type>(other));
+  }
 
   // Comparison operator
   template <class OtherIndexType, size_t... OtherExtents>

--- a/include/experimental/__p0009_bits/extents.hpp
+++ b/include/experimental/__p0009_bits/extents.hpp
@@ -440,8 +440,10 @@ public:
   MDSPAN_INLINE_FUNCTION
   constexpr explicit extents(OtherIndexTypes... dynvals) noexcept
       : m_vals(static_cast<index_type>(dynvals)...) {
+#if MDSPAN_HAS_CXX_17
     MDSPAN_IMPL_PRECONDITION(
         detail::all_values_are_nonnegative_and_representable<index_type>(dynvals...));
+#endif
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -456,9 +458,11 @@ public:
   MDSPAN_CONDITIONAL_EXPLICIT(N != m_rank_dynamic)
   constexpr extents(const std::array<OtherIndexType, N> &exts) noexcept
       : m_vals(std::move(exts)) {
+#if MDSPAN_HAS_CXX_17
     MDSPAN_IMPL_PRECONDITION(
         detail::range_is_nonnegative_and_representable<index_type>(
             std::begin(exts), std::end(exts)));
+#endif
   }
 
 #ifdef __cpp_lib_span
@@ -552,8 +556,10 @@ public:
       : m_vals(impl_construct_vals_from_extents(
             std::integral_constant<size_t, 0>(),
             std::integral_constant<size_t, 0>(), other)) {
+#if MDSPAN_HAS_CXX_17
     MDSPAN_IMPL_PRECONDITION(
         detail::extent_is_representable<index_type>(other));
+#endif
   }
 
   // Comparison operator

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -198,18 +198,32 @@ MDSPAN_INLINE_FUNCTION constexpr bool cmp_greater_equal(T t, U u) noexcept {
 
 template <class R, class T>
 MDSPAN_INLINE_FUNCTION constexpr bool in_range(T t) noexcept {
+  static_assert(std::is_integral_v<R> && std::is_integral_v<T>);
   return cmp_greater_equal(t, std::numeric_limits<R>::min()) &&
           cmp_less_equal(t, std::numeric_limits<R>::max());
 }
 
 template <class R, class T>
 MDSPAN_INLINE_FUNCTION constexpr bool is_nonnegative_and_representable(T t) noexcept {
-  if constexpr (std::is_signed_v<T>) {
-    if (t < 0)
-      return false;
-  }
+  // T might not be integral and thus invalid to pass to in_range
+  // Only check this if we can actually call in_range
+  if constexpr (std::is_integral_v<T>)
+  {
+    if constexpr (std::is_signed_v<T>) {
+      if (t < 0)
+        return false;
+    }
 
-  return in_range<R>(t);
+    return in_range<R>(t);
+  } else
+  {
+    if constexpr (std::is_signed_v<T>) {
+      if (static_cast<R>(t) < 0)
+        return false;
+    }
+
+    return true;
+  }
 }
 
 template<class R, class... Values>

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -202,6 +202,52 @@ MDSPAN_INLINE_FUNCTION constexpr bool in_range(T t) noexcept {
           cmp_less_equal(t, std::numeric_limits<R>::max());
 }
 
+template <class R, class T>
+MDSPAN_INLINE_FUNCTION constexpr bool is_nonnegative_and_representable(T t) noexcept {
+  if constexpr (std::is_signed_v<T>) {
+    if (t < 0)
+      return false;
+  }
+
+  return in_range<R>(t);
+}
+
+template<class R, class... Values>
+MDSPAN_INLINE_FUNCTION constexpr bool
+all_values_are_representable(Values... values) noexcept {
+  return ( in_range<R>( values ) && ... && true );
+}
+
+template<class R, class... Values>
+MDSPAN_INLINE_FUNCTION constexpr bool
+all_values_are_nonnegative_and_representable(Values... values) noexcept {
+  return ( is_nonnegative_and_representable<R>( values ) && ... && true );
+}
+
+template<class R, class ContiguousIterator>
+MDSPAN_INLINE_FUNCTION constexpr bool
+range_is_nonnegative_and_representable(ContiguousIterator begin, ContiguousIterator end) noexcept {
+  for ( auto it = begin; it != end; ++it )
+  {
+    if ( !is_nonnegative_and_representable<R>( *it ) )
+      return false;
+  }
+
+  return true;
+}
+
+template<class R, class Extents>
+MDSPAN_INLINE_FUNCTION constexpr bool
+extent_is_representable(const Extents &exts) noexcept {
+  for ( std::size_t r = 0; r < Extents::rank(); ++r )
+  {
+    if ( !is_nonnegative_and_representable<R>( exts.extent(r) ) )
+      return false;
+  }
+
+  return true;
+}
+
 template <typename T >
 MDSPAN_INLINE_FUNCTION constexpr bool
 check_mul_result_is_nonnegative_and_representable(T a, T b) {

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -217,7 +217,7 @@ MDSPAN_INLINE_FUNCTION constexpr bool is_nonnegative_and_representable(T t) noex
     return in_range<R>(t);
   } else
   {
-    if constexpr (std::is_signed_v<T>) {
+    if constexpr (std::is_signed_v<R>) {
       if (static_cast<R>(t) < 0)
         return false;
     }
@@ -229,13 +229,13 @@ MDSPAN_INLINE_FUNCTION constexpr bool is_nonnegative_and_representable(T t) noex
 template<class R, class... Values>
 MDSPAN_INLINE_FUNCTION constexpr bool
 all_values_are_representable(Values... values) noexcept {
-  return ( in_range<R>( values ) && ... && true );
+  return ( in_range<R>( values ) && ... );
 }
 
 template<class R, class... Values>
 MDSPAN_INLINE_FUNCTION constexpr bool
 all_values_are_nonnegative_and_representable(Values... values) noexcept {
-  return ( is_nonnegative_and_representable<R>( values ) && ... && true );
+  return ( is_nonnegative_and_representable<R>( values ) && ... );
 }
 
 template<class R, class ContiguousIterator>

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -240,8 +240,8 @@ all_values_are_nonnegative_and_representable(Values... values) noexcept {
 
 template<class R, class ContiguousIterator>
 MDSPAN_INLINE_FUNCTION constexpr bool
-range_is_nonnegative_and_representable(ContiguousIterator begin, ContiguousIterator end) noexcept {
-  for ( auto it = begin; it != end; ++it )
+  range_is_nonnegative_and_representable(ContiguousIterator begin, ContiguousIterator end) noexcept {
+  for ( auto it = begin; it < end; ++it )
   {
     if ( !is_nonnegative_and_representable<R>( *it ) )
       return false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,7 +78,7 @@ mdspan_add_test(test_macros ENABLE_PRECONDITIONS)
 mdspan_add_test(test_layout_preconditions ENABLE_PRECONDITIONS)
 
 mdspan_add_test(test_dims)
-mdspan_add_test(test_extents)
+mdspan_add_test(test_extents ENABLE_PRECONDITIONS)
 mdspan_add_test(test_mdspan_at)
 mdspan_add_test(test_mdspan_ctors)
 mdspan_add_test(test_mdspan_swap)

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -482,6 +482,7 @@ TEST(TestExtentsCTADStdArray, test_extents_ctad_std_array) {
 */
 #endif
 
+#if MDSPAN_HAS_CXX_17
 TEST(TestExtentsConstructorPreconditions, test_extents_construct_indices) {
   auto test_precondition_indices_not_representable = [] {
     [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ 500, 500 };
@@ -529,3 +530,4 @@ TEST(TestExtentsConstructorPreconditions, test_extents_construct_other_extents) 
   };
   EXPECT_DEATH(test_precondition_extent_ranks_not_representable(), "");
 }
+#endif

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -487,24 +487,40 @@ TEST(TestExtentsConstructorPreconditions, test_extents_construct_indices) {
   auto test_precondition_indices_not_representable = [] {
     [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ 500, 500 };
   };
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   EXPECT_DEATH(test_precondition_indices_not_representable(), "");
+#else
+  EXPECT_DEATH(test_precondition_indices_not_representable(), "all_values_are_nonnegative_and_representable");
+#endif
 
   auto test_precondition_indices_are_negative = [] {
     [[maybe_unused]] auto exts = Kokkos::dextents< int, 2 >{ 500, -500 };
   };
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   EXPECT_DEATH(test_precondition_indices_are_negative(), "");
+#else
+  EXPECT_DEATH(test_precondition_indices_are_negative(), "all_values_are_nonnegative_and_representable");
+#endif
 }
 
 TEST(TestExtentsConstructorPreconditions, test_extents_construct_array) {
   auto test_precondition_array_elements_not_representable = [] {
     [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ std::array{ 500, 500 } };
   };
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   EXPECT_DEATH(test_precondition_array_elements_not_representable(), "");
+#else
+  EXPECT_DEATH(test_precondition_array_elements_not_representable(), "range_is_nonnegative_and_representable");
+#endif
 
   auto test_precondition_array_elements_are_negative = [] {
     [[maybe_unused]] auto exts = Kokkos::dextents< int, 2 >{ std::array{ 500, -500 } };
   };
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   EXPECT_DEATH(test_precondition_array_elements_are_negative(), "");
+#else
+  EXPECT_DEATH(test_precondition_array_elements_are_negative(), "range_is_nonnegative_and_representable");
+#endif
 }
 
 #ifdef __cpp_lib_span
@@ -513,13 +529,21 @@ TEST(TestExtentsConstructorPreconditions, test_extents_construct_span) {
     auto indices = std::array{ 500, 500 };
     [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ std::span{ indices } };
   };
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   EXPECT_DEATH(test_precondition_span_elements_not_representable(), "");
+#else
+  EXPECT_DEATH(test_precondition_span_elements_not_representable(), "range_is_nonnegative_and_representable");
+#endif
 
   auto test_precondition_span_elements_are_negative = [] {
     auto indices = std::array{ 500, -500 };
     [[maybe_unused]] auto exts = Kokkos::dextents< int, 2 >{ std::span{ indices } };
   };
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   EXPECT_DEATH(test_precondition_span_elements_are_negative(), "");
+#else
+  EXPECT_DEATH(test_precondition_span_elements_are_negative(), "range_is_nonnegative_and_representable");
+#endif
 }
 #endif
 
@@ -528,6 +552,10 @@ TEST(TestExtentsConstructorPreconditions, test_extents_construct_other_extents) 
     auto first = Kokkos::dextents< int, 2 >{ 500, 500 };
     [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ first };
   };
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
   EXPECT_DEATH(test_precondition_extent_ranks_not_representable(), "");
+#else
+  EXPECT_DEATH(test_precondition_extent_ranks_not_representable(), "extent_is_representable");
+#endif
 }
 #endif

--- a/tests/test_extents.cpp
+++ b/tests/test_extents.cpp
@@ -481,3 +481,51 @@ TEST(TestExtentsCTADStdArray, test_extents_ctad_std_array) {
 }
 */
 #endif
+
+TEST(TestExtentsConstructorPreconditions, test_extents_construct_indices) {
+  auto test_precondition_indices_not_representable = [] {
+    [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ 500, 500 };
+  };
+  EXPECT_DEATH(test_precondition_indices_not_representable(), "");
+
+  auto test_precondition_indices_are_negative = [] {
+    [[maybe_unused]] auto exts = Kokkos::dextents< int, 2 >{ 500, -500 };
+  };
+  EXPECT_DEATH(test_precondition_indices_are_negative(), "");
+}
+
+TEST(TestExtentsConstructorPreconditions, test_extents_construct_array) {
+  auto test_precondition_array_elements_not_representable = [] {
+    [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ std::array{ 500, 500 } };
+  };
+  EXPECT_DEATH(test_precondition_array_elements_not_representable(), "");
+
+  auto test_precondition_array_elements_are_negative = [] {
+    [[maybe_unused]] auto exts = Kokkos::dextents< int, 2 >{ std::array{ 500, -500 } };
+  };
+  EXPECT_DEATH(test_precondition_array_elements_are_negative(), "");
+}
+
+#ifdef __cpp_lib_span
+TEST(TestExtentsConstructorPreconditions, test_extents_construct_span) {
+  auto test_precondition_span_elements_not_representable = [] {
+    auto indices = std::array{ 500, 500 };
+    [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ std::span{ indices } };
+  };
+  EXPECT_DEATH(test_precondition_span_elements_not_representable(), "");
+
+  auto test_precondition_span_elements_are_negative = [] {
+    auto indices = std::array{ 500, -500 };
+    [[maybe_unused]] auto exts = Kokkos::dextents< int, 2 >{ std::span{ indices } };
+  };
+  EXPECT_DEATH(test_precondition_span_elements_are_negative(), "");
+}
+#endif
+
+TEST(TestExtentsConstructorPreconditions, test_extents_construct_other_extents) {
+  auto test_precondition_extent_ranks_not_representable = [] {
+    auto first = Kokkos::dextents< int, 2 >{ 500, 500 };
+    [[maybe_unused]] auto exts = Kokkos::dextents< std::int8_t, 2 >{ first };
+  };
+  EXPECT_DEATH(test_precondition_extent_ranks_not_representable(), "");
+}


### PR DESCRIPTION
This adds the missing precondition checks for [mdspan.extents.cons](https://eel.is/c++draft/views.multidim#mdspan.extents.cons)