### PR TITLE
Fix layout stride converting explicit clause

### DIFF
--- a/compilation_tests/ctest_layout_convertible.cpp
+++ b/compilation_tests/ctest_layout_convertible.cpp
@@ -91,4 +91,22 @@ MDSPAN_STATIC_TEST(
   !std::is_constructible<LS1, NotARealLayout::mapping<E2>>::value
 );
 
+MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::layout_left::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::layout_left::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::layout_left::mapping<E1>>::value);
 
+MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::layout_right::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::layout_right::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::layout_right::mapping<E1>>::value);
+
+MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::layout_stride::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::layout_stride::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::layout_stride::mapping<E1>>::value);
+
+MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::Experimental::layout_left_padded<14>::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::Experimental::layout_left_padded<14>::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::Experimental::layout_left_padded<14>::mapping<E1>>::value);
+
+MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::Experimental::layout_right_padded<14>::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::Experimental::layout_right_padded<14>::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::Experimental::layout_right_padded<14>::mapping<E1>>::value);

--- a/compilation_tests/ctest_layout_convertible.cpp
+++ b/compilation_tests/ctest_layout_convertible.cpp
@@ -91,24 +91,24 @@ MDSPAN_STATIC_TEST(
   !std::is_constructible<LS1, NotARealLayout::mapping<E2>>::value
 );
 
-MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::layout_left::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_constructible<LS1, Kokkos::layout_left::mapping<E1>>::value);
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::layout_left::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::layout_left::mapping<E1>>::value);
 
-MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::layout_right::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_constructible<LS1, Kokkos::layout_right::mapping<E1>>::value);
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::layout_right::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::layout_right::mapping<E1>>::value);
 
-MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::layout_stride::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_constructible<LS1, Kokkos::layout_stride::mapping<E1>>::value);
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::layout_stride::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::layout_stride::mapping<E1>>::value);
 
 #if MDSPAN_HAS_CXX_17
-MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::Experimental::layout_left_padded<14>::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_constructible<LS1, Kokkos::Experimental::layout_left_padded<14>::mapping<E1>>::value);
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::Experimental::layout_left_padded<14>::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::Experimental::layout_left_padded<14>::mapping<E1>>::value);
 
-MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::Experimental::layout_right_padded<14>::mapping<E1>, LS1>::value);
+MDSPAN_STATIC_TEST(std::is_constructible<LS1, Kokkos::Experimental::layout_right_padded<14>::mapping<E1>>::value);
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::Experimental::layout_right_padded<14>::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::Experimental::layout_right_padded<14>::mapping<E1>>::value);
 #endif

--- a/compilation_tests/ctest_layout_convertible.cpp
+++ b/compilation_tests/ctest_layout_convertible.cpp
@@ -103,6 +103,7 @@ MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::layout_stride::mapping<E1>, LS1
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::layout_stride::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::layout_stride::mapping<E1>>::value);
 
+#if MDSPAN_HAS_CXX_17
 MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::Experimental::layout_left_padded<14>::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::Experimental::layout_left_padded<14>::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::Experimental::layout_left_padded<14>::mapping<E1>>::value);
@@ -110,3 +111,4 @@ MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::Experimental::layout_left_pad
 MDSPAN_STATIC_TEST(std::is_constructible<Kokkos::Experimental::layout_right_padded<14>::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_convertible<Kokkos::Experimental::layout_right_padded<14>::mapping<E1>, LS1>::value);
 MDSPAN_STATIC_TEST(std::is_assignable<LS1, Kokkos::Experimental::layout_right_padded<14>::mapping<E1>>::value);
+#endif

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -20,7 +20,10 @@
 #include "trait_backports.hpp"
 #include "compressed_pair.hpp"
 #include "utility.hpp"
+
+#if MDSPAN_HAS_CXX_17
 #include "../__p2642_bits/layout_padded_fwd.hpp"
+#endif
 
 #if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  include "no_unique_address.hpp"
@@ -442,9 +445,9 @@ struct layout_stride {
       !(std::is_convertible<typename StridedLayoutMapping::extents_type, extents_type>::value &&
        (detail::is_mapping_of<layout_left, StridedLayoutMapping> ||
         detail::is_mapping_of<layout_right, StridedLayoutMapping> ||
-        detail::is_mapping_of<layout_stride, StridedLayoutMapping> ||
         MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_left_padded_mapping<StridedLayoutMapping>::value || // Don't need to guard for C++14 as this isn't compiled in < C++20
-        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<StridedLayoutMapping>::value))
+        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<StridedLayoutMapping>::value ||
+        detail::is_mapping_of<layout_stride, StridedLayoutMapping>))
     ) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(StridedLayoutMapping const& other) noexcept // NOLINT(google-explicit-constructor)

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -443,7 +443,7 @@ struct layout_stride {
        (detail::is_mapping_of<layout_left, StridedLayoutMapping> ||
         detail::is_mapping_of<layout_right, StridedLayoutMapping> ||
         detail::is_mapping_of<layout_stride, StridedLayoutMapping> ||
-        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_left_padded_mapping<StridedLayoutMapping>::value ||
+        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_left_padded_mapping<StridedLayoutMapping>::value || // Don't need to guard for C++14 as this isn't compiled in < C++20
         MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<StridedLayoutMapping>::value))
     ) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14

--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -20,6 +20,7 @@
 #include "trait_backports.hpp"
 #include "compressed_pair.hpp"
 #include "utility.hpp"
+#include "../__p2642_bits/layout_padded_fwd.hpp"
 
 #if !defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
 #  include "no_unique_address.hpp"
@@ -441,7 +442,9 @@ struct layout_stride {
       !(std::is_convertible<typename StridedLayoutMapping::extents_type, extents_type>::value &&
        (detail::is_mapping_of<layout_left, StridedLayoutMapping> ||
         detail::is_mapping_of<layout_right, StridedLayoutMapping> ||
-        detail::is_mapping_of<layout_stride, StridedLayoutMapping>))
+        detail::is_mapping_of<layout_stride, StridedLayoutMapping> ||
+        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_left_padded_mapping<StridedLayoutMapping>::value ||
+        MDSPAN_IMPL_PROPOSED_NAMESPACE::detail::is_layout_right_padded_mapping<StridedLayoutMapping>::value))
     ) // needs two () due to comma
     MDSPAN_INLINE_FUNCTION MDSPAN_IMPL_CONSTEXPR_14
     mapping(StridedLayoutMapping const& other) noexcept // NOLINT(google-explicit-constructor)


### PR DESCRIPTION
We forgot to add the padded layouts to the `layout_stride` converting constructor, see https://eel.is/c++draft/mdspan.layout#stride.cons-9

This PR adds tests for all the strided layout conversions/constructions/assignments from other layouts