### PR TITLE
CI: Install g++-9

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,6 +54,9 @@ jobs:
       run: |
         curl  --url ${{ matrix.compiler_url }} --output download.sh
         sudo sh -x download.sh -s -a -s --action install --eula accept
+    - name: Install g++-9
+      if: ${{ matrix.compiler_driver == 'g++-9' }}
+      run: sudo apt-get install g++-9
     - name: Install gtest manually
       run: |
         sudo apt-get install libgtest-dev && cd /usr/src/gtest && sudo cmake CMakeLists.txt && sudo make && sudo cp lib/*.a /usr/lib && sudo ln -s /usr/lib/libgtest.a /usr/local/lib/libgtest.a && sudo ln -s /usr/lib/libgtest_main.a /usr/local/lib/libgtest_main.a


### PR DESCRIPTION
https://github.com/kokkos/mdspan/pull/438/checks and https://github.com/kokkos/mdspan/actions/runs/19241752392/job/55005898867 show that `g++-9` isn't installed by default (anymore).