### PR TITLE
Raise CMake minimum required version to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.22)
 
 project(MDSpan
   VERSION 0.6.0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,8 +49,6 @@ else()
       GIT_TAG v1.17.0
   )
   FetchContent_MakeAvailable(googletest)
-  
-  add_library(GTest::gtest_main ALIAS gtest_main)
 endif()
 
 # FIXME_MSVC

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ else()
   if (MSVC)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   endif()
+  set(INSTALL_GTEST OFF)
   FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,18 +43,12 @@ else()
   if (MSVC)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   endif()
-  fetchcontent_declare(
+  FetchContent_Declare(
       googletest
       GIT_REPOSITORY https://github.com/google/googletest.git
       GIT_TAG v1.17.0
   )
-  
-  # TODO CMake 3.28, we can pass EXCLUDE_FROM_ALL directly to fetchcontent_makeavailable
-  fetchcontent_getproperties(googletest)
-  if (NOT googletest_POPULATED)
-    fetchcontent_populate(googletest)
-    add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)
-  endif()
+  FetchContent_MakeAvailable(googletest)
   
   add_library(GTest::gtest_main ALIAS gtest_main)
 endif()


### PR DESCRIPTION
To align with Kokkos (Core) and to avoid having to set a number of policies when embedding in Kokkos.