### PR TITLE
Add an OpenACC variant of default_precondition_violation_handler()

### DIFF
--- a/include/experimental/__p0009_bits/config.hpp
+++ b/include/experimental/__p0009_bits/config.hpp
@@ -99,6 +99,12 @@ static_assert(MDSPAN_IMPL_CPLUSPLUS >= MDSPAN_CXX_STD_14, "mdspan requires C++14
 #  endif
 #endif
 
+#ifndef MDSPAN_IMPL_HAS_OPENACC
+#  if defined(_OPENACC)
+#    define MDSPAN_IMPL_HAS_OPENACC _OPENACC
+#  endif
+#endif
+
 #ifndef MDSPAN_IMPL_HAS_CPP_ATTRIBUTE
 #  ifndef __has_cpp_attribute
 #    define MDSPAN_IMPL_HAS_CPP_ATTRIBUTE(x) 0

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -24,7 +24,7 @@
 #if defined(MDSPAN_IMPL_HAS_SYCL)
 #include <sycl/sycl.hpp> // sycl::ext::oneapi::experimental::printf
 #endif
-#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL)
+#if defined(MDSPAN_IMPL_HAS_CUDA) || defined(MDSPAN_IMPL_HAS_HIP) || defined(MDSPAN_IMPL_HAS_SYCL) || defined(MDSPAN_IMPL_HAS_OPENACC)
 #include "assert.h"
 #endif
 
@@ -128,6 +128,14 @@ MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* c
   (void) file;
   (void) line;
 #endif
+  assert(0);
+}
+#elif defined(MDSPAN_IMPL_HAS_OPENACC)
+MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
+{
+  (void) cond;
+  (void) file;
+  (void) line;
   assert(0);
 }
 #else

--- a/include/experimental/__p0009_bits/macros.hpp
+++ b/include/experimental/__p0009_bits/macros.hpp
@@ -131,12 +131,9 @@ MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* c
   assert(0);
 }
 #elif defined(MDSPAN_IMPL_HAS_OPENACC)
-MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)
+MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* /* cond */, const char* /* file */, unsigned /* line */)
 {
-  (void) cond;
-  (void) file;
-  (void) line;
-  assert(0);
+  assert(false);
 }
 #else
 MDSPAN_FUNCTION inline void default_precondition_violation_handler(const char* cond, const char* file, unsigned line)


### PR DESCRIPTION
This PR adds an OpenACC variant of mdspan default_precondition_violation_handler() function, which fixes the unsupported fprintf error in Kokkos PR #9345 (https://github.com/kokkos/kokkos/pull/9345#issuecomment-5046076022).
This PR contains the same changes as Kokkos PR #9369 (https://github.com/kokkos/kokkos/pull/9369).