### PR TITLE
Enable negative strides

### DIFF
--- a/include/experimental/__p0009_bits/default_accessor.hpp
+++ b/include/experimental/__p0009_bits/default_accessor.hpp
@@ -42,12 +42,12 @@ struct default_accessor {
 
   MDSPAN_INLINE_FUNCTION
   constexpr data_handle_type
-  offset(data_handle_type p, size_t i) const noexcept {
+  offset(data_handle_type p, ptrdiff_t i) const noexcept {
     return p + i;
   }
 
   MDSPAN_FORCE_INLINE_FUNCTION
-  constexpr reference access(data_handle_type p, size_t i) const noexcept {
+  constexpr reference access(data_handle_type p, ptrdiff_t i) const noexcept {
     return p[i];
   }
 

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -193,7 +193,7 @@ struct layout_stride {
 
       template <class... Integral>
       MDSPAN_FORCE_INLINE_FUNCTION
-      static constexpr size_t _call_op_impl(mapping const& self, Integral... idxs) noexcept {
+      static constexpr index_type _call_op_impl(mapping const& self, Integral... idxs) noexcept {
         return MDSPAN_IMPL_FOLD_PLUS_RIGHT((idxs * self.stride(Idxs)), /* + ... + */ 0);
       }
 

--- a/include/experimental/__p2630_bits/strided_slice.hpp
+++ b/include/experimental/__p2630_bits/strided_slice.hpp
@@ -30,7 +30,7 @@ namespace detail {
 }
 
 // Slice Specifier allowing for strides and compile time extent
-template <class OffsetType, class ExtentType, class StrideType>
+template <class OffsetType, class ExtentType, class StrideType = std::integral_constant<size_t,1>>
 struct strided_slice {
   using offset_type = OffsetType;
   using extent_type = ExtentType;

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -29,7 +29,7 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_unsigned_v<Unsigned>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Unsigned abs(const Unsigned &val) {
+constexpr auto abs(const Unsigned &val) {
   return val;
 }
 
@@ -38,8 +38,8 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_unsigned_v<Unsigned>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Unsigned abs(const std::integral_constant<Unsigned, val>&) {
-  return val;
+constexpr auto abs(const std::integral_constant<Unsigned, val>&) {
+  return std::integral_constant<Unsigned, val>();
 }
 
 MDSPAN_TEMPLATE_REQUIRES(
@@ -47,7 +47,7 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_signed_v<Signed>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Signed abs(const Signed &val) {
+constexpr auto abs(const Signed &val) {
   return val < 0 ? -val : val;
 }
 
@@ -56,8 +56,8 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_signed_v<Signed>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Signed abs(const std::integral_constant<Signed, val>&) {
-  return val < 0 ? -val : val;
+constexpr auto abs(const std::integral_constant<Signed, val>&) {
+  return std::integral_constant<Signed, (val < 0 ? -val : val)>();
 }
 
 template <class IndexT, class T0, class T1>
@@ -443,7 +443,7 @@ struct extents_constructor {
           extents_constructor<K - 1, Extents, NewExtents..., dynamic_extent>;
       return next_t::next_extent(
           ext, slices_and_extents...,
-           r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, abs(r.stride)) : 0);
+          r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, abs(r.stride)) : 0);
     } else {
       constexpr size_t new_static_extent = new_static_extent_t::value;
       using next_t =

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -24,6 +24,63 @@
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
 namespace detail {
 
+MDSPAN_TEMPLATE_REQUIRES(
+  class Unsigned,
+  /* requires */ (std::is_unsigned_v<Unsigned>)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr Unsigned myabs(const Unsigned &val) {
+  return val;
+}
+
+MDSPAN_TEMPLATE_REQUIRES(
+  class Unsigned, Unsigned val,
+  /* requires */ (std::is_unsigned_v<Unsigned>)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr Unsigned myabs(const std::integral_constant<Unsigned, val>&) {
+  return val;
+}
+
+MDSPAN_TEMPLATE_REQUIRES(
+  class Signed,
+  /* requires */ (std::is_signed_v<Signed>)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr Signed myabs(const Signed &val) {
+  return val < 0 ? -val : val;
+}
+
+MDSPAN_TEMPLATE_REQUIRES(
+  class Signed, Signed val,
+  /* requires */ (std::is_signed_v<Signed>)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr Signed myabs(const std::integral_constant<Signed, val>&) {
+  return val < 0 ? -val : val;
+}
+
+MDSPAN_TEMPLATE_REQUIRES(
+  class Integral0, class Integral1,
+  /* requires */ (std::is_integral_v<Integral0> &&
+                  std::is_integral_v<Integral1>)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr size_t absminus(Integral0 val0, Integral1 val1) {
+  return (val0 > val1) ? val0 - val1 : val1 - val0;
+}
+
+MDSPAN_TEMPLATE_REQUIRES(
+  class Integral0, Integral0 val0, class Integral1, Integral1 val1,
+  /* requires */ (std::is_integral_v<Integral0> &&
+                  std::is_integral_v<Integral1>)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr size_t absminus(const std::integral_constant<Integral0, val0>&,
+                          const std::integral_constant<Integral1, val1>&) {
+  return (val0 > val1) ? val0 - val1 : val1 - val0;
+}
+
 // Mapping from submapping ranks to srcmapping ranks
 // InvMapRank is an index_sequence, which we build recursively
 // to contain the mapped indices.
@@ -299,13 +356,13 @@ template <class Arg0, class Arg1> struct StaticExtentFromRange {
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromRange<std::integral_constant<Integral0, val0>,
                              std::integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val1 - val0;
+  constexpr static size_t value = absminus(val1, val0);
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromRange<integral_constant<Integral0, val0>,
                              integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val1 - val0;
+  constexpr static size_t value = absminus(val1, val0);
 };
 
 // compute new static extent from strided_slice, preserving static
@@ -317,13 +374,13 @@ template <class Arg0, class Arg1> struct StaticExtentFromStridedRange {
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromStridedRange<std::integral_constant<Integral0, val0>,
                                     std::integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / val1 : 0;
+  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / myabs(val1) : 0;
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromStridedRange<integral_constant<Integral0, val0>,
                                     integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / val1 : 0;
+  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / myabs(val1) : 0;
 };
 
 // creates new extents through recursive calls to next_extent member function
@@ -349,9 +406,9 @@ struct extents_constructor {
     using index_t = typename Extents::index_type;
     return next_t::next_extent(
         ext, slices_and_extents...,
-        index_t(last_of(std::integral_constant<size_t, Extents::rank() - K>(), ext,
-                        sl)) -
-            index_t(first_of(sl)));
+        index_t(absminus(
+                last_of(std::integral_constant<size_t, Extents::rank() - K>(), ext, sl),
+                first_of(sl))));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(
@@ -380,7 +437,7 @@ struct extents_constructor {
           extents_constructor<K - 1, Extents, NewExtents..., dynamic_extent>;
       return next_t::next_extent(
           ext, slices_and_extents...,
-          r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, r.stride) : 0);
+           r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, myabs(r.stride)) : 0);
     } else {
       constexpr size_t new_static_extent = new_static_extent_t::value;
       using next_t =

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -109,7 +109,10 @@ struct is_strided_slice<
 
 // Traits for pair like things
 template <class T>
-struct pair_like_traits : std::false_type {};
+struct pair_like_traits : std::false_type {
+    using first_type = void;
+    using second_type = void;
+};
 
 template <class T1, class T2>
 struct pair_like_traits<std::pair<T1, T2>> {
@@ -160,35 +163,15 @@ struct integral_constant_pair_like<
 };
 
 // Helper for identifying valid pair like things
-template <class T, class IndexType> struct index_pair_like : std::false_type {};
-
-template <class IdxT1, class IdxT2, class IndexType>
-struct index_pair_like<std::pair<IdxT1, IdxT2>, IndexType> {
-  static constexpr bool value = std::is_convertible_v<IdxT1, IndexType> &&
-                                std::is_convertible_v<IdxT2, IndexType>;
-};
-
-template <class IdxT1, class IdxT2, class IndexType>
-struct index_pair_like<std::tuple<IdxT1, IdxT2>, IndexType> {
-  static constexpr bool value = std::is_convertible_v<IdxT1, IndexType> &&
-                                std::is_convertible_v<IdxT2, IndexType>;
-};
-
-template <class IdxT1, class IdxT2, class IndexType>
-struct index_pair_like<tuple<IdxT1, IdxT2>, IndexType> {
-  static constexpr bool value = std::is_convertible_v<IdxT1, IndexType> &&
-                                std::is_convertible_v<IdxT2, IndexType>;
-};
-
-template <class IdxT, class IndexType>
-struct index_pair_like<std::complex<IdxT>, IndexType> {
-  static constexpr bool value = std::is_convertible_v<IdxT, IndexType>;
-};
-
-template <class IdxT, class IndexType>
-struct index_pair_like<std::array<IdxT, 2>, IndexType> {
-  static constexpr bool value = std::is_convertible_v<IdxT, IndexType>;
-};
+template <class T, class IndexType>
+struct index_pair_like : std::conditional_t<
+    pair_like_traits<T>::value,
+    std::integral_constant<bool,
+        std::is_convertible_v<typename pair_like_traits<T>::first_type, IndexType> &&
+        std::is_convertible_v<typename pair_like_traits<T>::second_type, IndexType>
+    >,
+    std::false_type
+> {};
 
 // first_of(slice): getting begin of slice specifier range
 MDSPAN_TEMPLATE_REQUIRES(

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -311,6 +311,17 @@ constexpr auto stride_of(const T &) {
   return integral_constant<size_t, 1>();
 }
 
+MDSPAN_TEMPLATE_REQUIRES(
+  class Slice,
+  /* requires */(index_pair_like<Slice, size_t>::value)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr auto stride_of(const Slice& s) {
+  return get<0>(s) <= get<1>(s) ? 
+    integral_constant<std::ptrdiff_t, 1>() :
+    integral_constant<std::ptrdiff_t, -1>();
+}
+
 template <class OffsetType, class ExtentType, class StrideType>
 MDSPAN_INLINE_FUNCTION
 constexpr auto

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -317,8 +317,8 @@ MDSPAN_TEMPLATE_REQUIRES(
 MDSPAN_INLINE_FUNCTION
 constexpr auto stride_of(const Slice& s) {
   return get<0>(s) <= get<1>(s) ? 
-    integral_constant<std::ptrdiff_t, 1>() :
-    integral_constant<std::ptrdiff_t, -1>();
+    std::integral_constant<std::ptrdiff_t, 1>() :
+    std::integral_constant<std::ptrdiff_t, -1>();
 }
 
 template <class OffsetType, class ExtentType, class StrideType>

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -60,25 +60,21 @@ constexpr Signed abs(const std::integral_constant<Signed, val>&) {
   return val < 0 ? -val : val;
 }
 
-MDSPAN_TEMPLATE_REQUIRES(
-  class Integral0, class Integral1,
-  /* requires */ (std::is_integral_v<Integral0> &&
-                  std::is_integral_v<Integral1>)
-)
+template <class IndexT, class T0, class T1>
 MDSPAN_INLINE_FUNCTION
-constexpr size_t absminus(Integral0 val0, Integral1 val1) {
-  return (val0 > val1) ? val0 - val1 : val1 - val0;
+constexpr auto absminus(const T0 &v0, const T1 &v1) {
+    IndexT v0i = IndexT(v0);
+    IndexT v1i = IndexT(v1);
+  return (v0i > v1i) ? v0i - v1i : v1i - v0i;
 }
 
-MDSPAN_TEMPLATE_REQUIRES(
-  class Integral0, Integral0 val0, class Integral1, Integral1 val1,
-  /* requires */ (std::is_integral_v<Integral0> &&
-                  std::is_integral_v<Integral1>)
-)
+template <class IndexT, class T0, T0 v0, class T1, T1 v1>
 MDSPAN_INLINE_FUNCTION
-constexpr size_t absminus(const std::integral_constant<Integral0, val0>&,
-                          const std::integral_constant<Integral1, val1>&) {
-  return (val0 > val1) ? val0 - val1 : val1 - val0;
+constexpr auto absminus(const std::integral_constant<T0, v0> &,
+                      const std::integral_constant<T1, v1> &) {
+    IndexT v0i = IndexT(v0);
+    IndexT v1i = IndexT(v1);
+    return (v0i > v1i) ? v0i - v1i : v1i - v0i;
 }
 
 // Mapping from submapping ranks to srcmapping ranks
@@ -367,13 +363,13 @@ template <class Arg0, class Arg1> struct StaticExtentFromRange {
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromRange<std::integral_constant<Integral0, val0>,
                              std::integral_constant<Integral1, val1>> {
-  constexpr static size_t value = absminus(val1, val0);
+  constexpr static size_t value = absminus<size_t>(val1, val0);
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromRange<integral_constant<Integral0, val0>,
                              integral_constant<Integral1, val1>> {
-  constexpr static size_t value = absminus(val1, val0);
+  constexpr static size_t value = absminus<size_t>(val1, val0);
 };
 
 // compute new static extent from strided_slice, preserving static
@@ -416,10 +412,9 @@ struct extents_constructor {
         extents_constructor<K - 1, Extents, NewExtents..., new_static_extent>;
     using index_t = typename Extents::index_type;
     return next_t::next_extent(
-        ext, slices_and_extents...,
-        index_t(absminus(
-                last_of(std::integral_constant<size_t, Extents::rank() - K>(), ext, sl),
-                first_of(sl))));
+        ext, slices_and_extents..., absminus<index_t>(
+            last_of(std::integral_constant<size_t, Extents::rank() - K>(), ext, sl),
+            first_of(sl)));
   }
 
   MDSPAN_TEMPLATE_REQUIRES(

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -107,6 +107,58 @@ template <class OffsetType, class ExtentType, class StrideType>
 struct is_strided_slice<
     strided_slice<OffsetType, ExtentType, StrideType>> : std::true_type {};
 
+// Traits for pair like things
+template <class T>
+struct pair_like_traits : std::false_type {};
+
+template <class T1, class T2>
+struct pair_like_traits<std::pair<T1, T2>> {
+  using first_type = T1;
+  using second_type = T2;
+  static constexpr bool value = true;
+};
+
+template <class T1, class T2>
+struct pair_like_traits<std::tuple<T1, T2>> {
+  using first_type = T1;
+  using second_type = T2;
+  static constexpr bool value = true;
+};
+
+template <class T1, class T2>
+struct pair_like_traits<tuple<T1, T2>> {
+  using first_type = T1;
+  using second_type = T2;
+  static constexpr bool value = true;
+};
+
+template <class T>
+struct pair_like_traits<std::complex<T>> {
+  using first_type = T;
+  using second_type = T;
+  static constexpr bool value = true;
+};
+
+template <class T>
+struct pair_like_traits<std::array<T, 2>> {
+  using first_type = T;
+  using second_type = T;
+  static constexpr bool value = true;
+};
+
+template <class T, class = void>
+struct integral_constant_pair_like : std::false_type {};
+
+template <class T>
+struct integral_constant_pair_like<
+    T, std::void_t<typename pair_like_traits<T>::first_type,
+                   typename pair_like_traits<T>::second_type>>
+{
+    static constexpr bool value =
+        mdspan_is_integral_constant<typename pair_like_traits<T>::first_type>::value &&
+        mdspan_is_integral_constant<typename pair_like_traits<T>::second_type>::value;
+};
+
 // Helper for identifying valid pair like things
 template <class T, class IndexType> struct index_pair_like : std::false_type {};
 
@@ -301,6 +353,8 @@ last_of(std::integral_constant<size_t, k>, const Extents &,
 }
 
 // get stride of slices
+
+// For integral and full_extent_t return 1
 MDSPAN_TEMPLATE_REQUIRES(
   class Slice,
   /* requires */(!index_pair_like<Slice, size_t>::value)
@@ -312,13 +366,24 @@ constexpr auto stride_of(const Slice &) {
 
 MDSPAN_TEMPLATE_REQUIRES(
   class Slice,
-  /* requires */(index_pair_like<Slice, size_t>::value)
+  /* requires */(index_pair_like<Slice, size_t>::value &&
+                 integral_constant_pair_like<Slice>::value)
+)
+MDSPAN_INLINE_FUNCTION
+constexpr auto stride_of(const Slice&) {
+    return std::integral_constant<std::ptrdiff_t, (
+        pair_like_traits<Slice>::first_type::value <=
+        pair_like_traits<Slice>::second_type::value ? 1 : -1)>();
+}
+
+MDSPAN_TEMPLATE_REQUIRES(
+  class Slice,
+  /* requires */(index_pair_like<Slice, size_t>::value &&
+                 !integral_constant_pair_like<Slice>::value)
 )
 MDSPAN_INLINE_FUNCTION
 constexpr auto stride_of(const Slice& s) {
-  return get<0>(s) <= get<1>(s) ? 
-    std::integral_constant<std::ptrdiff_t, 1>() :
-    std::integral_constant<std::ptrdiff_t, -1>();
+  return get<0>(s) <= get<1>(s)? 1 : -1;
 }
 
 template <class OffsetType, class ExtentType, class StrideType>

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -301,9 +301,12 @@ last_of(std::integral_constant<size_t, k>, const Extents &,
 }
 
 // get stride of slices
-template <class T>
+MDSPAN_TEMPLATE_REQUIRES(
+  class Slice,
+  /* requires */(!index_pair_like<Slice, size_t>::value)
+)
 MDSPAN_INLINE_FUNCTION
-constexpr auto stride_of(const T &) {
+constexpr auto stride_of(const Slice &) {
   return integral_constant<size_t, 1>();
 }
 

--- a/include/experimental/__p2630_bits/submdspan_extents.hpp
+++ b/include/experimental/__p2630_bits/submdspan_extents.hpp
@@ -29,7 +29,7 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_unsigned_v<Unsigned>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Unsigned myabs(const Unsigned &val) {
+constexpr Unsigned abs(const Unsigned &val) {
   return val;
 }
 
@@ -38,7 +38,7 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_unsigned_v<Unsigned>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Unsigned myabs(const std::integral_constant<Unsigned, val>&) {
+constexpr Unsigned abs(const std::integral_constant<Unsigned, val>&) {
   return val;
 }
 
@@ -47,7 +47,7 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_signed_v<Signed>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Signed myabs(const Signed &val) {
+constexpr Signed abs(const Signed &val) {
   return val < 0 ? -val : val;
 }
 
@@ -56,7 +56,7 @@ MDSPAN_TEMPLATE_REQUIRES(
   /* requires */ (std::is_signed_v<Signed>)
 )
 MDSPAN_INLINE_FUNCTION
-constexpr Signed myabs(const std::integral_constant<Signed, val>&) {
+constexpr Signed abs(const std::integral_constant<Signed, val>&) {
   return val < 0 ? -val : val;
 }
 
@@ -374,13 +374,13 @@ template <class Arg0, class Arg1> struct StaticExtentFromStridedRange {
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromStridedRange<std::integral_constant<Integral0, val0>,
                                     std::integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / myabs(val1) : 0;
+  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / abs(val1) : 0;
 };
 
 template <class Integral0, Integral0 val0, class Integral1, Integral1 val1>
 struct StaticExtentFromStridedRange<integral_constant<Integral0, val0>,
                                     integral_constant<Integral1, val1>> {
-  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / myabs(val1) : 0;
+  constexpr static size_t value = val0 > 0 ? 1 + (val0 - 1) / abs(val1) : 0;
 };
 
 // creates new extents through recursive calls to next_extent member function
@@ -437,13 +437,13 @@ struct extents_constructor {
           extents_constructor<K - 1, Extents, NewExtents..., dynamic_extent>;
       return next_t::next_extent(
           ext, slices_and_extents...,
-           r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, myabs(r.stride)) : 0);
+           r.extent > 0 ? 1 + divide<index_t>(r.extent - 1, abs(r.stride)) : 0);
     } else {
       constexpr size_t new_static_extent = new_static_extent_t::value;
       using next_t =
           extents_constructor<K - 1, Extents, NewExtents..., new_static_extent>;
       return next_t::next_extent(
-          ext, slices_and_extents..., index_t(divide<index_t>(ExtentType(), StrideType())));
+          ext, slices_and_extents..., index_t(divide<index_t>(ExtentType(), abs(StrideType()))));
     }
   }
 };


### PR DESCRIPTION
I'm writing a pytorch-like wrapper over mdspan. Python-like array slicing allows for negative stride for which there is currently no support for in mdspan. There has been some discussion on this already: #352 
This PR adds some helper functions to compute absolute values for signed types during subspan creation, as well as using std::ptrdiff_t in key areas, such as in the default_accessor.

I also snuck in a default template parameter for strided_slice, otherwise strided_slice{0,3} gives unexpected results.

I've written a quick example that verifies results by printing some small arrays to console. Github is being difficult and won't let me upload .cpp files so I've renamed it as a .txt
[negative_stride.txt](https://github.com/user-attachments/files/22674238/negative_stride.txt)