### PR TITLE
Avoid TU-local entities

### DIFF
--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -50,7 +50,7 @@ constexpr bool rankwise_equal(with_rank<N>, const T1& x, const T2& y, F func)
 #if MDSPAN_HAS_CXX_17
 inline
 #endif
-constexpr struct
+constexpr struct extent_struct
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -63,7 +63,7 @@ constexpr struct
 #if MDSPAN_HAS_CXX_17
 inline
 #endif
-constexpr struct
+constexpr struct stride_struct
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -50,7 +50,7 @@ constexpr bool rankwise_equal(with_rank<N>, const T1& x, const T2& y, F func)
 #if MDSPAN_HAS_CXX_17
 inline
 #endif
-constexpr struct extent_struct
+constexpr struct extent_functor
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION
@@ -63,7 +63,7 @@ constexpr struct extent_struct
 #if MDSPAN_HAS_CXX_17
 inline
 #endif
-constexpr struct stride_struct
+constexpr struct stride_functor
 {
   template <class T, class I>
   MDSPAN_INLINE_FUNCTION

--- a/include/experimental/__p2630_bits/strided_slice.hpp
+++ b/include/experimental/__p2630_bits/strided_slice.hpp
@@ -21,13 +21,11 @@
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
-namespace {
   template<class T>
   struct mdspan_is_integral_constant: std::false_type {};
 
   template<class T, T val>
   struct mdspan_is_integral_constant<std::integral_constant<T,val>>: std::true_type {};
-}
 
 // Slice Specifier allowing for strides and compile time extent
 template <class OffsetType, class ExtentType, class StrideType>

--- a/include/experimental/__p2630_bits/strided_slice.hpp
+++ b/include/experimental/__p2630_bits/strided_slice.hpp
@@ -21,11 +21,13 @@
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 
+namespace detail {
   template<class T>
   struct mdspan_is_integral_constant: std::false_type {};
 
   template<class T, T val>
   struct mdspan_is_integral_constant<std::integral_constant<T,val>>: std::true_type {};
+}
 
 // Slice Specifier allowing for strides and compile time extent
 template <class OffsetType, class ExtentType, class StrideType>
@@ -38,9 +40,9 @@ struct strided_slice {
   MDSPAN_IMPL_NO_UNIQUE_ADDRESS ExtentType extent{};
   MDSPAN_IMPL_NO_UNIQUE_ADDRESS StrideType stride{};
 
-  static_assert(std::is_integral_v<OffsetType> || mdspan_is_integral_constant<OffsetType>::value);
-  static_assert(std::is_integral_v<ExtentType> || mdspan_is_integral_constant<ExtentType>::value);
-  static_assert(std::is_integral_v<StrideType> || mdspan_is_integral_constant<StrideType>::value);
+  static_assert(std::is_integral_v<OffsetType> || detail::mdspan_is_integral_constant<OffsetType>::value);
+  static_assert(std::is_integral_v<ExtentType> || detail::mdspan_is_integral_constant<ExtentType>::value);
+  static_assert(std::is_integral_v<StrideType> || detail::mdspan_is_integral_constant<StrideType>::value);
 };
 
 } // MDSPAN_IMPL_STANDARD_NAMESPACE

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -190,18 +190,15 @@ struct deduce_layout_left_submapping<
 
 // We are reusing the same thing for layout_left and layout_left_padded
 // For layout_left as source StaticStride is static_extent(0)
-template<class Extents, size_t NumGaps, size_t StaticStride>
-struct compute_s_static_layout_left {
+template<class Extents, size_t NumGaps, size_t StaticStride, size_t... Idx>
+MDSPAN_INLINE_FUNCTION constexpr size_t
+compute_s_static_layout_left(std::index_sequence<Idx...>) {
   // Neither StaticStride nor any of the provided extents can be zero.
   // StaticStride can never be zero, the static_extents we are looking at are associated with
   // integral slice specifiers - which wouldn't be valid for zero extent
-  template<size_t ... Idx>
-  MDSPAN_INLINE_FUNCTION
-  static constexpr size_t value(std::index_sequence<Idx...>) {
     size_t val = ((Idx>0 && Idx<=NumGaps ? (Extents::static_extent(Idx) == dynamic_extent?0:Extents::static_extent(Idx)) : 1) * ... * (StaticStride == dynamic_extent?0:StaticStride));
     return val == 0?dynamic_extent:val;
   }
-};
 
 } // namespace detail
 
