### PR TITLE
Disable no_unique_address for CUDA 13 with C++20

### DIFF
--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -116,7 +116,7 @@ static_assert(MDSPAN_IMPL_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14
 
 #if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  if ((MDSPAN_IMPL_HAS_CPP_ATTRIBUTE(no_unique_address) >= 201803L) && \
-       (!defined(__NVCC__) || MDSPAN_HAS_CXX_20) && \
+       (!defined(__NVCC__) || (__CUDACC_VER_MAJOR__ < 13 && MDSPAN_HAS_CXX_20)) && \
        (!defined(MDSPAN_IMPL_COMPILER_MSVC) || MDSPAN_HAS_CXX_20))
 #    define MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS 1
 #    define MDSPAN_IMPL_NO_UNIQUE_ADDRESS [[no_unique_address]]


### PR DESCRIPTION
We noticed failures in Kokkos unit tests with CUDA 13 and C++20, see https://github.com/kokkos/kokkos/pull/8562, that disappear when disabling `no_unique_address` usage.