### PR TITLE
workaround gcc substition bug

### DIFF
--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -48,9 +48,26 @@ struct layout_right {
 };
 
 namespace detail {
+  // FIXME GCC <= 12: workaround gcc-12 bug that shows up in Kokkos; compilation fails when Mapping doesn't have
+  // extents_type. Normally this should just be a substititon failure, but causes an error with GCC <= 12
+  template<class, class Enabled = void>
+  struct is_mapping_of_impl {
+    template<class>
+    static constexpr bool value_for_layout = false;
+  };
+
+  template<class Mapping>
+  struct is_mapping_of_impl<Mapping, std::void_t<typename Mapping::extents_type>>
+  {
+    // FIXME GCC <= 12: We can't just do a conjunction of the two conditions, because the affected GCC versions seem to not
+    // short-circuit when resolving the substition of Mapping
+    template<class Layout>
+    static constexpr bool value_for_layout = std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
+  };
+
   template<class Layout, class Mapping>
   constexpr bool is_mapping_of =
-    std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
+    is_mapping_of_impl<Mapping>::template value_for_layout<Layout>;
 
 #if defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 #  if !defined(__cpp_lib_concepts)

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -55,24 +55,20 @@ namespace detail {
 #endif
   // FIXME GCC <= 12: workaround gcc-12 bug that shows up in Kokkos; compilation fails when Mapping doesn't have
   // extents_type. Normally this should just be a substitution failure, but causes an error with GCC <= 12
-  template<class, class Enabled = void>
-  struct is_mapping_of_impl {
-    template<class>
-    static constexpr bool value_for_layout = false;
-  };
+  // FIXME MSVC: I guess MSVC has a similar issue when it hits Layout::template mapping
+  template<class, class, class = void, class = void>
+  struct is_mapping_of_impl : std::false_type {};
 
-  template<class Mapping>
-  struct is_mapping_of_impl<Mapping, void_t<typename Mapping::extents_type>>
-  {
-    // FIXME GCC <= 12: We can't just do a conjunction of the two conditions, because the affected GCC versions seem to not
-    // short-circuit when resolving the substitution of Mapping
-    template<class Layout>
-    static constexpr bool value_for_layout = std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
-  };
+  // FIXME GCC <= 12: We can't just do a conjunction of the two conditions, because the affected GCC versions seem to not
+  // short-circuit when resolving the substitution of Mapping
+  template<class Mapping, class Layout>
+  struct is_mapping_of_impl<Mapping, Layout, void_t<typename Mapping::extents_type>, void_t< typename Layout::template mapping<typename Mapping::extents_type> >>
+    : std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>
+  {};
 
   template<class Layout, class Mapping>
   constexpr bool is_mapping_of =
-    is_mapping_of_impl<Mapping>::template value_for_layout<Layout>;
+    is_mapping_of_impl<Mapping, Layout>::value;
 
 #if defined(MDSPAN_IMPL_USE_CONCEPTS) && MDSPAN_HAS_CXX_20
 #  if !defined(__cpp_lib_concepts)

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -48,8 +48,13 @@ struct layout_right {
 };
 
 namespace detail {
+#if MDSPAN_HAS_CXX_17
+  using std::void_t;
+#else
+  template<class...> using void_t = void;
+#endif
   // FIXME GCC <= 12: workaround gcc-12 bug that shows up in Kokkos; compilation fails when Mapping doesn't have
-  // extents_type. Normally this should just be a substititon failure, but causes an error with GCC <= 12
+  // extents_type. Normally this should just be a substitution failure, but causes an error with GCC <= 12
   template<class, class Enabled = void>
   struct is_mapping_of_impl {
     template<class>
@@ -57,10 +62,10 @@ namespace detail {
   };
 
   template<class Mapping>
-  struct is_mapping_of_impl<Mapping, std::void_t<typename Mapping::extents_type>>
+  struct is_mapping_of_impl<Mapping, void_t<typename Mapping::extents_type>>
   {
     // FIXME GCC <= 12: We can't just do a conjunction of the two conditions, because the affected GCC versions seem to not
-    // short-circuit when resolving the substition of Mapping
+    // short-circuit when resolving the substitution of Mapping
     template<class Layout>
     static constexpr bool value_for_layout = std::is_same<typename Layout::template mapping<typename Mapping::extents_type>, Mapping>::value;
   };


### PR DESCRIPTION
Affects versions 11 and 12 (and probably less than those). This bug showed up in Kokkos, where a substitution failure in `is_mapping_of` causes a compilation failure instead of just removing the corresponding constructor (`layout_stride::mapping` constructor taking a mapping).

See discussion in https://github.com/kokkos/kokkos/pull/7401

There seems to be a secondary and possibly related bug that doesn't let me use `&&` between the two conditions, as GCC doesn't seem to short circuit properly.