### PR TITLE
use cuda/std/limits with cuda version >= 12.6

### DIFF
--- a/include/experimental/__p0009_bits/utility.hpp
+++ b/include/experimental/__p0009_bits/utility.hpp
@@ -4,7 +4,7 @@
 #include <type_traits>
 #include <array>
 #include <utility>
-#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__)
+#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__) && (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10 >= 1260)
 #include <cuda/std/limits>
 #else
 #include <limits>
@@ -203,7 +203,7 @@ MDSPAN_INLINE_FUNCTION constexpr bool cmp_greater_equal(T t, U u) noexcept {
 
 template <class R, class T>
 MDSPAN_INLINE_FUNCTION constexpr bool in_range(T t) noexcept {
-#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__)
+#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__) && (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10 >= 1260)
   using cuda::std::numeric_limits;
 #else
   using std::numeric_limits;
@@ -226,7 +226,7 @@ check_mul_result_is_nonnegative_and_representable(T a, T b) {
   if constexpr (std::is_signed_v<T>) {
     if ( a < 0 || b < 0 ) return false;
   }
-#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__)
+#if defined(MDSPAN_IMPL_HAS_CUDA) && defined(__NVCC__) && (__CUDACC_VER_MAJOR__ * 100 + __CUDACC_VER_MINOR__ * 10 >= 1260)
   using cuda::std::numeric_limits;
 #else
   using std::numeric_limits;


### PR DESCRIPTION
this works around compiler issues showing up with downstream usage of kokkos, such as in Trilinos, when testing with cuda/12.4 of the type

```
error: 'iterator_traits' is not a member of 'cuda::std::__4';
```