### PR TITLE
Include header for sycl::ext::oneapi::experimental::printf when SYCL support is detected

### DIFF
--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -21,6 +21,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <type_traits> // std::is_void
+#if defined(MDSPAN_IMPL_HAS_SYCL)
+#include <sycl/sycl.hpp> // sycl::ext::oneapi::experimental::printf
+#endif
 #if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
 #include "assert.h"
 #endif


### PR DESCRIPTION
Detecting SYCL support in https://github.com/kokkos/mdspan/blob/3c1aa524617f272836a7222e69d17574ce998dd8/include/experimental/__p0009_bits/config.hpp#L96-L100 doesn't depend on the SYCL header `sycl/sycl.hpp` being included but we need this header for `sycl::ext::oneapi::experimental::printf`.