### PR TITLE
Fix required_span_size for padded layouts with empty extents

### DIFF
--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -576,7 +576,7 @@ public:
       for (rank_type r = 1; r < extents_type::rank(); ++r) {
         value *= exts.extent(r);
       }
-      return value + exts.extent(0) - padded_stride.value(0);
+      return value == 0 ? 0 : value + exts.extent(0) - padded_stride.value(0);
     }
   }
 
@@ -969,7 +969,7 @@ public:
       for (rank_type r = 0; r < extent_to_pad_idx; ++r) {
         value *= exts.extent(r);
       }
-      return value + exts.extent(extent_to_pad_idx) - padded_stride.value(0);
+      return value == 0 ? 0 : value + exts.extent(extent_to_pad_idx) - padded_stride.value(0);
     }
   }
 

--- a/tests/test_layout_padded_left.cpp
+++ b/tests/test_layout_padded_left.cpp
@@ -498,6 +498,19 @@ TEST(LayoutLeftTests, issue362) {
   ASSERT_EQ(mapping.required_span_size(), mapping(1, 1) + 1);
 }
 
+TEST(LayoutLeftTests, empty_span) {
+  {
+    auto mapping = KokkosEx::layout_left_padded<16>::mapping<
+        Kokkos::extents<std::size_t, 0, 15>>();
+    ASSERT_EQ(mapping.required_span_size(), 0);
+  }
+  {
+    auto mapping = KokkosEx::layout_left_padded<16>::mapping<
+        Kokkos::extents<std::size_t, 15, 0>>();
+    ASSERT_EQ(mapping.required_span_size(), 0);
+  }
+}
+
 // https://github.com/kokkos/mdspan/issues/393
 #define LAYOUT_LEFT_COMPILE_ISSUE393_DEATH 0
 TEST(LayoutLeftTests, issue393) {

--- a/tests/test_layout_padded_right.cpp
+++ b/tests/test_layout_padded_right.cpp
@@ -500,6 +500,19 @@ TEST(LayoutRightTests, issue362) {
   ASSERT_EQ(mapping.required_span_size(), mapping(1, 1) + 1);
 }
 
+TEST(LayoutRightTests, empty_span) {
+  {
+    auto mapping = KokkosEx::layout_left_padded<16>::mapping<
+        Kokkos::extents<std::size_t, 0, 15>>();
+    ASSERT_EQ(mapping.required_span_size(), 0);
+  }
+  {
+    auto mapping = KokkosEx::layout_left_padded<16>::mapping<
+        Kokkos::extents<std::size_t, 15, 0>>();
+    ASSERT_EQ(mapping.required_span_size(), 0);
+  }
+}
+
 // https://github.com/kokkos/mdspan/issues/393
 #define LAYOUT_RIGHT_COMPILE_ISSUE393_DEATH 0
 TEST(LayoutRightTests, issue393) {


### PR DESCRIPTION
Fixes https://github.com/kokkos/kokkos/issues/8460.