### PR TITLE
Fix nvcc warnings about using std::numeric_limits in device functions

### DIFF
--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -4,6 +4,11 @@
 #include <type_traits>
 #include <array>
 #include <utility>
+#ifdef MDSPAN_IMPL_HAS_CUDA
+#include <cuda/std/limits>
+#else
+#include <limits>
+#endif
 #include "macros.hpp"
 
 namespace MDSPAN_IMPL_STANDARD_NAMESPACE {
@@ -198,8 +203,13 @@ MDSPAN_INLINE_FUNCTION constexpr bool cmp_greater_equal(T t, U u) noexcept {
 
 template <class R, class T>
 MDSPAN_INLINE_FUNCTION constexpr bool in_range(T t) noexcept {
+#ifdef MDSPAN_IMPL_HAS_CUDA
+  return cmp_greater_equal(t, cuda::std::numeric_limits<R>::min()) &&
+          cmp_less_equal(t, cuda::std::numeric_limits<R>::max());
+#else
   return cmp_greater_equal(t, std::numeric_limits<R>::min()) &&
           cmp_less_equal(t, std::numeric_limits<R>::max());
+#endif
 }
 
 template <typename T >
@@ -216,7 +226,11 @@ check_mul_result_is_nonnegative_and_representable(T a, T b) {
   if constexpr (std::is_signed_v<T>) {
     if ( a < 0 || b < 0 ) return false;
   }
+#ifdef MDSPAN_IMPL_HAS_CUDA
+  return a <= cuda::std::numeric_limits<T>::max() / b;
+#else
   return a <= std::numeric_limits<T>::max() / b;
+#endif
 #endif
 }
 #endif

--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -204,12 +204,12 @@ MDSPAN_INLINE_FUNCTION constexpr bool cmp_greater_equal(T t, U u) noexcept {
 template <class R, class T>
 MDSPAN_INLINE_FUNCTION constexpr bool in_range(T t) noexcept {
 #ifdef MDSPAN_IMPL_HAS_CUDA
-  return cmp_greater_equal(t, cuda::std::numeric_limits<R>::min()) &&
-          cmp_less_equal(t, cuda::std::numeric_limits<R>::max());
+  using cuda::std::numeric_limits;
 #else
-  return cmp_greater_equal(t, std::numeric_limits<R>::min()) &&
-          cmp_less_equal(t, std::numeric_limits<R>::max());
+  using std::numeric_limits;
 #endif
+  return cmp_greater_equal(t, numeric_limits<R>::min()) &&
+          cmp_less_equal(t, numeric_limits<R>::max());
 }
 
 template <typename T >
@@ -227,10 +227,11 @@ check_mul_result_is_nonnegative_and_representable(T a, T b) {
     if ( a < 0 || b < 0 ) return false;
   }
 #ifdef MDSPAN_IMPL_HAS_CUDA
-  return a <= cuda::std::numeric_limits<T>::max() / b;
+  using cuda::std::numeric_limits;
 #else
-  return a <= std::numeric_limits<T>::max() / b;
+  using std::numeric_limits;
 #endif
+  return a <= numeric_limits<T>::max() / b;
 #endif
 }
 #endif


### PR DESCRIPTION
Corresponds to https://github.com/kokkos/kokkos/pull/8750.
If not including `mdspan` as `SYSTEM` header (`-isystem` on Linux), we are seeing warnings such as
```
/var/jenkins/workspace/Kokkos_PR-8728/tpls/mdspan/include/mdspan/../experimental/__p0009_bits/utility.hpp(219): error #20013-D: calling a constexpr __host__ function("max") from a __host__ __device__ function("check_mul_result_is_nonnegative_and_representable") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
          detected during:
            instantiation of "__nv_bool Kokkos::detail::check_mul_result_is_nonnegative_and_representable(T, T) [with T=std::size_t]" 
/usr/include/c++/9/type_traits(2924): here
            instantiation of "const __nv_bool std::is_assignable_v [with _Tp=Kokkos::mdspan<uint32_t, Kokkos::extents<std::size_t, 18446744073709551615UL>, Kokkos::Experimental::layout_left_padded<18446744073709551615UL>, Kokkos::Impl::SpaceAwareAccessor<Kokkos::CudaSpace::memory_space, Kokkos::Impl::ReferenceCountedAccessor<uint32_t, Kokkos::CudaSpace::memory_space, Kokkos::default_accessor<uint32_t>>>>, _Up=Kokkos::mdspan<uint32_t, Kokkos::extents<std::size_t, 18446744073709551615UL>, Kokkos::Experimental::layout_left_padded<18446744073709551615UL>, Kokkos::Impl::SpaceAwareAccessor<Kokkos::CudaSpace::memory_space, Kokkos::Impl::ReferenceCountedAccessor<uint32_t, Kokkos::CudaSpace::memory_space, Kokkos::default_accessor<uint32_t>>>>]" 
/var/jenkins/workspace/Kokkos_PR-8728/core/src/Cuda/Kokkos_Cuda_UniqueToken.hpp(48): here
/var/jenkins/workspace/Kokkos_PR-8728/tpls/mdspan/include/mdspan/../experimental/__p0009_bits/utility.hpp(201): error #20013-D: calling a constexpr __host__ function("min") from a __host__ __device__ function("in_range") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this.
          detected during:
            instantiation of "__nv_bool Kokkos::detail::in_range<R,T>(T) noexcept [with R=std::size_t, T=size_t]" 
/usr/include/c++/9/type_traits(2924): here
```
or (MSVC+Cuda)
```
2025-12-11T13:15:48.8447466Z D:\a\kokkos\kokkos\tpls\mdspan\include\experimental\__p0009_bits\utility.hpp(219): warning #20013-D: calling a constexpr __host__ function("max") from a __host__ __device__ function("check_mul_result_is_nonnegative_and_representable") is not allowed. The experimental flag '--expt-relaxed-constexpr' can be used to allow this. [D:\a\kokkos\kokkos\build\algorithms\unit_tests\Kokkos_AlgorithmsUnitTest_StdSet_A.vcxproj]
2025-12-11T13:15:48.8451584Z       return a <= std::numeric_limits<T>::max() / b;
2025-12-11T13:15:48.8454510Z                   ^
2025-12-11T13:15:48.8457518Z             detected during:
2025-12-11T13:15:48.8461252Z               instantiation of "__nv_bool Kokkos::detail::check_mul_result_is_nonnegative_and_representable(T, T) [with T=size_t]" at line 328 of C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\type_traits
2025-12-11T13:15:48.8466658Z               instantiation of "const __nv_bool std::is_convertible_v [with _From=Kokkos::extents<size_t, 18446744073709551615ULL>, _To=Kokkos::extents<size_t, 18446744073709551615ULL>]" at line 328 of C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\type_traits
2025-12-11T13:15:48.8470689Z               instantiation of "const __nv_bool std::is_convertible_v [with _From=const Kokkos::Experimental::layout_left_padded<18446744073709551615ULL>::mapping<Kokkos::extents<size_t, 18446744073709551615ULL>> &, _To=Kokkos::Experimental::layout_left_padded<18446744073709551615ULL>::mapping<Kokkos::extents<size_t, 18446744073709551615ULL>>]" at line 35 of D:\a\kokkos\kokkos\core\src\Cuda/Kokkos_Cuda_UniqueToken.hpp
2025-12-11T13:15:48.8473154Z   
2025-12-11T13:15:48.8476322Z   Remark: The warnings can be suppressed with "-diag-suppress <warning-number>"
2025-12-11T13:15:48.8478123Z   
```
with `nvcc`. This pull request fixes them by using `cuda::std::numeric_limits` instead of `std::numeric_limits`.