### PR TITLE
Add Wextra-semi warning as error

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,17 +16,19 @@ jobs:
         include:
         - compiler_driver: g++-9
           compiler_prefix: /usr/bin
+          cxx_flags_extra: "-Wextra-semi"
         - compiler_driver: g++-10
           compiler_prefix: /usr/bin
+          cxx_flags_extra: "-Wextra-semi"
         - compiler_driver: clang++
           compiler_prefix: /usr/bin
-          cxx_flags_extra: "-stdlib=libc++ -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments"
+          cxx_flags_extra: "-stdlib=libc++ -Wextra-semi -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments"
         - compiler_driver: icpx
           compiler_prefix: /opt/intel/oneapi/compiler/latest/linux/bin
           # To get new URL, look here:
           # https://www.intel.com/content/www/us/en/developer/articles/tool/oneapi-standalone-components.html#inpage-nav-6-undefined
           compiler_url: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebf5d9aa-17a7-46a4-b5df-ace004227c0e/l_dpcpp-cpp-compiler_p_2023.2.1.8_offline.sh
-          cxx_flags_extra: "-DMDSPAN_USE_BRACKET_OPERATOR=0 -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments"
+          cxx_flags_extra: "-DMDSPAN_USE_BRACKET_OPERATOR=0 -Wextra-semi -Wno-c++17-attribute-extensions -Wno-gnu-zero-variadic-macro-arguments"
         - enable_benchmark: ON
         - stdcxx: 14
           enable_benchmark: OFF

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -458,7 +458,7 @@ struct layout_stride {
 #else
       return this->base_t::ref().first();
 #endif
-    };
+    }
 
     MDSPAN_INLINE_FUNCTION
     constexpr std::array< index_type, extents_type::rank() > strides() const noexcept {

--- a/include/experimental/__p0009_bits/mdspan.hpp
+++ b/include/experimental/__p0009_bits/mdspan.hpp
@@ -91,7 +91,7 @@ public:
   MDSPAN_INLINE_FUNCTION static constexpr size_t rank() noexcept { return extents_type::rank(); }
   MDSPAN_INLINE_FUNCTION static constexpr size_t rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
   MDSPAN_INLINE_FUNCTION static constexpr size_t static_extent(size_t r) noexcept { return extents_type::static_extent(r); }
-  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return mapping_ref().extents().extent(r); };
+  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return mapping_ref().extents().extent(r); }
 
 private:
 
@@ -389,11 +389,11 @@ public:
 
   MDSPAN_INLINE_FUNCTION constexpr size_type size() const noexcept {
     return static_cast<size_type>(deduction_workaround_impl::size(*this));
-  };
+  }
 
   MDSPAN_INLINE_FUNCTION constexpr bool empty() const noexcept {
     return deduction_workaround_impl::empty(*this);
-  };
+  }
 
   MDSPAN_INLINE_FUNCTION
   friend constexpr void swap(mdspan& x, mdspan& y) noexcept {
@@ -414,22 +414,22 @@ public:
   // [mdspan.basic.domobs], mdspan observers of the domain multidimensional index space
 
 
-  MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return mapping_ref().extents(); };
-  MDSPAN_INLINE_FUNCTION constexpr const data_handle_type& data_handle() const noexcept { return ptr_ref(); };
-  MDSPAN_INLINE_FUNCTION constexpr const mapping_type& mapping() const noexcept { return mapping_ref(); };
-  MDSPAN_INLINE_FUNCTION constexpr const accessor_type& accessor() const noexcept { return accessor_ref(); };
+  MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return mapping_ref().extents(); }
+  MDSPAN_INLINE_FUNCTION constexpr const data_handle_type& data_handle() const noexcept { return ptr_ref(); }
+  MDSPAN_INLINE_FUNCTION constexpr const mapping_type& mapping() const noexcept { return mapping_ref(); }
+  MDSPAN_INLINE_FUNCTION constexpr const accessor_type& accessor() const noexcept { return accessor_ref(); }
 
   //--------------------------------------------------------------------------------
   // [mdspan.basic.obs], mdspan observers of the mapping
 
-  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() { return mapping_type::is_always_unique(); };
-  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_exhaustive() { return mapping_type::is_always_exhaustive(); };
-  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() { return mapping_type::is_always_strided(); };
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() { return mapping_type::is_always_unique(); }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_exhaustive() { return mapping_type::is_always_exhaustive(); }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() { return mapping_type::is_always_strided(); }
 
