### PR TITLE
Silence unused variable warnings with CUDA 12.8/12.9

### DIFF
--- a/tests/test_layout_ctors.cpp
+++ b/tests/test_layout_ctors.cpp
@@ -257,20 +257,24 @@ struct is_stride_avail< T
 TEST(TestLayoutLeftStrideConstraint, test_layout_left_stride_constraint) {
   Kokkos::extents<int,16> ext1d{};
   Kokkos::layout_left::mapping m1d{ext1d};
+  ASSERT_EQ (m1d.extents(), ext1d);
   ASSERT_TRUE ((is_stride_avail< decltype(m1d), int >::value));
 
   Kokkos::extents<int> ext0d{};
   Kokkos::layout_left::mapping m0d{ext0d};
+  ASSERT_EQ (m0d.extents(), ext0d);
   ASSERT_FALSE((is_stride_avail< decltype(m0d), int >::value));
 }
 
 TEST(TestLayoutRightStrideConstraint, test_layout_right_stride_constraint) {
   Kokkos::extents<int,16> ext1d{};
   Kokkos::layout_right::mapping m1d{ext1d};
+  ASSERT_EQ (m1d.extents(), ext1d);
   ASSERT_TRUE ((is_stride_avail< decltype(m1d), int >::value));
 
   Kokkos::extents<int> ext0d{};
   Kokkos::layout_right::mapping m0d{ext0d};
+  ASSERT_EQ (m0d.extents(), ext0d);
   ASSERT_FALSE((is_stride_avail< decltype(m0d), int >::value));
 }
 #endif

--- a/tests/test_layout_stride.cpp
+++ b/tests/test_layout_stride.cpp
@@ -220,11 +220,13 @@ struct is_stride_avail< T
 TEST(TestLayoutStrideStrideConstraint, test_layout_stride_stride_constraint) {
   Kokkos::extents<int,16> ext1d{};
   Kokkos::layout_stride::mapping m1d{ext1d, std::array<int,1>{1}};
+  ASSERT_EQ (m1d.extents(), ext1d);
   ASSERT_TRUE ((is_stride_avail< decltype(m1d), int >::value));
 
   Kokkos::extents<int> ext0d{};
   Kokkos::layout_stride::mapping m0d{ext0d, std::array<int,0>{}};
   // This is weird, but its what the standard says
+  ASSERT_EQ (m0d.extents(), ext0d);
   ASSERT_TRUE((is_stride_avail< decltype(m0d), int >::value));
 }
 #endif


### PR DESCRIPTION
The variable was used in a decltype situation, but not at runtime effectively.

```
/ascldap/users/crtrott/Kokkos/mdspan/tests/test_layout_ctors.cpp(264): error #550-D: variable "m0d" was set but never used
    Kokkos::layout_left::mapping m0d{ext0d};
                                 ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/ascldap/users/crtrott/Kokkos/mdspan/tests/test_layout_stride.cpp(222): error #550-D: variable "m1d" was set but never used
    Kokkos::layout_stride::mapping m1d{ext1d, std::array<int,1>{1}};
                                   ^

Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"

/ascldap/users/crtrott/Kokkos/mdspan/tests/test_layout_stride.cpp(226): error #550-D: variable "m0d" was set but never used
    Kokkos::layout_stride::mapping m0d{ext0d, std::array<int,0>{}};
```