### PR TITLE
Ensure to use the C printf function

### DIFF
--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -112,7 +112,7 @@ namespace detail {
 #if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP)
 MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
 {
-  printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
+  ::printf("%s:%u: precondition failure: `%s`\n", file, line, cond);
   assert(0);
 }
 #elif defined(MDSPAN_IMPL_HAS_SYCL)


### PR DESCRIPTION
The PR ensures that we always refer to the C `printf` function inside `Kokkos::detail::default_precondition_violation_handler`.

The old implemention lead to the unintended call to `Kokkos::printf` when using both Kokkos and mdspan. Note this is also how Kokkos calls `printf` in the CUDA and HIP cases, https://github.com/kokkos/kokkos/blob/95494ae1e305884e064e9d159a560f9931eaf431/core/src/Kokkos_Printf.hpp#L45-L48