-  MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const { return mapping_ref().is_unique(); };
-  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const { return mapping_ref().is_exhaustive(); };
-  MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const { return mapping_ref().is_strided(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return mapping_ref().stride(r); };
+  MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const { return mapping_ref().is_unique(); }
+  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const { return mapping_ref().is_exhaustive(); }
+  MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const { return mapping_ref().is_strided(); }
+  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return mapping_ref().stride(r); }
 
 private:
 

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -88,7 +88,7 @@ struct integral_constant {
   // These interop functions work, because other than the value_type operator
   // everything of std::integral_constant works on device (defaulted functions)
   MDSPAN_FUNCTION
-  constexpr integral_constant(std::integral_constant<T,v>) {};
+  constexpr integral_constant(std::integral_constant<T,v>) {}
 
   MDSPAN_FUNCTION constexpr operator std::integral_constant<T,v>() const noexcept {
     return std::integral_constant<T,v>{};

--- a/include/experimental/__p1684_bits/mdarray.hpp
+++ b/include/experimental/__p1684_bits/mdarray.hpp
@@ -363,10 +363,10 @@ public:
 #endif
   #endif
 
-  MDSPAN_INLINE_FUNCTION constexpr pointer data() noexcept { return ctr_.data(); };
-  MDSPAN_INLINE_FUNCTION constexpr const_pointer data() const noexcept { return ctr_.data(); };
-  MDSPAN_INLINE_FUNCTION constexpr container_type& container() noexcept { return ctr_; };
-  MDSPAN_INLINE_FUNCTION constexpr const container_type& container() const noexcept { return ctr_; };
+  MDSPAN_INLINE_FUNCTION constexpr pointer data() noexcept { return ctr_.data(); }
+  MDSPAN_INLINE_FUNCTION constexpr const_pointer data() const noexcept { return ctr_.data(); }
+  MDSPAN_INLINE_FUNCTION constexpr container_type& container() noexcept { return ctr_; }
+  MDSPAN_INLINE_FUNCTION constexpr const container_type& container() const noexcept { return ctr_; }
 
   //--------------------------------------------------------------------------------
   // [mdspan.basic.domobs], mdspan observers of the domain multidimensional index space
@@ -375,26 +375,26 @@ public:
   MDSPAN_INLINE_FUNCTION static constexpr rank_type rank_dynamic() noexcept { return extents_type::rank_dynamic(); }
   MDSPAN_INLINE_FUNCTION static constexpr size_t static_extent(size_t r) noexcept { return extents_type::static_extent(r); }
 
-  MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return map_.extents(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return map_.extents().extent(r); };
+  MDSPAN_INLINE_FUNCTION constexpr const extents_type& extents() const noexcept { return map_.extents(); }
+  MDSPAN_INLINE_FUNCTION constexpr index_type extent(size_t r) const noexcept { return map_.extents().extent(r); }
   MDSPAN_INLINE_FUNCTION constexpr index_type size() const noexcept {
 //    return impl::size(*this);
     return ctr_.size();
-  };
+  }
 
 
   //--------------------------------------------------------------------------------
   // [mdspan.basic.obs], mdspan observers of the mapping
 
-  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept { return mapping_type::is_always_unique(); };
-  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_exhaustive() noexcept { return mapping_type::is_always_exhaustive(); };
-  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() noexcept { return mapping_type::is_always_strided(); };
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_unique() noexcept { return mapping_type::is_always_unique(); }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_exhaustive() noexcept { return mapping_type::is_always_exhaustive(); }
+  MDSPAN_INLINE_FUNCTION static constexpr bool is_always_strided() noexcept { return mapping_type::is_always_strided(); }
 
-  MDSPAN_INLINE_FUNCTION constexpr const mapping_type& mapping() const noexcept { return map_; };
-  MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const noexcept { return map_.is_unique(); };
-  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept { return map_.is_exhaustive(); };
-  MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const noexcept { return map_.is_strided(); };
-  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return map_.stride(r); };
+  MDSPAN_INLINE_FUNCTION constexpr const mapping_type& mapping() const noexcept { return map_; }
+  MDSPAN_INLINE_FUNCTION constexpr bool is_unique() const noexcept { return map_.is_unique(); }
+  MDSPAN_INLINE_FUNCTION constexpr bool is_exhaustive() const noexcept { return map_.is_exhaustive(); }
+  MDSPAN_INLINE_FUNCTION constexpr bool is_strided() const noexcept { return map_.is_strided(); }
+  MDSPAN_INLINE_FUNCTION constexpr index_type stride(size_t r) const { return map_.stride(r); }
 
   // Converstion to mdspan
   MDSPAN_TEMPLATE_REQUIRES(

--- a/tests/libcxx-backports/ConvertibleToIntegral.h
+++ b/tests/libcxx-backports/ConvertibleToIntegral.h
@@ -12,7 +12,7 @@
 struct IntType {
   int val;
   constexpr IntType() = default;
-  constexpr IntType(int v) noexcept : val(v){};
+  constexpr IntType(int v) noexcept : val(v){}
 
   constexpr bool operator==(const IntType& rhs) const { return val == rhs.val; }
   constexpr operator int() const noexcept { return val; }
@@ -24,7 +24,7 @@ struct IntType {
 struct IntTypeNC {
   int val;
   constexpr IntTypeNC() = default;
-  constexpr IntTypeNC(int v) noexcept : val(v){};
+  constexpr IntTypeNC(int v) noexcept : val(v){}
 
   constexpr bool operator==(const IntType& rhs) const { return val == rhs.val; }
   constexpr operator int() noexcept { return val; }

--- a/tests/libcxx-backports/CustomTestLayouts.h
+++ b/tests/libcxx-backports/CustomTestLayouts.h
@@ -77,7 +77,7 @@ private:
 
 public:
   constexpr mapping() noexcept = delete;
-  constexpr mapping(const mapping& other) noexcept : extents_(other.extents()){};
+  constexpr mapping(const mapping& other) noexcept : extents_(other.extents()){}
   constexpr mapping(extents_type&& ext) noexcept
     requires(Wrap == 8)
       : extents_(ext) {}
@@ -113,7 +113,7 @@ public:
   constexpr mapping& operator=(const mapping& other) noexcept {
     extents_ = other.extents_;
     return *this;
-  };
+  }
 
   constexpr const extents_type& extents() const noexcept { return extents_; }
 
@@ -244,9 +244,9 @@ private:
 public:
   constexpr mapping() noexcept = delete;
   constexpr mapping(const mapping& other) noexcept
-      : extents_(other.extents_), offset_(other.offset_), scaling_(other.scaling_){};
+      : extents_(other.extents_), offset_(other.offset_), scaling_(other.scaling_){}
   constexpr mapping(const extents_type& ext, index_type offset = 0, index_type scaling = 1) noexcept
-      : extents_(ext), offset_(offset), scaling_(scaling){};
+      : extents_(ext), offset_(offset), scaling_(scaling){}
 
   template <class OtherExtents>
   constexpr mapping(const mapping<OtherExtents>& other) noexcept {
@@ -271,7 +271,7 @@ public:
     offset_  = other.offset_;
     scaling_ = other.scaling_;
     return *this;
-  };
+  }
 
   constexpr const extents_type& extents() const noexcept { return extents_; }
 

--- a/tests/libcxx-backports/extents/ctad.pass.cpp
+++ b/tests/libcxx-backports/extents/ctad.pass.cpp
@@ -24,7 +24,7 @@
 struct NoDefaultCtorIndex {
   size_t value;
   constexpr NoDefaultCtorIndex() = delete;
-  constexpr NoDefaultCtorIndex(size_t val) : value(val){};
+  constexpr NoDefaultCtorIndex(size_t val) : value(val){}
   constexpr operator size_t() const noexcept { return value; }
 };
 

--- a/tests/test_mdarray_ctors.cpp
+++ b/tests/test_mdarray_ctors.cpp
@@ -46,7 +46,7 @@ struct ChatterResource : std::pmr::memory_resource{
 
     bool do_is_equal( const std::pmr::memory_resource& other ) const noexcept override{
         return this == &other;
-    };
+    }
 
     std::pmr::memory_resource* upstream = std::pmr::get_default_resource();
 };


### PR DESCRIPTION
- Add `Wextra-semi` in all setups (should fail, see for example [here](https://github.com/kokkos/mdspan/actions/runs/15674823307/job/44152627113))
- Remove extra semicolons