### PR TITLE
fix google benchmark deprecated warnings

### DIFF
--- a/benchmarks/matvec/openmp/matvec_openmp.cpp
+++ b/benchmarks/matvec/openmp/matvec_openmp.cpp
@@ -95,9 +95,12 @@ void BM_MDSpan_OpenMP_MatVec(benchmark::State& state, MDSpanMatrix, DynSizes... 
 
   int R = 10;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(A.data_handle());
-    benchmark::DoNotOptimize(y.data_handle());
-    benchmark::DoNotOptimize(x.data_handle());
+    auto ah = A.data_handle();
+    auto yh = y.data_handle();
+    auto xh = x.data_handle();
+    benchmark::DoNotOptimize(ah);
+    benchmark::DoNotOptimize(yh);
+    benchmark::DoNotOptimize(xh);
     for(int r=0; r<R; r++) {
     #pragma omp parallel for
     for(index_type i = 0; i < A.extent(0); i ++) {
@@ -161,9 +164,12 @@ void BM_MDSpan_OpenMP_MatVec_Raw_Left(benchmark::State& state, MDSpanMatrix, Dyn
 
   int R = 10;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(A.data_handle());
-    benchmark::DoNotOptimize(y.data_handle());
-    benchmark::DoNotOptimize(x.data_handle());
+    auto ah = A.data_handle();
+    auto yh = y.data_handle();
+    auto xh = x.data_handle();
+    benchmark::DoNotOptimize(ah);
+    benchmark::DoNotOptimize(yh);
+    benchmark::DoNotOptimize(xh);
     for(int r=0; r<R; r++) {
     #pragma omp parallel for
     for(index_type i = 0; i < A.extent(0); i ++) {
@@ -225,9 +231,12 @@ void BM_MDSpan_OpenMP_MatVec_Raw_Right(benchmark::State& state, MDSpanMatrix, Dy
 
   int R = 10;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(A.data_handle());
-    benchmark::DoNotOptimize(y.data_handle());
-    benchmark::DoNotOptimize(x.data_handle());
+    auto ah = A.data_handle();
+    auto yh = y.data_handle();
+    auto xh = x.data_handle();
+    benchmark::DoNotOptimize(ah);
+    benchmark::DoNotOptimize(yh);
+    benchmark::DoNotOptimize(xh);
     for(int r=0; r<R; r++) {
     #pragma omp parallel for
     for(index_type i = 0; i < A.extent(0); i ++) {

--- a/benchmarks/sum/openmp/sum_3d_openmp.cpp
+++ b/benchmarks/sum/openmp/sum_3d_openmp.cpp
@@ -57,7 +57,8 @@ void BM_MDSpan_Sum_3D_OpenMP(benchmark::State& state, MDSpan, DynSizes... dyn) {
           }
         }
         benchmark::DoNotOptimize(sum);
-        benchmark::DoNotOptimize(s.data_handle());
+        auto h = s.data_handle();
+        benchmark::DoNotOptimize(h);
       }
     }
   }
@@ -83,8 +84,10 @@ void BM_MDSpan_Sum_3D_loop_OpenMP(benchmark::State& state, MDSpan, DynSizes... d
   auto sums_buffer = std::make_unique<value_type[]>(omp_get_max_threads());
   auto* sum = sums_buffer.get();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(sums_buffer.get());
-    benchmark::DoNotOptimize(s.data_handle());
+    auto sbv = sums_buffer.get();
+    auto sh = s.data_handle();
+    benchmark::DoNotOptimize(sbv);
+    benchmark::DoNotOptimize(sh);
     #pragma omp parallel for default(none) shared(s, sum)
     for (index_type i = 0; i < s.extent(0); ++i) {
       for (index_type j = 0; j < s.extent(1); ++j) {
@@ -146,4 +149,3 @@ BENCHMARK_CAPTURE(
 //================================================================================
 
 BENCHMARK_MAIN();
-

--- a/benchmarks/tiny_matrix_add/openmp/tiny_matrix_add_openmp.cpp
+++ b/benchmarks/tiny_matrix_add/openmp/tiny_matrix_add_openmp.cpp
@@ -74,8 +74,10 @@ void BM_MDSpan_OpenMP_noloop_TinyMatrixSum(benchmark::State& state, MDSpan, DynS
 
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(o.data_handle());
-    benchmark::DoNotOptimize(s.data_handle());
+    auto oh = o.data_handle();
+    auto sh = s.data_handle();
+    benchmark::DoNotOptimize(oh);
+    benchmark::DoNotOptimize(sh);
 #pragma omp parallel
     {
       auto chunk_size = s.extent(0) / omp_get_num_threads();
@@ -138,8 +140,10 @@ void BM_MDSpan_OpenMP_TinyMatrixSum(benchmark::State& state, MDSpan, DynSizes...
   }
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(o.data_handle());
-    benchmark::DoNotOptimize(s.data_handle());
+    auto oh = o.data_handle();
+    auto sh = s.data_handle();
+    benchmark::DoNotOptimize(oh);
+    benchmark::DoNotOptimize(sh);
     #pragma omp parallel for
     for(index_type i = 0; i < s.extent(0); i ++) {
       for(int r = 0; r<global_repeat; r++) {


### PR DESCRIPTION
Google benchmark deprecated the use of `DoNotOptimize` with const ref. According to the deprecation warning, compilers might still optimize const refs. This PR creates temporary variables in order to use the const ref versions.