### PR TITLE
Fix return type of  `layout_padded` operator

### DIFF
--- a/include/experimental/__p2642_bits/layout_padded.hpp
+++ b/include/experimental/__p2642_bits/layout_padded.hpp
@@ -592,7 +592,7 @@ public:
       /* requires */ (sizeof...(Indices) == extents_type::rank() &&
                       (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::
                            are_valid_indices<index_type, Indices...>())))
-  MDSPAN_INLINE_FUNCTION constexpr size_t
+  MDSPAN_INLINE_FUNCTION constexpr index_type
   operator()(Indices... idxs) const noexcept {
 #if !defined(NDEBUG)
     ::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::check_all_indices(this->extents(),
@@ -985,7 +985,7 @@ public:
       /* requires */ (sizeof...(Indices) == extents_type::rank() &&
                       (::MDSPAN_IMPL_STANDARD_NAMESPACE::detail::
                            are_valid_indices<index_type, Indices...>())))
-  MDSPAN_INLINE_FUNCTION constexpr size_t
+  MDSPAN_INLINE_FUNCTION constexpr index_type
   operator()(Indices... idxs) const noexcept {
     return compute_offset(std::index_sequence_for<Indices...>{}, idxs...);
   }


### PR DESCRIPTION
I was testing `layout_padded` while doing in `layout_padded` indices operator -> The return type was size_t but in `compute_offset` is returned by as `index_type` .

```
    using extint32 = MDSPAN_IMPL_STANDARD_NAMESPACE::extents<int, 2, 3, 4>;
    using layout_left = Kokkos::Experimental::layout_left_padded<16>::mapping<extint32>;
    layout_left l1(extint32{});
    static_assert(std::is_same_v<decltype(l1(0,0,0)),extint32::index_type>," not int");
```
->
```
/home/sajid/kokkos_internal/kokkos_tree/mdspan/kokkos_extent_inv.hpp(78): error: static assertion failed with " not int"
      static_assert(std::is_same_v<decltype(l1(0,0,0)),extint32::index_type>," not int");
      ^
```