### PR TITLE
Disable check_mul_result_is_nonnegative_and_representable for SYCL device code

### DIFF
--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -205,6 +205,11 @@ MDSPAN_INLINE_FUNCTION constexpr bool in_range(T t) noexcept {
 template <typename T >
 MDSPAN_INLINE_FUNCTION constexpr bool
 check_mul_result_is_nonnegative_and_representable(T a, T b) {
+// FIXME_SYCL The code below compiles to old_llvm.umul.with.overflow.i64
+// which isn't defined in device code
+#ifdef __SYCL_DEVICE_ONLY__
+  return true;
+#else
   if (b == 0 || a == 0)
     return true;
 
@@ -212,7 +217,7 @@ check_mul_result_is_nonnegative_and_representable(T a, T b) {
     if ( a < 0 || b < 0 ) return false;
   }
   return a <= std::numeric_limits<T>::max() / b;
-  return true;
+#endif
 }
 #endif
 } // namespace detail


### PR DESCRIPTION
`check_mul_result_is_nonnegative_and_representable` compiles to `old_llvm.umul.with.overflow.i64` which isn't defined in SYCL device code. Errors look like
```
error: undefined reference to `old_llvm.umul.with.overflow.i64'
in function: 'old_llvm.umul.with.overflow.i64' called by kernel: 'typeinfo name for sycl::_V1::event Kokkos::Impl::ParallelFor<Test::ThreadScratch<Kokkos::SYCL>, Kokkos::TeamPolicy<Kokkos::SYCL>, Kokkos::SYCL>::sycl_direct_launch<Kokkos::Impl::SYCLFunctionWrapper<Test::ThreadScratch<Kokkos::SYCL>, Kokkos::Impl::SYCLInternal::USMObjectMem<(sycl::_V1::usm::alloc)0>, false> >(sycl::_V1::multi_ptr<char, (sycl::_V1::access::address_space)4, (sycl::_V1::access::decorated)2>, Kokkos::Impl::SYCLFunctionWrapper<Test::ThreadScratch<Kokkos::SYCL>, Kokkos::Impl::SYCLInternal::USMObjectMem<(sycl::_V1::usm::alloc)0>, false> const&, sycl::_V1::event const&) const::'lambda'(sycl::_V1::handler&)::operator()(sycl::_V1::handler&) const::'lambda'(sycl::_V1::nd_item<2>)'

error: backend compiler failed build.

Build failed with error code: -11
Command was: /usr/bin/ocloc -output /tmp/Test12a_ThreadScratch_SYCL-7aaea1-2f6dc1.out -file /tmp/icpx-4c3707fe9f/Test12a_ThreadScratch_SYCL-e87284-4ddfb7.spv -output_no_suffix -spirv_input -device_options 12.60.7 -ze-intel-enable-auto-large-GRF-mode -options "-g" -device 12.60.7
llvm-foreach: 
icpx: error: gen compiler command failed with exit code 245 (use -v to see invocation)
Intel(R) oneAPI DPC++/C++ Compiler 2025.1.1 (2025.1.1.20250418)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /opt/intel/oneapi/compiler/2025.1/bin/compiler
Configuration file: /opt/intel/oneapi/compiler/2025.1/bin/compiler/../icpx.cfg
```