### PR TITLE
Change global tag variables to local variables.

### DIFF
--- a/include/experimental/__p0009_bits/layout_stride.hpp
+++ b/include/experimental/__p0009_bits/layout_stride.hpp
@@ -367,7 +367,7 @@ struct layout_stride {
 #else
       : base_t(base_t{member_pair_t(
 #endif
-          e, strides_storage_t(deduction_workaround_impl::fill_strides(mdspan_non_standard, s))
+          e, strides_storage_t(deduction_workaround_impl::fill_strides(mdspan_non_standard_tag(), s))
 #if defined(MDSPAN_IMPL_USE_ATTRIBUTE_NO_UNIQUE_ADDRESS)
         }
 #else

--- a/include/experimental/__p2630_bits/submdspan_mapping.hpp
+++ b/include/experimental/__p2630_bits/submdspan_mapping.hpp
@@ -252,7 +252,7 @@ layout_left::mapping<Extents>::submdspan_mapping_impl(
     auto inv_map = detail::inv_map_rank(std::integral_constant<size_t, 0>(),
                                         std::index_sequence<>(), slices...);
     return submdspan_mapping_result<dst_mapping_t> {
-      dst_mapping_t(mdspan_non_standard, dst_ext,
+      dst_mapping_t(mdspan_non_standard_tag(), dst_ext,
                     detail::construct_sub_strides(
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
@@ -333,7 +333,7 @@ layout_left_padded<PaddingValue>::mapping<Extents>::submdspan_mapping_impl(
                                         std::index_sequence<>(), slices...);
       using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t> {
-      dst_mapping_t(mdspan_non_standard, dst_ext,
+      dst_mapping_t(mdspan_non_standard_tag(), dst_ext,
                     MDSPAN_IMPL_STANDARD_NAMESPACE::detail::construct_sub_strides(
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
@@ -488,7 +488,7 @@ layout_right::mapping<Extents>::submdspan_mapping_impl(
     auto inv_map = detail::inv_map_rank(std::integral_constant<size_t, 0>(),
                                         std::index_sequence<>(), slices...);
     return submdspan_mapping_result<dst_mapping_t> {
-      dst_mapping_t(mdspan_non_standard, dst_ext,
+      dst_mapping_t(mdspan_non_standard_tag(), dst_ext,
                     detail::construct_sub_strides(
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
@@ -561,7 +561,7 @@ layout_right_padded<PaddingValue>::mapping<Extents>::submdspan_mapping_impl(
                                         std::index_sequence<>(), slices...);
       using dst_mapping_t = typename layout_stride::template mapping<dst_ext_t>;
     return submdspan_mapping_result<dst_mapping_t> {
-      dst_mapping_t(mdspan_non_standard, dst_ext,
+      dst_mapping_t(mdspan_non_standard_tag(), dst_ext,
                     MDSPAN_IMPL_STANDARD_NAMESPACE::detail::construct_sub_strides(
                         *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit
@@ -613,7 +613,7 @@ layout_stride::mapping<Extents>::submdspan_mapping_impl(
                     : this->operator()(detail::first_of(slices)...));
 
   return submdspan_mapping_result<dst_mapping_t> {
-    dst_mapping_t(mdspan_non_standard, dst_ext,
+    dst_mapping_t(mdspan_non_standard_tag(), dst_ext,
                   detail::construct_sub_strides(
                       *this, inv_map,
 // HIP needs deduction guides to have markups so we need to be explicit


### PR DESCRIPTION
This PR changes global tag variables accessed in Kokkos subview-related functions to local variables, so that NVHPC OpenACC compiler (nvc++ version higher than 24.5) can compile a Kokkos program where a subview is created in a device kernel.
This PR contains the same changes as mdspan code changes in Kokkos PR 9486 (https://github.com/kokkos/kokkos/pull/9486) 