### PR TITLE
Only use cuda::std::numeric_limits with nvcc

### DIFF
--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -4,7 +4,7 @@
 #include <type_traits>
 #include <array>
 #include <utility>
-#ifdef MDSPAN_IMPL_HAS_CUDA
+#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__)
 #include <cuda/std/limits>
 #else
 #include <limits>
@@ -203,7 +203,7 @@ MDSPAN_INLINE_FUNCTION constexpr bool cmp_greater_equal(T t, U u) noexcept {
 
 template <class R, class T>
 MDSPAN_INLINE_FUNCTION constexpr bool in_range(T t) noexcept {
-#ifdef MDSPAN_IMPL_HAS_CUDA
+#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__)
   using cuda::std::numeric_limits;
 #else
   using std::numeric_limits;
@@ -226,7 +226,7 @@ check_mul_result_is_nonnegative_and_representable(T a, T b) {
   if constexpr (std::is_signed_v<T>) {
     if ( a < 0 || b < 0 ) return false;
   }
-#ifdef MDSPAN_IMPL_HAS_CUDA
+#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__)
   using cuda::std::numeric_limits;
 #else
   using std::numeric_limits;


### PR DESCRIPTION
Follow-up to https://github.com/kokkos/mdspan/pull/440. As https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8750/3/pipeline-overview/?selected-node=187 shows `clang` complains about using variadic functions
```
[CUDA-11.8-Clang-15] /usr/local/cuda/include/cuda/std/detail/libcxx/include/type_traits:520:12: error: CUDA device code does not support variadic functions [clang-diagnostic-error]
[CUDA-11.8-Clang-15] false_type __sfinae_test_impl(...);
[CUDA-11.8-Clang-15]            ^
[CUDA-11.8-Clang-15] /usr/local/cuda/include/cuda/std/detail/libcxx/include/type_traits:1059:69: error: CUDA device code does not support variadic functions [clang-diagnostic-error]
[CUDA-11.8-Clang-15]     template <class _Tp> _LIBCUDACXX_INLINE_VISIBILITY static __two __test(...);
[CUDA-11.8-Clang-15]                                                                     ^
[CUDA-11.8-Clang-15] /usr/local/cuda/include/cuda/std/detail/libcxx/include/type_traits:1175:5: error: CUDA device code does not support variadic functions [clang-diagnostic-error]
[CUDA-11.8-Clang-15]     __any(...);
[CUDA-11.8-Clang-15]     ^
[CUDA-11.8-Clang-15] /usr/local/cuda/include/cuda/std/detail/libcxx/include/type_traits:1852:16: error: CUDA device code does not support variadic functions [clang-diagnostic-error]
[CUDA-11.8-Clang-15]    static void __test(...);
[CUDA-11.8-Clang-15]                ^
[CUDA-11.8-Clang-15] /usr/local/cuda/include/cuda/std/detail/libcxx/include/type_traits:2276:18: error: CUDA device code does not support variadic functions [clang-diagnostic-error]
[CUDA-11.8-Clang-15]     static __two __test (...);
[CUDA-11.8-Clang-15]                  ^
[CUDA-11.8-Clang-15] /usr/local/cuda/include/cuda/std/detail/libcxx/include/type_traits:4336:16: error: CUDA device code does not support variadic functions [clang-diagnostic-error]
[CUDA-11.8-Clang-15]   static __nat __try_call(...);
```
According to https://github.com/llvm/llvm-project/issues/58410 and https://github.com/NVIDIA/cccl/issues/1020, we need at least clang-17 for avoiding that error unless using `-fcuda-allow-variadic-functions`. Since `clang` never complained about using `std::numeric_limits` in the first place, this pull request proposes to only use `cuda::std::numeric_limits` with `nvcc`. https://cloud1.cees.ornl.gov/jenkins-ci/job/Kokkos/job/PR-8750/5/pipeline-overview/?selected-node=259 passes.