@@ -237,7 +234,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
     return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext),
                                                    offset};
   } else if constexpr (deduce_layout::layout_left_padded_value()) {
-    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(0)>::value(std::make_index_sequence<Extents::rank()>());
+    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(0)>(std::make_index_sequence<Extents::rank()>());
     using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<S_static>::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext, stride(1 + deduce_layout::gap_len)), offset};
@@ -316,7 +313,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<PaddingValue>::mapping<Extent
         using dst_mapping_t = typename layout_left::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
       } else if constexpr (deduce_layout::layout_left_padded_value()) { // can keep layout_left_padded
-        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
+        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, static_padding_stride>(std::make_index_sequence<Extents::rank()>());
         using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_left_padded<S_static>::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext, stride(1 + deduce_layout::gap_len)), offset};
@@ -421,18 +418,15 @@ struct deduce_layout_right_submapping<
 
 // We are reusing the same thing for layout_right and layout_right_padded
 // For layout_right as source StaticStride is static_extent(Rank-1)
-template<class Extents, size_t NumGaps, size_t StaticStride>
-struct compute_s_static_layout_right {
+template<class Extents, size_t NumGaps, size_t StaticStride, size_t... Idx>
+MDSPAN_INLINE_FUNCTION constexpr size_t
+compute_s_static_layout_right (std::index_sequence<Idx...>) {
   // Neither StaticStride nor any of the provided extents can be zero.
   // StaticStride can never be zero, the static_extents we are looking at are associated with
   // integral slice specifiers - which wouldn't be valid for zero extent
-  template<size_t ... Idx>
-  MDSPAN_INLINE_FUNCTION
-  static constexpr size_t value(std::index_sequence<Idx...>) {
     size_t val = ((Idx >= Extents::rank() - 1 - NumGaps && Idx < Extents::rank() - 1 ? (Extents::static_extent(Idx) == dynamic_extent?0:Extents::static_extent(Idx)) : 1) * ... * (StaticStride == dynamic_extent?0:StaticStride));
     return val == 0?dynamic_extent:val;
   }
-};
 
 } // namespace detail
 
@@ -468,7 +462,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
     return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t(dst_ext),
                                                    offset};
   } else if constexpr (deduce_layout::layout_right_padded_value()) {
-    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(Extents::rank() - 1)>::value(std::make_index_sequence<Extents::rank()>());
+    constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_left<Extents, deduce_layout::gap_len, Extents::static_extent(Extents::rank() - 1)>(std::make_index_sequence<Extents::rank()>());
     using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<S_static>::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext,
@@ -541,7 +535,7 @@ MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<PaddingValue>::mapping<Exten
         using dst_mapping_t = typename layout_right::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{dst_mapping_t{dst_ext}, offset};
       } else if constexpr (deduce_layout::layout_right_padded_value()) { // can keep layout_right_padded
-        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_right<Extents, deduce_layout::gap_len, static_padding_stride>::value(std::make_index_sequence<Extents::rank()>());
+        constexpr size_t S_static = MDSPAN_IMPL_STANDARD_NAMESPACE::detail::compute_s_static_layout_right<Extents, deduce_layout::gap_len, static_padding_stride>(std::make_index_sequence<Extents::rank()>());
         using dst_mapping_t = typename MDSPAN_IMPL_PROPOSED_NAMESPACE::layout_right_padded<S_static>::template mapping<dst_ext_t>;
         return submdspan_mapping_result<dst_mapping_t>{
         dst_mapping_t(dst_ext, stride(Extents::rank() - 2 - deduce_layout::gap_len)), offset};


### PR DESCRIPTION
Related to https://github.com/kokkos/kokkos/pull/8117. While trying to build a C++20 module for Kokkos with g++-15, I ran into a couple of instances where TU-local entities (https://en.cppreference.com/w/cpp/language/tu_local.html, https://eel.is/c++draft/basic.link#14) are exposed. This pull request tries to fix those I was able to address.
Note that clang++ is much more lenient with TU-local entities as decribed at https://clang.llvm.org/docs/StandardCPlusPlusModules.html#using-tu-local-entity-in-other-units.

- anonymous structs are TU-local even if the respective variable is declared `inline`.
- anonymous namespaces create TU-local symbols
- It's not quite clear to me why `compute_s_static_layout_left` and `compute_s_static_layout_right` were considered TU-local but converting those structs to functions seems be an improvement (since it's more concise) anyway.

~~It's not quite clear to me which clang-format version was used for these files before so I kept the indentation fixes with clang-16 in a separate commit.~~